### PR TITLE
Update .gitignore to ignore *env/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ var/
 .idea/
 
 # Dev
-venv
+*env/


### PR DESCRIPTION
Just a small tweak to `.gitignore` to exclude all `*env/` dirs.

This will exclude env dirs like:

- venv/ (like it was before)
- .venv/
- env/

etc.