### PR TITLE
Fix building on CUDA 12.1

### DIFF
--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -994,7 +994,7 @@ struct CollectiveMainloopFwdSm90 {
             if constexpr (LargeHeadDimV) {
                 return make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_scale.data()), SmemLayoutScale{});
             } else { // won't be used, just a placeholder
-                return make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_q.data()), SmemLayoutScale{});
+                return make_tensor(make_smem_ptr(static_cast<float*>(nullptr)), SmemLayoutScale{});
             }
         }();
         Tensor sQv = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_qv.data()), SmemLayoutQv{});


### PR DESCRIPTION
Fix building on CUDA 12.1 which was failing with:

```
[2025-02-14T20:12:40Z] #27 4842.4 /workspace/.deps/vllm-flash-attn-src/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp(1068): error: no operator "=" matches these operands
[2025-02-14T20:12:40Z] #27 4842.4             operand types are: cutlass::bfloat16_t = float
[2025-02-14T20:12:40Z] #27 4842.4                       sScale(get<0>(taccOcO_row(mi)), stage) = scales(mi);
```