### PR TITLE
FA3 Decode Perf - Use single mma warp group for decode batches 

### DIFF
--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -727,7 +727,7 @@ mha_fwd(at::Tensor &q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seq
     int const max_num_pages_per_seq = !paged_KV ? 0 : page_table.size(1);
     int const num_pages = !paged_KV ? 0 : k.size(0);
     int const page_size = !paged_KV ? 1 : k.size(1);
-    int const seqlen_k = !is_varlen_k ? (!paged_KV ? k.size(1) : max_num_pages_per_seq * page_size) : max_seqlen_k_.value();
+    int const seqlen_k = !max_seqlen_k_.has_value() ? (!paged_KV ? k.size(1) : max_num_pages_per_seq * page_size) : max_seqlen_k_.value();
     int const total_k = !is_varlen_k ? batch_size * k.size(1) : k.size(0);
     int const num_heads_k = k.size(-2);
     int const batch_size_k = !paged_KV ? (!is_varlen_k ? k.size(0) : cu_seqlens_k.size(0) - 1) : page_table.size(0);

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -431,8 +431,7 @@ inline int get_num_splits(Flash_fwd_params const& params) {
     // params.page_table must already be set
     // This needs to match the kernel configs
     bool varlen = params.cu_seqlens_q || params.cu_seqlens_k || params.seqused_q || params.seqused_k || params.leftpad_k;
-    bool use_one_mma_wg = params.seqlen_q * (!params.pack_gqa ? 1 : params.h / params.h_k) <= 64;
-    auto kBlockMN_kernel_args_sm90 = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, false /*v_colmajor*/, params.page_table && !params.pagedkv_tma, params.softcap > 0.f, use_one_mma_wg);
+    auto kBlockMN_kernel_args_sm90 = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, false /*v_colmajor*/, params.page_table && !params.pagedkv_tma, params.softcap > 0.f, use_one_mma_wg(params));
     // Strictly speaking we need to pass in (varlen && params.num_splits > 1) but num_splits
     // has not been set here. It's OK though because we might just underestimate kBlockN a bit
     auto kBlockMN_kernel_args_sm8x = tile_size_fwd_sm8x(params.arch == 86 || params.arch == 89, params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, params.page_table, varlen, params.softcap > 0.f, params.knew_ptr);
@@ -614,7 +613,7 @@ mha_fwd_get_scheduler_metadata(
     }
 
     if (params.num_splits_dynamic_ptr) {
-        auto kBlockMN_kernel_args_sm90 = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, false /*v_colmajor*/, params.page_table && !params.pagedkv_tma, params.softcap > 0.f);
+        auto kBlockMN_kernel_args_sm90 = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, false /*v_colmajor*/, params.page_table && !params.pagedkv_tma, params.softcap > 0.f, use_one_mma_wg(params));
         auto kBlockMN_kernel_args_sm8x = tile_size_fwd_sm8x(params.arch == 86 || params.arch == 89, params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, params.page_table, is_varlen && params.num_splits > 1, params.softcap > 0.f, params.knew_ptr);
         int const kBlockM = params.arch >= 90 ? std::get<0>(kBlockMN_kernel_args_sm90) : std::get<0>(kBlockMN_kernel_args_sm8x);
         int const kBlockN = params.arch >= 90 ? std::get<1>(kBlockMN_kernel_args_sm90) : std::get<1>(kBlockMN_kernel_args_sm8x);

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -26,7 +26,7 @@ using namespace cute;
 
 template <int Arch, int kHeadDim, int kHeadDimV, int ClusterM, typename Element, typename ElementOut,
           bool Is_causal, bool Is_local, bool Has_softcap, bool Varlen, bool PagedKVNonTMA, bool AppendKV, bool HasQv,
-          bool PackGQA, bool Split, bool V_colmajor>
+          bool PackGQA, bool Split, bool V_colmajor, bool Use_one_mma_wg>
 void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     static_assert(!(Is_causal && Is_local), "Causal and Local cannot be enabled at the same time");
     static_assert(!(AppendKV && V_colmajor), "AppendKV and V_colmajor cannot be enabled at the same time");
