### PR TITLE
Add python 3.13 support to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
 set(ignoreMe "${VLLM_PYTHON_PATH}")
 
 # Supported python versions. These should be kept in sync with setup.py.
-set(PYTHON_SUPPORTED_VERSIONS "3.8" "3.9" "3.10" "3.11" "3.12")
+set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12" "3.13")
 
 # Supported NVIDIA architectures.
 set(CUDA_SUPPORTED_ARCHS "8.0;8.6;8.9;9.0")


### PR DESCRIPTION
This matches the work done in https://github.com/vllm-project/flash-attention/commit/88786928edeecf647cc1aca29f95eeda4a6eacea Python 3.8 was subsequently dropped as well here.

Related to https://github.com/vllm-project/vllm/pull/13164