### PR TITLE
[BugFix] Fix FA2 RuntimeError when sinks is provided

### DIFF
--- a/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm_flash_attn/flash_attn_interface.py
@@ -226,6 +226,8 @@ def flash_attn_varlen_func(
                     "FA2 does not support scheduler_metadata, q_descale, "
                     "k_descale, v_descale"
                 )
+        if s_aux is not None:
+            raise NotImplementedError("FA2 does not support s_aux")
         if num_splits > 1:
             raise NotImplementedError("FA2 does not support num_splits > 1")
         out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(
@@ -250,7 +252,6 @@ def flash_attn_varlen_func(
             softcap,
             return_softmax_lse and dropout_p > 0,
             None,
-            s_aux=s_aux,
         )
     elif fa_version == 3:
         assert alibi_slopes is None, "Alibi is not supported in FA3"


### PR DESCRIPTION
fix 
```
RuntimeError: _vllm_fa2_C::varlen_fwd() expected at most 21 argument(s) but received 22 argument(s). Declaration: _vllm_fa2_C::varlen_fwd(Tensor($0! -> ) q, Tensor k, Tensor v, Tensor($1! -> )? out, Tensor cu_seqlens_q, Tensor cu_seqlens_k, Tensor? seqused_k, Tensor? leftpad_k, Tensor? block_table, Tensor? alibi_slopes, int max_seqlen_q, int max_seqlen_k, float p_dropout, float softmax_scale, bool zero_tensors, bool is_causal, int window_size_left, int window_size_right, float softcap, bool return_softmax, Generator? gen) -> Tensor[]
```

introduced in https://github.com/vllm-project/flash-attention/pull/75