### PR TITLE
fix: reenable fa3 path for v0

### DIFF
--- a/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm_flash_attn/flash_attn_interface.py
@@ -445,7 +445,8 @@ def flash_attn_with_kvcache(
             rotary_interleaved,
             num_splits,
         )
-    elif fa_version == 3:
+    else:
+        assert fa_version == 3
         assert alibi_slopes is None, "Alibi is not supported in FA3"
         out, softmax_lse, _, _ = torch.ops._vllm_fa3_C.fwd(
             q, k_cache, v_cache, # q, k, v


### PR DESCRIPTION
I believe https://github.com/vllm-project/flash-attention/pull/78 removed fa3 for v0 backend by mistake?

Re-enabling it