### PR TITLE
Adds Python 3.12 to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
           os: ['ubuntu-20.04']
-          python-version: ['3.8', '3.9', '3.10', '3.11']
+          python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
           pytorch-version: ['2.4.0']  # Should be synced with setup.py.
           cuda-version: ['12.1', '11.8']
 


### PR DESCRIPTION
FIX issue reported here with vllm-flash-attn blocking vLLM's python upgrade https://github.com/vllm-project/vllm/issues/6877#issuecomment-2257939832

Should be this simple based on the support in flash-attention: https://github.com/Dao-AILab/flash-attention/pull/870/files