@@ -36,7 +36,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     using ArchTag = std::conditional_t<Arch >= 90, cutlass::arch::Sm90, cutlass::arch::Sm80>;
 
     // Can't use structured binding since it's not compatible with constexpr
-    static constexpr std::tuple<int, int, bool, bool> kBlockMN_RS_IntraWGOverlap = tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(Element) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap);
+    static constexpr std::tuple<int, int, bool, bool> kBlockMN_RS_IntraWGOverlap = tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(Element) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap, Use_one_mma_wg);
     static constexpr std::tuple<int, int, int, int, bool> kBlockMN_kNWarps_Stages_RS = tile_size_fwd_sm8x(Arch == 86 || Arch == 89, kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(Element) /*element_size*/, PagedKVNonTMA, Varlen && Split, Has_softcap, AppendKV);
     static constexpr int kBlockM = Arch >= 90 ? std::get<0>(kBlockMN_RS_IntraWGOverlap) : std::get<0>(kBlockMN_kNWarps_Stages_RS);
     static constexpr int kBlockN = Arch >= 90 ? std::get<1>(kBlockMN_RS_IntraWGOverlap) : std::get<1>(kBlockMN_kNWarps_Stages_RS);
@@ -203,17 +203,19 @@ void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream) {
         VCOLMAJOR_SWITCH(params.v_dim_stride != 1, V_colmajor_, [&] {
             static constexpr bool V_colmajor = V_colmajor_ && sizeof(T) == 1;
             VARLEN_SWITCH(params.cu_seqlens_q || params.cu_seqlens_k || params.seqused_q || params.seqused_k || params.leftpad_k, Varlen, [&] {
-                // Only needed here to decide if we should use cluster
-                static constexpr int kBlockM = Arch >= 90 ? std::get<0>(tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(T) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap)) : 128;
+                BOOL_SWITCH(params.seqlen_q * (!PackGQA ? 1 : params.h / params.h_k) <= 64, Use_one_mma_wg, [&] {
+                    // Only needed here to decide if we should use cluster
+                    static constexpr int kBlockM = Arch >= 90 ? std::get<0>(tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(T) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap, Use_one_mma_wg)) : 128;
 
-                static constexpr bool Enable_cluster = Arch == 90 && (sizeof(T) == 2 ? (kHeadDim >= 128) : (kHeadDim == 192)) && !Is_causal && !Is_local && !Split && !PagedKVNonTMA && !Varlen;
-                BOOL_SWITCH(params.qv_ptr, HasQV_, [&] {
-                    static constexpr bool HasQv = HasQV_ && Arch == 90 && !Is_FP8 && kHeadDim == 64 && kHeadDimV >= 256;
-                    APPENDKV_SWITCH(params.knew_ptr, AppendKV, [&] {
-                        // Only use Cluster if number of tiles along seqlen_q is even and not varlen
-                        CLUSTER_SWITCH(cutlass::ceil_div(params.seqlen_q * (!PackGQA ? 1 : params.h / params.h_k), kBlockM) % 2 == 0, Use_cluster, [&] {
-                            static constexpr int ClusterM = Enable_cluster && Use_cluster ? 2 : 1;
-                            run_flash_fwd<Arch, kHeadDim, kHeadDimV, ClusterM, T, T_out, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV && Varlen, HasQv, PackGQA, Split, V_colmajor>(params, stream);
+                    static constexpr bool Enable_cluster = Arch == 90 && (sizeof(T) == 2 ? (kHeadDim >= 128) : (kHeadDim == 192)) && !Is_causal && !Is_local && !Split && !PagedKVNonTMA && !Varlen;
+                    BOOL_SWITCH(params.qv_ptr, HasQV_, [&] {
+                        static constexpr bool HasQv = HasQV_ && Arch == 90 && !Is_FP8 && kHeadDim == 64 && kHeadDimV >= 256;
+                        APPENDKV_SWITCH(params.knew_ptr, AppendKV, [&] {
+                            // Only use Cluster if number of tiles along seqlen_q is even and not varlen
+                            CLUSTER_SWITCH(cutlass::ceil_div(params.seqlen_q * (!PackGQA ? 1 : params.h / params.h_k), kBlockM) % 2 == 0, Use_cluster, [&] {
+                                static constexpr int ClusterM = Enable_cluster && Use_cluster ? 2 : 1;
+                                run_flash_fwd<Arch, kHeadDim, kHeadDimV, ClusterM, T, T_out, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV && Varlen, HasQv, PackGQA, Split, V_colmajor, Use_one_mma_wg>(params, stream);
+                            });
                         });
                     });
                 });

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -21,6 +21,7 @@
 #include "mainloop_fwd_sm90_tma_gmma_ws.hpp"
 #include "mainloop_fwd_sm80.hpp"
 #include "epilogue_fwd.hpp"
+#include "heuristics.h"
 
 using namespace cute;
 
@@ -203,7 +204,10 @@ void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream) {
         VCOLMAJOR_SWITCH(params.v_dim_stride != 1, V_colmajor_, [&] {
             static constexpr bool V_colmajor = V_colmajor_ && sizeof(T) == 1;
             VARLEN_SWITCH(params.cu_seqlens_q || params.cu_seqlens_k || params.seqused_q || params.seqused_k || params.leftpad_k, Varlen, [&] {
-                BOOL_SWITCH(params.seqlen_q * (!PackGQA ? 1 : params.h / params.h_k) <= 64, Use_one_mma_wg, [&] {
+                BOOL_SWITCH(use_one_mma_wg(params), Use_one_mma_wg_, [&] {
+                    // Avoid over compiliation by making sure this only get set if it is actually used, i.e. we currently only support one mma wg for 128 head dim and hopper
+                    static constexpr bool Use_one_mma_wg = Use_one_mma_wg_ && Arch >= 90 && kHeadDim == 128;
+
                     // Only needed here to decide if we should use cluster
                     static constexpr int kBlockM = Arch >= 90 ? std::get<0>(tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(T) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap, Use_one_mma_wg)) : 128;
 

--- a/hopper/heuristics.h
+++ b/hopper/heuristics.h
@@ -5,6 +5,12 @@
 #pragma once
 
 #include <vector>
+#include "flash.h"
+
+inline bool use_one_mma_wg(Flash_fwd_params const& params) {
+    return params.arch >= 90 && params.d == 128 && 
+        params.seqlen_q * (!params.pack_gqa ? 1 : params.h / params.h_k) <= 64;
+};
 
 inline bool should_pack_gqa(bool varlen_q, int seqlen_q, int qhead_per_khead, int blockM) {
     // If varlen, we don't actually know seqlen_q but only max_seqlen_q.


### PR DESCRIPTION
Boost decode performance by using only 1 mma warp group to reduce wasted compute (i.e. use kBlockM == 64 instead of 128)

# Batch Size == 1 Decode Perf

## Main
```
                           FlashAttn vs FlashInfer Timing (ms)                           
┏━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━┳━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Type   ┃ Name        ┃ S     ┃ P  ┃ FlashAttn (ms) ┃ FlashInfer (ms) ┃ (FA-FI)/FI (%) ┃
┡━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━╇━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ decode │ qwen32b-tp2 │ 1024  │ 1  │ 0.0148         │ 0.0123          │ 20.30          │
│ decode │ qwen32b-tp2 │ 2048  │ 1  │ 0.0156         │ 0.0142          │ 9.39           │
│ decode │ qwen32b-tp2 │ 4096  │ 1  │ 0.0165         │ 0.0159          │ 3.78           │
│ decode │ qwen32b-tp2 │ 8192  │ 1  │ 0.0191         │ 0.0188          │ 1.36           │
│ decode │ qwen32b-tp2 │ 16384 │ 1  │ 0.0263         │ 0.0251          │ 4.81           │
│ decode │ qwen32b-tp2 │ 1024  │ 16 │ 0.0153         │ 0.0129          │ 18.36          │
│ decode │ qwen32b-tp2 │ 2048  │ 16 │ 0.0155         │ 0.0141          │ 9.29           │
│ decode │ qwen32b-tp2 │ 4096  │ 16 │ 0.0165         │ 0.0158          │ 4.39           │
│ decode │ qwen32b-tp2 │ 8192  │ 16 │ 0.0191         │ 0.0187          │ 1.77           │
│ decode │ qwen32b-tp2 │ 16384 │ 16 │ 0.0257         │ 0.0245          │ 5.06           │
│ decode │ qwen32b-tp1 │ 1024  │ 1  │ 0.0146         │ 0.0140          │ 3.61           │
│ decode │ qwen32b-tp1 │ 2048  │ 1  │ 0.0159         │ 0.0157          │ 1.37           │
│ decode │ qwen32b-tp1 │ 4096  │ 1  │ 0.0186         │ 0.0184          │ 0.97           │
│ decode │ qwen32b-tp1 │ 8192  │ 1  │ 0.0249         │ 0.0245          │ 1.45           │
│ decode │ qwen32b-tp1 │ 16384 │ 1  │ 0.0368         │ 0.0361          │ 1.91           │
│ decode │ qwen32b-tp1 │ 1024  │ 16 │ 0.0144         │ 0.0138          │ 4.57           │
│ decode │ qwen32b-tp1 │ 2048  │ 16 │ 0.0157         │ 0.0155          │ 1.28           │
│ decode │ qwen32b-tp1 │ 4096  │ 16 │ 0.0185         │ 0.0183          │ 1.36           │
│ decode │ qwen32b-tp1 │ 8192  │ 16 │ 0.0247         │ 0.0241          │ 2.43           │
│ decode │ qwen32b-tp1 │ 16384 │ 16 │ 0.0363         │ 0.0352          │ 3.20           │
│ decode │ llama8b-tp1 │ 1024  │ 1  │ 0.0145         │ 0.0139          │ 3.92           │
│ decode │ llama8b-tp1 │ 2048  │ 1  │ 0.0158         │ 0.0156          │ 0.70           │
│ decode │ llama8b-tp1 │ 4096  │ 1  │ 0.0185         │ 0.0184          │ 0.90           │
│ decode │ llama8b-tp1 │ 8192  │ 1  │ 0.0247         │ 0.0245          │ 0.85           │
│ decode │ llama8b-tp1 │ 16384 │ 1  │ 0.0365         │ 0.0361          │ 1.09           │
│ decode │ llama8b-tp1 │ 1024  │ 16 │ 0.0147         │ 0.0139          │ 5.99           │
│ decode │ llama8b-tp1 │ 2048  │ 16 │ 0.0158         │ 0.0155          │ 1.55           │
│ decode │ llama8b-tp1 │ 4096  │ 16 │ 0.0185         │ 0.0183          │ 1.49           │
│ decode │ llama8b-tp1 │ 8192  │ 16 │ 0.0243         │ 0.0239          │ 1.69           │
│ decode │ llama8b-tp1 │ 16384 │ 16 │ 0.0361         │ 0.0351          │ 2.93           │
└────────┴─────────────┴───────┴────┴────────────────┴─────────────────┴────────────────┘
```

## PR
```
                           FlashAttn vs FlashInfer Timing (ms)                           
┏━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━┳━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Type   ┃ Name        ┃ S     ┃ P  ┃ FlashAttn (ms) ┃ FlashInfer (ms) ┃ (FA-FI)/FI (%) ┃
┡━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━╇━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ decode │ qwen32b-tp2 │ 1024  │ 1  │ 0.0128         │ 0.0124          │ 2.97           │
│ decode │ qwen32b-tp2 │ 2048  │ 1  │ 0.0149         │ 0.0143          │ 4.45           │
│ decode │ qwen32b-tp2 │ 4096  │ 1  │ 0.0159         │ 0.0159          │ -0.04          │
│ decode │ qwen32b-tp2 │ 8192  │ 1  │ 0.0183         │ 0.0190          │ -3.30          │
│ decode │ qwen32b-tp2 │ 16384 │ 1  │ 0.0251         │ 0.0254          │ -1.21          │
│ decode │ qwen32b-tp2 │ 1024  │ 16 │ 0.0133         │ 0.0129          │ 2.73           │
│ decode │ qwen32b-tp2 │ 2048  │ 16 │ 0.0149         │ 0.0142          │ 4.94           │
│ decode │ qwen32b-tp2 │ 4096  │ 16 │ 0.0159         │ 0.0158          │ 0.22           │
│ decode │ qwen32b-tp2 │ 8192  │ 16 │ 0.0183         │ 0.0188          │ -2.79          │
│ decode │ qwen32b-tp2 │ 16384 │ 16 │ 0.0249         │ 0.0246          │ 1.41           │
│ decode │ qwen32b-tp1 │ 1024  │ 1  │ 0.0134         │ 0.0140          │ -4.86          │
│ decode │ qwen32b-tp1 │ 2048  │ 1  │ 0.0151         │ 0.0157          │ -4.15          │
│ decode │ qwen32b-tp1 │ 4096  │ 1  │ 0.0178         │ 0.0185          │ -3.95          │
│ decode │ qwen32b-tp1 │ 8192  │ 1  │ 0.0238         │ 0.0248          │ -4.07          │
│ decode │ qwen32b-tp1 │ 16384 │ 1  │ 0.0349         │ 0.0361          │ -3.37          │
│ decode │ qwen32b-tp1 │ 1024  │ 16 │ 0.0133         │ 0.0139          │ -4.34          │
│ decode │ qwen32b-tp1 │ 2048  │ 16 │ 0.0150         │ 0.0156          │ -3.80          │
│ decode │ qwen32b-tp1 │ 4096  │ 16 │ 0.0177         │ 0.0184          │ -3.73          │
│ decode │ qwen32b-tp1 │ 8192  │ 16 │ 0.0234         │ 0.0241          │ -2.88          │
│ decode │ qwen32b-tp1 │ 16384 │ 16 │ 0.0349         │ 0.0353          │ -1.09          │
│ decode │ llama8b-tp1 │ 1024  │ 1  │ 0.0134         │ 0.0140          │ -4.23          │
│ decode │ llama8b-tp1 │ 2048  │ 1  │ 0.0150         │ 0.0157          │ -4.49          │
│ decode │ llama8b-tp1 │ 4096  │ 1  │ 0.0176         │ 0.0185          │ -4.61          │
│ decode │ llama8b-tp1 │ 8192  │ 1  │ 0.0236         │ 0.0246          │ -4.38          │
│ decode │ llama8b-tp1 │ 16384 │ 1  │ 0.0349         │ 0.0360          │ -3.15          │
│ decode │ llama8b-tp1 │ 1024  │ 16 │ 0.0132         │ 0.0139          │ -5.06          │
│ decode │ llama8b-tp1 │ 2048  │ 16 │ 0.0150         │ 0.0156          │ -4.07          │
│ decode │ llama8b-tp1 │ 4096  │ 16 │ 0.0177         │ 0.0184          │ -3.80          │
│ decode │ llama8b-tp1 │ 8192  │ 16 │ 0.0235         │ 0.0241          │ -2.48          │
│ decode │ llama8b-tp1 │ 16384 │ 16 │ 0.0348         │ 0.0350          │ -0.60          │
└────────┴─────────────┴───────┴────┴────────────────┴─────────────────┴────────────────┘
```