### PR TITLE
[NVIDIA] CUDA 13 needed WAR

### DIFF
--- a/hopper/sm90_pipeline_no_cluster.hpp
+++ b/hopper/sm90_pipeline_no_cluster.hpp
@@ -39,7 +39,7 @@ public:
     if (is_initializing_warp) {
       // Barrier FULL and EMPTY init
       constexpr int producer_arv_cnt = 1;
-      uint32_t const num_consumer_warpgroups_per_cluster = params.num_consumers / NumThreadsPerWarpGroup;
+      uint32_t const num_consumer_warpgroups_per_cluster = (params.num_consumers + NumThreadsPerWarpGroup - 1) / NumThreadsPerWarpGroup;
       uint32_t const multicast_consumer_arrival_count = num_consumer_warpgroups_per_cluster;
 
       cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(storage.full_barrier_), decltype(storage.empty_barrier_), Stages>(


### PR DESCRIPTION
params.num_consumers could be 32, while NumThreadsPerWarpGroup
is 128. This results in num_consumer_warpgroups_per_cluster being
zero, which in turn causes a compiler failure due to barrier
initialization code receiving zero as input.

The root cause for why params.num_consumers is less than 128 is
still TBD.