### PR TITLE
[Perf] SM103 tcgen05.ld.red for fused TMEM load + row-max in softmax

### DIFF
--- a/flash_attn/cute/blackwell_helpers.py
+++ b/flash_attn/cute/blackwell_helpers.py
@@ -1087,3 +1087,44 @@ def gemm_ptx_precomputed_varname(
             is_align_stack=False,
             asm_dialect=llvm.AsmDialect.AD_ATT,
         )
+
+
+@cute.jit
+def tmem_ld_red_max(
+    tStS: cute.Tensor,
+    tSrS: cute.Tensor,
+) -> cutlass.Float32:
+    """SM103: fused TMEM load + row-max via raw tcgen05.ld.red PTX.
+
+    Drop-in replacement for cute.copy(thr_tmem_load, src, dst) that also
+    returns the row max. Same instruction count as baseline (one x32 load
+    per tile), with the max computed in the TMEM controller at zero ALU cost.
+    """
+    from cutlass._mlir import ir as _ir
+
+    num_tiles = cute.size(tStS.shape[2])
+    f32_ty = _ir.F32Type.get()
+    struct_ty = llvm.StructType.get_literal([f32_ty] * 33)
+    
+    asm_str = (
+        "tcgen05.ld.red.sync.aligned.32x32b.x32.f32.max"
+        " {" + ", ".join(f"${i}" for i in range(32)) + "}"
+        ", $32, [$33];\n"
+    )
+
+    row_max = cutlass.Float32(0.0)
+    for k in cutlass.range_constexpr(num_tiles):
+        result = llvm.inline_asm(
+            struct_ty,
+            [tStS[None, None, k].iterator.toint().ir_value()],
+            asm_str,
+            "=f," * 33 + "r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+        for i in cutlass.range_constexpr(32):
+            tSrS[k * 32 + i] = cutlass.Float32(llvm.extractvalue(f32_ty, result, [i]))
+        tile_max = cutlass.Float32(llvm.extractvalue(f32_ty, result, [32]))
+        row_max = tile_max if cutlass.const_expr(k == 0) else cute.arch.fmax(row_max, tile_max)
+    return row_max

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2148,9 +2148,15 @@ class FlashAttentionForwardSm100:
 
         # Wait for Si
         pipeline_s_p_o.consumer_wait_w_index_phase(stage, mma_si_consumer_phase)
+
+        # Load S from TMEM. SM103 uses tcgen05.ld.red (fused load + max).
         tSrS_t2r = cute.make_fragment(thr_tmem_load.partition_D(tScS).shape, self.qk_acc_dtype)
-        cute.copy(thr_tmem_load, tStS_t2r, tSrS_t2r)
-        # tSrS_t2r = copy_utils.load_t2r(thr_tmem_load, tScS_shape, tStS_t2r)
+        if const_expr(self.is_sm103 and self.score_mod is None and self.n_block_size >= 128):
+            hw_max = sm100_utils.tmem_ld_red_max(tStS_t2r, tSrS_t2r)
+        else:
+            cute.copy(thr_tmem_load, tStS_t2r, tSrS_t2r)
+            hw_max = None
+
         if cutlass.const_expr(self.score_mod is not None):
             self.apply_score_mod(
                 tSrS_t2r,
@@ -2169,7 +2175,14 @@ class FlashAttentionForwardSm100:
 
         if const_expr(mask_fn is not None):
             mask_fn(tSrS_t2r, n_block=n_block)
-        row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
+
+        # SM103: always use hardware max (valid even after masking — softmax is
+        # translation-invariant, so max >= true_max just shifts exp2 values down
+        # proportionally; row_sum normalization corrects the ratios).
+        if const_expr(hw_max is not None):
+            row_max, acc_scale = softmax.update_row_max_precomputed(hw_max, is_first)
+        else:
+            row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
 
         if const_expr(not is_first):
             # tSrScale_r2t = cute.make_fragment(thr_tmem_store_scale.partition_S(tScScale).shape, Float32)

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2151,7 +2151,7 @@ class FlashAttentionForwardSm100:
 
         # Load S from TMEM. SM103 uses tcgen05.ld.red (fused load + max).
         tSrS_t2r = cute.make_fragment(thr_tmem_load.partition_D(tScS).shape, self.qk_acc_dtype)
-        if const_expr(self.is_sm103 and self.score_mod is None and self.n_block_size >= 128):
+        if const_expr(self.is_sm103 and self.score_mod is None):
             hw_max = sm100_utils.tmem_ld_red_max(tStS_t2r, tSrS_t2r)
         else:
             cute.copy(thr_tmem_load, tStS_t2r, tSrS_t2r)
@@ -2176,10 +2176,10 @@ class FlashAttentionForwardSm100:
         if const_expr(mask_fn is not None):
             mask_fn(tSrS_t2r, n_block=n_block)
 
-        # SM103: always use hardware max (valid even after masking — softmax is
-        # translation-invariant, so max >= true_max just shifts exp2 values down
-        # proportionally; row_sum normalization corrects the ratios).
-        if const_expr(hw_max is not None):
+        # SM103: use hardware max when no masking. With masking (causal boundary,
+        # seqlen boundary), fall back to software fmax_reduce — the hardware max
+        # includes padding/OOB values that masking sets to -inf.
+        if const_expr(hw_max is not None and mask_fn is None):
             row_max, acc_scale = softmax.update_row_max_precomputed(hw_max, is_first)
         else:
             row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)

--- a/flash_attn/cute/softmax.py
+++ b/flash_attn/cute/softmax.py
@@ -216,6 +216,33 @@ class SoftmaxSm100(Softmax):
         self.row_max[0] = row_max_new
         return row_max_safe, acc_scale
 
+    @cute.jit
+    def update_row_max_precomputed(
+        self, hw_row_max: Float32, is_first: int
+    ) -> Tuple[Float32, Float32]:
+        """SM103 fast path: row_max already computed by tcgen05.ld.red hardware.
+
+        Skips the fmax_reduce tree reduction (~64 ALU ops) since the TMEM controller
+        computed the max during the load.
+        """
+        if cutlass.const_expr(is_first):
+            row_max_new = hw_row_max
+            row_max_safe = row_max_new if row_max_new != -cutlass.Float32.inf else 0.0
+            acc_scale = 0.0
+        else:
+            row_max_old = self.row_max[0]
+            row_max_new = cute.arch.fmax(hw_row_max, row_max_old)
+            row_max_safe = row_max_new if row_max_new != -cutlass.Float32.inf else 0.0
+            acc_scale_ = (row_max_old - row_max_safe) * self.scale_log2
+            acc_scale = cute.math.exp2(acc_scale_, fastmath=True)
+            if cutlass.const_expr(self.rescale_threshold > 0.0):
+                if acc_scale_ >= -self.rescale_threshold:
+                    row_max_new = row_max_old
+                    row_max_safe = row_max_old
+                    acc_scale = 1.0
+        self.row_max[0] = row_max_new
+        return row_max_safe, acc_scale
+
     def update_row_sum(
         self, acc_S_row_exp: cute.TensorSSA, row_scale: Float32, is_first: int = False
     ) -> None:


### PR DESCRIPTION
### Summary

Uses the SM103-only `tcgen05.ld.red` instruction to fuse the TMEM load with a hardware max reduction in FA4's softmax step, eliminating `fmax` ALU ops per tile. The max is computed in the TMEM controller at zero ALU cost.

#### Decode (seqlen_q=1, BS × SL sweep)

Production model configs (hdim=128, causal), `_flash_attn_fwd` direct call:

| Model                     | Config     | Mean speedup | Best (BS=1-4, SL≥16K) |
|---------------------------|------------|--------------|------------------------|
| GPT-OSS 120B TP8 (GQA=8) | q8kv1d128  | **+4.0%**    | +6-8%                  |
| GPT-OSS 120B TP4 (GQA=8) | q16kv2d128 | **+3.8%**    | +5-7%                  |
| GPT-OSS 120B TP2 (GQA=8) | q32kv4d128 | **+3.5%**    | +5-7%                  |
| GPT-OSS 120B TP1 (GQA=8) | q64kv8d128 | **+3.5%**    | +6-8%                  |

Speedup scales with lower batch sizes and longer sequences — softmax `fmax_reduce` is a larger fraction of kernel time when there's less MMA work.

#### Prefill (seqlen_q=seqlen_k, BS × SL sweep)

| Model                     | Config     | Mean speedup |
|---------------------------|------------|--------------|
| GPT-OSS 120B TP8 (GQA=8) | q8kv1d128  | **+1.8%**    |
| GPT-OSS 120B TP4 (GQA=8) | q16kv2d128 | **+1.7%**    |
| GPT-OSS 120B TP2 (GQA=8) | q32kv4d128 | **+1.6%**    |
| GPT-OSS 120B TP1 (GQA=8) | q64kv8d128 | **+1.5%**    |

Prefill shows smaller gains because MMA scales quadratically with seqlen while softmax savings scale linearly.

#### Exhaustive sweep (hdim × GQA heatmap)

2,048 decode + 1,764 prefill configs (3 hdims × 7 head configs × 2 causal × 7 BS × 6-7 SL). Zero regressions.

Decode sweet spot: hdim=64 causal with high GQA → **+5-6%** mean.

<img width="1812" height="719" alt="heatmap_ldred_b300_hdim_gqa" src="https://github.com/user-attachments/assets/4e58d657-1d58-468c-8786-e091a02471e7" />

Related PR: https://github.com/Dao-AILab/flash-attention/pull/2449