### PR TITLE
refactor: simplify split index check in attention sink

### DIFF
--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -1126,7 +1126,7 @@ struct CollectiveMainloopFwdSm90 {
         using TensorT = typename Softmax::TensorT;
         using LayoutT = typename TensorT::layout_type;
         auto finalize_dispatch = [&](TensorT& scores_scale, float const v_descale) {
-            if (params.ptr_S_aux && (!Split || (split_idx & 0x0000FFFF) == 0)) {
+            if (params.ptr_S_aux && (!Split || split_idx == 0)) {
                 Tensor sS_aux = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_s_aux.data()), SmemLayoutSAux{});
                 Tensor tSrS_aux = make_tensor_like(scores_scale);
                 static_assert(is_static<decltype(layout(tSrS_aux))>::value);


### PR DESCRIPTION
The check `(split_idx & 0x0000FFFF) == 0` was equivalent to `split_idx == 0` 
because split_idx never exceeds 16 bits. This change improves **readability** 
without affecting behavior.