### PR TITLE
[BugFix] Fix raising exception when FA3 isn't available 

### DIFF
--- a/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm_flash_attn/flash_attn_interface.py
@@ -22,7 +22,6 @@ try:
     FA3_UNAVAILABLE_REASON = None
     FA3_AVAILABLE = True
 except ImportError as e:
-    raise e
     FA3_UNAVAILABLE_REASON = str(e)
     FA3_AVAILABLE = False
 


### PR DESCRIPTION
FIX: https://github.com/vllm-project/vllm/issues/16995

Bug introduced in: https://github.com/vllm-project/flash-attention/pull/61