### PR TITLE
Turn import vllm_flash_attn_c into optional in flash_attn_interface.py

### DIFF
--- a/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm_flash_attn/flash_attn_interface.py
@@ -8,7 +8,14 @@ import torch.nn as nn
 # isort: off
 # We need to import the CUDA kernels after importing torch
 # Use relative import to support build-from-source installation in vLLM
-from . import vllm_flash_attn_c # noqa: F401
+try:
+    from . import vllm_flash_attn_c # noqa: F401
+except:
+    # We may put the cpp extension .so file in a different folder. So we
+    # should allow this happens.
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.warning("Failed to load from OSS vllm_flash_attn_c build, please ensure we use other way to load it.")
 
 # isort: on
 


### PR DESCRIPTION
In Open Source, we assume the build is done by CMake, but there is exceptions. So we cannot always assume vllm_flash_attn_c (the .so) file is in the same folder as flash_attn_interface.py. Instead, we turn this import as optional. Even the import fails, we still keep running the remaining part of the file.