### PR TITLE
[Hopper] optimize decoding performance for headdim 128 fp8

### DIFF
--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -60,7 +60,11 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
         } else if (headdim <= 96) {
             return {192, 128, true, true};
         } else if (headdim <= 128) {
-            return {128, paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224), true, true};
+            if (use_one_mma_wg) {
+                return {64, 96, true, true};
+            } else{
+                return {128, paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224), true, true};
+            }
         } else if (headdim <= 192) {
             return {128, (paged_kv_non_TMA || softcap) && is_local ? 128 : 160, true, true};
         } else {


### PR DESCRIPTION
Similar to https://github.com/vllm-project/flash-attention/pull/91 this PR optimizes the FP8 tiles sizes for headdim 128. This applies for example to `Qwen3-Coder-30B-A3B-Instruct` where it reduces the context-length dependent inter-token latency by ~1.39x against BF16.
With the current mainline config, FP8 decoding is not faster at all than BF16 for Qwen3-Coder-30B-A3B-Instruct.