### PR TITLE
feat: FA4 flash att supports fused fp8 output

### DIFF
--- a/benchmarks/bench_flash_attention_fp8_output.py
+++ b/benchmarks/bench_flash_attention_fp8_output.py
@@ -108,7 +108,7 @@ def main():
     args = parser.parse_args()
 
     cap = torch.cuda.get_device_capability()
-    if cap[0] != 10:
+    if cap[0] not in (10, 11):
         raise SystemExit(
             f"Fused FP8 output requires SM100/SM110 (Blackwell). "
             f"Detected sm{cap[0]}{cap[1]}; aborting."

--- a/benchmarks/bench_flash_attention_fp8_output.py
+++ b/benchmarks/bench_flash_attention_fp8_output.py
@@ -1,0 +1,127 @@
+"""FA4 fused FP8 output vs. BF16 attn + torch.compile'd post-quant cast.
+
+Requires SM100/SM110 (Blackwell). FA4 ships no FP8 quant op, so the unfused
+baseline uses torch.compile to fuse the divide+clamp+cast into one kernel.
+
+    python benchmarks/bench_flash_attention_fp8_output.py [--shape ...] [--rep N]
+"""
+
+import argparse
+import time
+
+import torch
+from triton.testing import do_bench
+
+from flash_attn.cute.bench_utils import flops
+from flash_attn.cute.interface import flash_attn_func
+
+
+# (name, batch, seqlen_q, seqlen_k, num_heads, num_kv_heads, head_dim, head_dim_v, causal)
+# Naming convention: <mode>_<attn>_<seqlen>, where:
+#   mode = prefill (sq == sk) | decode (sq == 1, sk large)
+#   attn = mla (qk=192, v=128) | mha (h_q == h_kv) | gqa (h_q > h_kv)
+#   seqlen = the K-side context length
+SHAPES = {
+    # DeepSeek-V3 MLA prefill — the primary target of this PR.
+    "prefill_mla_4k":  (2,  4096, 4096, 16,   1, 192, 128, True),
+    # Standard MHA prefill, 4K context.
+    "prefill_mha_4k":  (2,  4096, 4096, 32,  32, 128, 128, True),
+    # Llama-style GQA prefill (8:1 ratio), 8K context.
+    "prefill_gqa_8k":  (2,  8192, 8192, 32,   4, 128, 128, True),
+    # GQA decode (sq=1, h=16/1), 8K context — common decode shape.
+    "decode_gqa_8k":   (16,    1, 8192, 16,   1, 128, 128, True),
+    # MHA decode, 8K context.
+    "decode_mha_8k":   (16,    1, 8192, 16,  16, 128, 128, True),
+}
+
+
+def static_fp8_quant_eager(out_bf16: torch.Tensor, inv_scale: float) -> torch.Tensor:
+    """Stand-in for vLLM's `static_scaled_fp8_quant`."""
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    return out_bf16.float().mul(inv_scale).clamp(finfo.min, finfo.max).to(torch.float8_e4m3fn)
+
+
+
+_static_fp8_quant_compiled = torch.compile(static_fp8_quant_eager, mode="reduce-overhead")
+
+
+def bench_one(name, shape, warmup, rep):
+    batch, sq, sk, nh, nkv, dq, dv, causal = shape
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    q = torch.randn(batch, sq, nh, dq, dtype=dtype, device=device)
+    k = torch.randn(batch, sk, nkv, dq, dtype=dtype, device=device)
+    v = torch.randn(batch, sk, nkv, dv, dtype=dtype, device=device)
+
+    # Pick a representative scale (peak of one BF16 forward).
+    ref_out, _ = flash_attn_func(q, k, v, causal=causal)
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    out_scale = max(float(ref_out.float().abs().amax().item()) / finfo.max, 1e-4)
+    inv_scale = 1.0 / out_scale
+    out_scale_t = torch.tensor(out_scale, dtype=torch.float32, device=device)
+
+    fp8_buf = torch.empty(batch, sq, nh, dv, dtype=torch.float8_e4m3fn, device=device)
+
+    def fwd_bf16():
+        return flash_attn_func(q, k, v, causal=causal)
+
+    def fwd_bf16_then_quant():
+        out, _ = flash_attn_func(q, k, v, causal=causal)
+        return _static_fp8_quant_compiled(out, inv_scale)
+
+    def fwd_fp8_fused():
+        return flash_attn_func(
+            q, k, v, causal=causal,
+            out=fp8_buf,
+            output_scale=out_scale_t,
+        )
+
+    time.sleep(1.0)
+    ms_bf16 = do_bench(fwd_bf16, warmup=warmup, rep=rep) * 1e-3
+    time.sleep(1.0)
+    ms_unfused = do_bench(fwd_bf16_then_quant, warmup=warmup, rep=rep) * 1e-3
+    time.sleep(1.0)
+    ms_fused = do_bench(fwd_fp8_fused, warmup=warmup, rep=rep) * 1e-3
+
+    n_flops = flops(batch, nh, sq, sk, dq, dv, causal=causal)
+    def tflops(s): return n_flops / s * 1e-12
+
+    saved = ms_unfused - ms_fused
+    speedup = ms_unfused / ms_fused
+
+    print(
+        f"{name:<14} b={batch} sq={sq:>5} sk={sk:>5} h={nh:>3}/{nkv:<3} d={dq}-{dv:<3}  "
+        f"bf16={ms_bf16*1e6:>7.1f}us/{tflops(ms_bf16):>4.0f}TF  "
+        f"bf16+quant={ms_unfused*1e6:>7.1f}us/{tflops(ms_unfused):>4.0f}TF  "
+        f"fused-fp8={ms_fused*1e6:>7.1f}us/{tflops(ms_fused):>4.0f}TF  "
+        f"saved={saved*1e6:>+6.1f}us ({speedup:.2f}x)"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FA4 fused FP8 output benchmark")
+    parser.add_argument("--shape", action="append", choices=list(SHAPES) + ["all"],
+                        default=None, help="Shape preset to run (repeatable). Default: all.")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--rep", type=int, default=10)
+    args = parser.parse_args()
+
+    cap = torch.cuda.get_device_capability()
+    if cap[0] != 10:
+        raise SystemExit(
+            f"Fused FP8 output requires SM100/SM110 (Blackwell). "
+            f"Detected sm{cap[0]}{cap[1]}; aborting."
+        )
+
+    shapes = list(SHAPES) if not args.shape or "all" in args.shape else args.shape
+    print(f"Device: {torch.cuda.get_device_name(0)}")
+    print(f"Warmup={args.warmup}, rep={args.rep}\n")
+
+    for name in shapes:
+        torch.cuda.empty_cache()
+        bench_one(name, SHAPES[name], args.warmup, args.rep)
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -56,6 +56,7 @@ class FlashAttentionForwardBase:
         mask_mod: Optional[cutlass.Constexpr] = None,
         has_aux_tensors: bool = False,
         q_subtile_factor: int | None = None,
+        output_quant_key: Optional[cutlass.Constexpr[str]] = None,
     ):
         """Initializes the configuration for a flash attention kernel.
 
@@ -75,6 +76,10 @@ class FlashAttentionForwardBase:
             Callable signature: ``score_mod(scores, batch_idx, head_idx, q_idx, kv_idx, aux_tensors) -> Any``
         :param mask_mod: A callable that takes the attention scores and returns a boolean representing whether that score should be masked.
             Callable signature: ``mask_mod(batch_idx, head_idx, q_idx, kv_idx, aux_tensors) -> Boolean``
+        :param output_quant_key: compile-time tag represents specialized fused quant output in epilogue.
+            Used as a tag in compile_key. Inspired by quant keys in vLLM and derived from output scales args.
+            Supported: ``"kFp8StaticTensorSym"`` (per-tensor static FP8 e4m3fn)
+            TODO: ``"kFp8Dynamic128Sym"``, ``"kFp8Dynamic64Sym"``, ``"kNvfp4Dynamic"``
         """
         self.dtype = dtype
         # padding head_dim to a multiple of 16 as k_block_size
@@ -98,6 +103,7 @@ class FlashAttentionForwardBase:
         self.Q_in_regs = Q_in_regs
         self.score_mod = score_mod
         self.mask_mod = mask_mod
+        self.output_quant_key = output_quant_key
         self.qk_acc_dtype = Float32
         self.vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
@@ -604,6 +610,12 @@ class FlashAttentionForwardBase:
 
 
 class FlashAttentionForwardSm80(FlashAttentionForwardBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert self.output_quant_key is None, (
+            f"Fused quant output not implemented for {type(self).__name__}"
+        )
+
     def _get_smem_layout_atom(self):
         sQ_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.tile_hdim)
         sK_layout_atom = sQ_layout_atom
@@ -665,6 +677,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors=None,
+        output_scale: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -762,6 +775,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             TileScheduler,
             aux_tensors,
             fastdiv_mods,
+            output_scale,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -801,6 +815,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         TileScheduler: cutlass.Constexpr[Callable],
         aux_tensors=None,
         fastdiv_mods=None,
+        output_scale: Optional[cute.Tensor] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()

--- a/flash_attn/cute/flash_fwd_combine.py
+++ b/flash_attn/cute/flash_fwd_combine.py
@@ -29,6 +29,7 @@ class FlashAttentionForwardCombine:
         log_max_splits: int = 4,
         num_threads: int = 256,
         stages: int = 4,
+        output_quant_key: Optional[cutlass.Constexpr[str]] = None,
     ):
         """
         Forward combine kernel for split attention computation.
@@ -42,6 +43,8 @@ class FlashAttentionForwardCombine:
         :param num_threads: number of threads
         :param varlen: whether using variable length sequences
         :param stages: number of pipeline stages
+        :param output_quant_key: compile-time tag for fused quant output,
+            see FlashAttentionForwardBase for more details.
         """
         self.dtype = dtype
         self.dtype_partial = dtype_partial
@@ -52,6 +55,7 @@ class FlashAttentionForwardCombine:
         self.num_threads = num_threads
         self.is_even_k = head_dim % k_block_size == 0
         self.stages = stages
+        self.output_quant_key = output_quant_key
 
     @staticmethod
     def can_implement(
@@ -64,7 +68,9 @@ class FlashAttentionForwardCombine:
         num_threads,
     ) -> bool:
         """Check if the kernel can be implemented with the given parameters."""
-        if dtype not in [cutlass.Float16, cutlass.BFloat16, cutlass.Float32]:
+        if dtype not in [
+            cutlass.Float16, cutlass.BFloat16, cutlass.Float32, cutlass.Float8E4M3FN,
+        ]:
             return False
         if dtype_partial not in [cutlass.Float16, cutlass.BFloat16, Float32]:
             return False
@@ -199,6 +205,7 @@ class FlashAttentionForwardCombine:
         num_splits_dynamic_ptr: Optional[cute.Tensor] = None,
         varlen_batch_idx: Optional[cute.Tensor] = None,
         semaphore_to_reset: Optional[cute.Tensor] = None,
+        output_scale: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -313,6 +320,7 @@ class FlashAttentionForwardCombine:
             seqlen_divmod,
             head_divmod,
             varlen,
+            output_scale,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -342,10 +350,15 @@ class FlashAttentionForwardCombine:
         seqlen_divmod: FastDivmodDivisor,
         head_divmod: FastDivmodDivisor,
         varlen: cutlass.Constexpr[bool],
+        output_scale: Optional[cute.Tensor] = None,
     ):
         # Thread and block indices
         tidx, _, _ = cute.arch.thread_idx()
         m_block, k_block, maybe_virtual_batch = cute.arch.block_idx()
+
+        # Load FP8 output scale and invert in-kernel.
+        if const_expr(self.output_quant_key == "kFp8StaticTensorSym"):
+            output_scale_inv = Float32(1.0) / Float32(output_scale[0])
 
         # Map virtual batch index to real batch index (for persistent tile schedulers)
         batch_idx = (
@@ -643,7 +656,11 @@ class FlashAttentionForwardCombine:
             # ===============================
 
             rO = cute.make_rmem_tensor_like(tOrO, self.dtype)
-            rO.store(tOrO.load().to(self.dtype))
+            # Fold per-tensor output scale into the cast (fused FP8 out).
+            if const_expr(self.output_quant_key == "kFp8StaticTensorSym"):
+                rO.store((tOrO.load() * output_scale_inv).to(self.dtype))
+            else:
+                rO.store(tOrO.load().to(self.dtype))
             mO_cur = seqlen_info.offset_batch(mO, batch_idx, dim=3)
             if const_expr(cu_seqlens is None):
                 mO_cur = mO[None, None, None, batch_idx]

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -134,6 +134,8 @@ class FlashAttentionForwardSm100:
         is_varlen_q: bool = False,
         use_2cta_instrs: bool = False,
         use_clc_scheduler: bool = False,
+        # Derived tag for fused quant output, also see FlashAttentionForwardBase
+        output_quant_key: cutlass.Constexpr[str] | None = None,
     ):
         self.use_tma_KV = not paged_kv_non_tma
         # self.dtype = dtype
@@ -185,6 +187,7 @@ class FlashAttentionForwardSm100:
         )
         self.score_mod = score_mod
         self.mask_mod = mask_mod
+        self.output_quant_key = output_quant_key
         self.vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
         )
@@ -374,6 +377,7 @@ class FlashAttentionForwardSm100:
         descale_tensors: Optional[DescaleTensors] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
+        output_scale: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -760,6 +764,7 @@ class FlashAttentionForwardSm100:
             aux_tensors,
             fastdiv_mods,
             head_divmod,
+            output_scale,
         ).launch(
             grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
@@ -807,6 +812,7 @@ class FlashAttentionForwardSm100:
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
         head_divmod=None,
+        output_scale: Optional[cute.Tensor] = None,
     ):
         """The device kernel implementation of the Fused Multi-Head Attention.
 
@@ -1284,7 +1290,8 @@ class FlashAttentionForwardSm100:
                 num_splits,
                 SeqlenInfoCls,
                 blocksparse_tensors,
-                tile_scheduler=tile_scheduler,
+                tile_scheduler,
+                output_scale,
             )
             tmem_alloc_barrier.arrive()
 
@@ -2345,6 +2352,7 @@ class FlashAttentionForwardSm100:
         SeqlenInfoCls: Callable,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         tile_scheduler=None,
+        output_scale: Optional[cute.Tensor] = None,
     ):
         tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.correction_warp_ids))
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
@@ -2364,6 +2372,10 @@ class FlashAttentionForwardSm100:
 
         tStScales_t2r = [thr_tmem_load_vec.partition_S(tStScales[stage]) for stage in range(self.q_stage)]
         tSrScale_t2r_shape = thr_tmem_load_vec.partition_D(tScScale).shape
+
+        # Load FP8 output scale and invert in-kernel.
+        if const_expr(self.output_quant_key == "kFp8StaticTensorSym"):
+            output_scale_inv = Float32(1.0) / Float32(output_scale[0])
 
         # First iter: no correction is required
         # Notify mma warp that O has been rescaled
@@ -2500,6 +2512,9 @@ class FlashAttentionForwardSm100:
                     stats[stage] = (row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
                     scale = cute.arch.rcp_approx(row_sum if not acc_O_mn_row_is_zero_or_nan else 1.0)
                     scale = scale * v_descale
+                    # Fold per-tensor output scale into the existing per-row scale.
+                    if const_expr(self.output_quant_key == "kFp8StaticTensorSym"):
+                        scale = scale * output_scale_inv
                     # Wait for the last O to be ready from the MMA warp
                     pipeline_o_acc.consumer_wait_w_index_phase(stage, o_corr_consumer_phase)
                     if const_expr(not self.use_correction_warps_for_epi):

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -59,6 +59,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        assert self.output_quant_key is None, (
+            f"Fused quant output not implemented for {type(self).__name__}"
+        )
         self.intra_wg_overlap = intra_wg_overlap
         self.mma_pv_is_rs = mma_pv_is_rs
         self.buffer_align_bytes = 1024
@@ -179,6 +182,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
+        output_scale: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -187,7 +191,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
         (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
         """
-
         self._check_type(
             *(
                 t.element_type if t is not None else None
@@ -411,6 +414,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             num_splits,
             aux_tensors,
             fastdiv_mods,
+            output_scale,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -458,6 +462,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         num_splits: Int32 = Int32(1),
         aux_tensors=Optional[list[cute.Tensor]],
         fastdiv_mods=None,
+        output_scale: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # Prefetch tma descriptor

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -323,6 +323,7 @@ def _flash_attn_fwd(
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Forward pass for FlashAttention.
 
@@ -334,8 +335,12 @@ def _flash_attn_fwd(
         return_lse: Whether to return the log softmax of the attention scores. If set to True will always calculate
             The returned LSE supports taking gradient.
         out: Optional pre-allocated output tensor. If None, will be allocated internally.
+            FP8 (e4m3fn) dtype is selected automatically when `output_scale` is set.
         lse: Optional pre-allocated log-sum-exp tensor. If None, will be allocated when needed.
         aux_tensors: Some score_mods will want to read from global aux_tensors. This is how we thread them through to the inner kernel.
+        output_scale: 0-d FP32 GPU tensor. Presence opts into the static per-tensor
+            FP8 (e4m3fn) fused-quant output: the kernel writes FP8 with
+            dequant = out_fp8 * output_scale. SM100/SM110 only.
     """
     q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
     q_descale, k_descale, v_descale = [maybe_contiguous(t) for t in (q_descale, k_descale, v_descale)]
@@ -416,6 +421,7 @@ def _flash_attn_fwd(
                 seqused_k,
                 page_table,
                 learnable_sink,
+                output_scale,
             )
         ), "inputs must be on CUDA device"
     arch = _get_device_arch() if _arch is None else _arch
@@ -435,7 +441,21 @@ def _flash_attn_fwd(
     is_fp8 = q.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     if is_fp8 and (q.requires_grad or k.requires_grad or v.requires_grad):
         raise NotImplementedError("FA4 CuTe FP8 backward is not supported yet (forward-only).")
-    out_torch_dtype = torch.bfloat16 if is_fp8 else q.dtype
+    if output_scale is not None:
+        assert output_scale.dtype == torch.float32, "output_scale must be float32"
+        assert output_scale.numel() == 1, "output_scale must be a scalar (numel == 1) tensor"
+        assert output_scale.device == q.device, "output_scale must be on the same device as q"
+        assert block_sparse_tensors is None, "fused FP8 output + block sparsity not supported yet"
+        assert page_table is None, "fused FP8 output + paged KV not supported yet"
+        out_torch_dtype = torch.float8_e4m3fn
+        # Derived output quant key for use as tag in compile_key.
+        # The tag values are inspired by vLLM. More support will be added for keys:
+        # kFp8Dynamic128Sym, kFp8Dynamic64Sym, kNvfp4Dynamic
+        output_quant_key = "kFp8StaticTensorSym"
+        output_scale = output_scale.reshape(1)
+    else:
+        out_torch_dtype = torch.bfloat16 if is_fp8 else q.dtype
+        output_quant_key = None
     device = q.device
     q_batch_seqlen_shape = (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
     lse_shape = (batch_size, num_head, seqlen_q) if cu_seqlens_q is None else (num_head, total_q)
@@ -724,6 +744,7 @@ def _flash_attn_fwd(
         sparse_kv,
         disable_sparse_kv_bitmask,
         fa_logging.get_fa_log_level(),
+        output_quant_key,
     )
 
     if compile_key not in _flash_attn_fwd.compile_cache:
@@ -733,11 +754,12 @@ def _flash_attn_fwd(
             seqused_q_tensor,
             seqused_k_tensor,
             learnable_sink_tensor,
+            output_scale_tensor, # 1d scalar tensor
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
             else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, output_scale)
         ]
         page_table_tensor = (
             to_cute_tensor(page_table, assumed_align=4, leading_dim=1)
@@ -812,6 +834,7 @@ def _flash_attn_fwd(
                 score_mod=score_mod,
                 mask_mod=mask_mod,
                 has_aux_tensors=aux_tensors is not None,
+                output_quant_key=output_quant_key,
             )
         elif arch // 10 == 9:
             fa_fwd = FlashAttentionForwardSm90(
@@ -835,8 +858,15 @@ def _flash_attn_fwd(
                 has_aux_tensors=aux_tensors is not None,
                 q_subtile_factor=q_subtile_factor,
                 paged_kv_non_tma=page_size not in [None, tile_n],
+                # SplitKV: forward writes FP32 partials, combine does the fold.
+                output_quant_key=output_quant_key if not is_split_kv else None,
             )
         elif arch // 10 in [10, 11]:
+            if output_quant_key is not None:
+                assert qv is None, "fused FP8 output + MLA (qv) not supported yet"
+                assert not use_dedicated_hd256_kernel, (
+                    "fused FP8 output + head_dim=256 kernel not supported yet"
+                )
             if qv is not None:
                 fa_fwd = FlashAttentionMLAForwardSm100(
                     is_causal=causal,
@@ -879,37 +909,60 @@ def _flash_attn_fwd(
                     # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
                     pack_gqa = False
 
-                flash_fwd_obj_cls = (
-                    BlackwellFusedMultiHeadAttentionForward
-                    if use_dedicated_hd256_kernel
-                    else FlashAttentionForwardSm100
-                )
-
-                fa_fwd = flash_fwd_obj_cls(
-                    head_dim,
-                    head_dim_v,
-                    qhead_per_kvhead=qhead_per_kvhead,
-                    is_causal=causal,
-                    is_local=local,
-                    is_split_kv=is_split_kv,
-                    pack_gqa=pack_gqa,
-                    m_block_size=tile_m,
-                    n_block_size=tile_n,
-                    q_stage=q_stage,
-                    is_persistent=not causal
-                        and not local
-                        and cu_seqlens_q is None
-                        and seqused_q is None
-                        and not is_split_kv,
-                    score_mod=score_mod,
-                    mask_mod=mask_mod,
-                    has_aux_tensors=aux_tensors is not None,
-                    paged_kv_non_tma=page_size not in [None, tile_n],
-                    is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
-                    q_subtile_factor=q_subtile_factor,
-                    use_2cta_instrs=use_2cta_instrs,
-                    use_clc_scheduler=use_clc_scheduler,
-                )
+                if use_dedicated_hd256_kernel:
+                    fa_fwd = BlackwellFusedMultiHeadAttentionForward(
+                        head_dim,
+                        head_dim_v,
+                        qhead_per_kvhead=qhead_per_kvhead,
+                        is_causal=causal,
+                        is_local=local,
+                        is_split_kv=is_split_kv,
+                        pack_gqa=pack_gqa,
+                        m_block_size=tile_m,
+                        n_block_size=tile_n,
+                        q_stage=q_stage,
+                        is_persistent=not causal
+                            and not local
+                            and cu_seqlens_q is None
+                            and seqused_q is None
+                            and not is_split_kv,
+                        score_mod=score_mod,
+                        mask_mod=mask_mod,
+                        has_aux_tensors=aux_tensors is not None,
+                        paged_kv_non_tma=page_size not in [None, tile_n],
+                        is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
+                        q_subtile_factor=q_subtile_factor,
+                        use_2cta_instrs=use_2cta_instrs,
+                        use_clc_scheduler=use_clc_scheduler,
+                    )
+                else:
+                    fa_fwd = FlashAttentionForwardSm100(
+                        head_dim,
+                        head_dim_v,
+                        qhead_per_kvhead=qhead_per_kvhead,
+                        is_causal=causal,
+                        is_local=local,
+                        is_split_kv=is_split_kv,
+                        pack_gqa=pack_gqa,
+                        m_block_size=tile_m,
+                        n_block_size=tile_n,
+                        q_stage=q_stage,
+                        is_persistent=not causal
+                            and not local
+                            and cu_seqlens_q is None
+                            and seqused_q is None
+                            and not is_split_kv,
+                        score_mod=score_mod,
+                        mask_mod=mask_mod,
+                        has_aux_tensors=aux_tensors is not None,
+                        paged_kv_non_tma=page_size not in [None, tile_n],
+                        is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
+                        q_subtile_factor=q_subtile_factor,
+                        use_2cta_instrs=use_2cta_instrs,
+                        use_clc_scheduler=use_clc_scheduler,
+                        # SplitKV: forward writes FP32 partials, combine does the fold.
+                        output_quant_key=output_quant_key if not is_split_kv else None,
+                    )
         elif arch // 10 == 12:
             # SM120 (Blackwell GeForce / DGX Spark): uses SM80 MMA with SM120 SMEM capacity
             assert not use_block_sparsity, "Block sparsity not supported on SM 12.0"
@@ -931,6 +984,7 @@ def _flash_attn_fwd(
                 score_mod=score_mod,
                 mask_mod=mask_mod,
                 has_aux_tensors=aux_tensors is not None,
+                output_quant_key=output_quant_key,
             )
         else:
             raise ValueError(
@@ -981,6 +1035,11 @@ def _flash_attn_fwd(
             ]
             if arch // 10 in [10, 11]:
                 compile_args.insert(-3, descale_tensors_tensor)
+            # TODO: thread output_scale into the hd256 (BlackwellFusedMultiHeadAttentionForward)
+            # and MLA (FlashAttentionMLAForwardSm100) kernels so fused FP8 output works there
+            # too, then drop this special-casing and the qv/hd256 fp8-output guards above.
+            if not use_dedicated_hd256_kernel:
+                compile_args.insert(-1, output_scale_tensor)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
 
     if not is_fake_mode():
@@ -1048,6 +1107,9 @@ def _flash_attn_fwd(
                 else None,
                 aux_tensors,
             ])
+            # See the TODO above: hd256/MLA kernels don't take output_scale yet.
+            if not use_dedicated_hd256_kernel:
+                call_args.append(output_scale)
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
     if is_split_kv:
         _flash_attn_fwd_combine(
@@ -1057,6 +1119,7 @@ def _flash_attn_fwd(
             lse.transpose(-1, -2) if lse is not None else None,
             cu_seqlens_q,
             seqused_q,
+            output_scale=output_scale,
         )
     return out, lse
 
@@ -1936,6 +1999,8 @@ class FlashAttnFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
         block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
         return_lse: bool = False,
+        out: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ):
         out, lse = _flash_attn_fwd(
             q,
@@ -1956,6 +2021,8 @@ class FlashAttnFunc(torch.autograd.Function):
             block_sparse_tensors=block_sparse_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
+            out=out,
+            output_scale=output_scale,
         )
         ctx.save_for_backward(q, k, v, out, lse, *(aux_tensors or ()))
         ctx.softmax_scale = softmax_scale
@@ -2031,6 +2098,8 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         score_mod_bwd: Optional[Callable] = None,
         aux_tensors: Optional[list] = None,
         return_lse: bool = False,
+        out: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ):
         out, lse = _flash_attn_fwd(
             q,
@@ -2057,6 +2126,8 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             aux_tensors=aux_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
+            out=out,
+            output_scale=output_scale,
         )
         ctx.save_for_backward(
             q,
@@ -2140,6 +2211,8 @@ def flash_attn_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
+    out: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
 ):
     return FlashAttnFunc.apply(
         q,
@@ -2162,6 +2235,8 @@ def flash_attn_func(
         block_sparse_tensors,
         block_sparse_tensors_bwd,
         return_lse,
+        out,
+        output_scale,
     )
 
 
@@ -2191,6 +2266,8 @@ def flash_attn_varlen_func(
     score_mod_bwd: Optional[Callable] = None,
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
+    out: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
 ):
     """
     Explanation of some optional arguments:
@@ -2232,12 +2309,14 @@ def flash_attn_varlen_func(
         score_mod_bwd,
         aux_tensors,
         return_lse,
+        out,
+        output_scale,
     )
 
 
 def _compile_fwd_combine(
     dtype, dtype_partial, head_dim, tile_m, k_block_size, log_max_splits,
-    has_cu_seqlens, has_seqused, has_lse, has_varlen_batch_idx,
+    has_cu_seqlens, has_seqused, has_lse, has_varlen_batch_idx, output_quant_key,
 ):
     """Compile fwd combine kernel using cute fake tensors (no real GPU tensors needed)."""
     sym = cute.sym_int
@@ -2250,6 +2329,7 @@ def _compile_fwd_combine(
         tile_m=tile_m,
         k_block_size=k_block_size,
         log_max_splits=log_max_splits,
+        output_quant_key=output_quant_key,
     )
     if not fa_combine.can_implement(
         dtype, dtype_partial, head_dim, tile_m, k_block_size, log_max_splits,
@@ -2282,11 +2362,13 @@ def _compile_fwd_combine(
     mNumSplitsDynamic = None  # Not parametrized in compile_key
     mVarlenBatchIdx = fake_tensor(Int32, (batch_for_1d,), divisibility=1) if has_varlen_batch_idx else None
     mSemaphore = None  # Not parametrized in compile_key
+    output_scale = fake_tensor(Float32, (1,), divisibility=1) if output_quant_key is not None else None
 
     return cute.compile(
         fa_combine,
         mO_partial, mLSE_partial, mO, mLSE,
         mCuSeqlens, mSeqused, mNumSplitsDynamic, mVarlenBatchIdx, mSemaphore,
+        output_scale,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
         options="--enable-tvm-ffi",
     )
@@ -2302,6 +2384,7 @@ def _flash_attn_fwd_combine(
     num_splits_dynamic_ptr: Optional[torch.Tensor] = None,
     varlen_batch_idx: Optional[torch.Tensor] = None,
     semaphore_to_reset: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
 ) -> None:
     """Forward combine kernel for split attention computation.
 
@@ -2327,6 +2410,13 @@ def _flash_attn_fwd_combine(
     assert out_partial.dtype in [torch.float16, torch.bfloat16, torch.float32], (
         "out_partial must be fp16, bf16, or fp32"
     )
+
+    if output_scale is not None:
+        # Derived output quant key for use in compile_key and const_expr.
+        output_quant_key = "kFp8StaticTensorSym"
+    else:
+        output_quant_key = None
+
     if not is_fake_mode():
         assert out_partial.is_cuda and lse_partial.is_cuda, "tensors must be on CUDA device"
     # Determine if this is variable length based on dimensions
@@ -2370,6 +2460,7 @@ def _flash_attn_fwd_combine(
         seqused is not None,
         lse is not None,
         varlen_batch_idx is not None,
+        output_quant_key,
     )
     if compile_key not in _flash_attn_fwd_combine.compile_cache:
         _flash_attn_fwd_combine.compile_cache[compile_key] = _compile_fwd_combine(
@@ -2380,6 +2471,7 @@ def _flash_attn_fwd_combine(
             out_partial, lse_partial, out, lse,
             cu_seqlens, seqused, num_splits_dynamic_ptr, varlen_batch_idx,
             semaphore_to_reset,
+            output_scale,
         )
 
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1052,6 +1052,9 @@ def _flash_attn_fwd(
             v_call = v_call.view(torch.uint8)
             if qv_call is not None:
                 qv_call = qv_call.view(torch.uint8)
+        out_call = out.detach()
+        if out_call.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            out_call = out_call.view(torch.uint8)
         descale_tensors = (
             DescaleTensors(q_descale=q_descale, k_descale=k_descale, v_descale=v_descale)
             if q_descale is not None or k_descale is not None or v_descale is not None
@@ -1063,7 +1066,7 @@ def _flash_attn_fwd(
                 qv_call,
                 k_call,
                 v_call,
-                out.detach(),
+                out_call,
                 lse,
                 softmax_scale,
                 cu_seqlens_q,
@@ -1080,7 +1083,7 @@ def _flash_attn_fwd(
                 q_call,
                 k_call,
                 v_call,
-                out.detach() if not is_split_kv else out_partial,
+                out_call if not is_split_kv else out_partial,
                 lse_partial if is_split_kv else lse,
                 softmax_scale,
                 cu_seqlens_q,

--- a/tests/cute/test_flash_attn_fp8_output.py
+++ b/tests/cute/test_flash_attn_fp8_output.py
@@ -390,12 +390,14 @@ def test_fp8_output_validation_errors():
     out_fp8 = torch.empty(2, 64, 4, 128, dtype=torch.float8_e4m3fn, device=device)
     scale = _scale_t(0.5, device)
 
-    # FP8 output without output_scale -> AssertionError
-    with pytest.raises(AssertionError, match="no output_scale was provided"):
+    # FP8 `out` without output_scale: caught downstream by _validate_tensor
+    # (out_torch_dtype falls back to bf16, so the fp8 buffer dtype mismatches).
+    with pytest.raises(AssertionError, match="out dtype"):
         _flash_attn_fwd(q, k, v, out=out_fp8, _arch=100)
 
-    # output_scale as a Python float -> AssertionError
-    with pytest.raises(AssertionError, match="must be a torch.Tensor"):
+    # Non-tensor output_scale is rejected by the shared CUDA-device check,
+    # same as any other tensor arg (e.g. q_descale) given a Python float.
+    with pytest.raises(AttributeError):
         _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=0.5, _arch=100)
 
     # output_scale wrong dtype -> AssertionError

--- a/tests/cute/test_flash_attn_fp8_output.py
+++ b/tests/cute/test_flash_attn_fp8_output.py
@@ -22,7 +22,7 @@ from flash_attn.cute.testing import (
 USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
 IS_FP8_SM_SUPPORTED = (
     torch.cuda.is_available()
-    and torch.cuda.get_device_capability()[0] == 10
+    and torch.cuda.get_device_capability()[0] in (10, 11)
 )
 
 skip_if_no_fp8_sm = pytest.mark.skipif(
@@ -414,9 +414,9 @@ def test_fp8_output_validation_errors():
         _flash_attn_fwd(q, k, v, out=bf16_out, output_scale=scale, _arch=100)
 
     # SM80 / SM90 / SM120 reject FP8 output in each forward class's __init__.
-    with pytest.raises(AssertionError, match="FP8 output not implemented"):
+    with pytest.raises(AssertionError, match="Fused quant output not implemented"):
         _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=scale, _arch=80)
-    with pytest.raises(AssertionError, match="FP8 output not implemented"):
+    with pytest.raises(AssertionError, match="Fused quant output not implemented"):
         _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=scale, _arch=90)
-    with pytest.raises(AssertionError, match="FP8 output not implemented"):
+    with pytest.raises(AssertionError, match="Fused quant output not implemented"):
         _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=scale, _arch=120)

--- a/tests/cute/test_flash_attn_fp8_output.py
+++ b/tests/cute/test_flash_attn_fp8_output.py
@@ -1,0 +1,422 @@
+# Copyright (c) 2025, the FlashAttention authors.
+"""Static per-tensor FP8 (e4m3fn) fused output tests, SM100/SM110.
+
+Accuracy bound mirrors `test_flash_attn.py`: kernel error vs FP32 ref is
+allowed to be at most `rtol`x the eager-BF16-then-FP8 path's error vs the
+same FP32 ref, plus a small ULP atol.
+"""
+
+import math
+import os
+
+import pytest
+import torch
+
+from flash_attn.cute.interface import flash_attn_func, flash_attn_varlen_func
+from flash_attn.cute.testing import (
+    attention_ref,
+    is_fake_mode,
+    maybe_fake_tensor_mode,
+)
+
+USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
+IS_FP8_SM_SUPPORTED = (
+    torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] == 10
+)
+
+skip_if_no_fp8_sm = pytest.mark.skipif(
+    not IS_FP8_SM_SUPPORTED,
+    reason="Fused FP8 output requires SM100/SM110 (Blackwell).",
+)
+
+# Data-independent so it works under FakeTensorMode (no `.amax()` allowed).
+DEFAULT_OUT_SCALE = 0.005
+
+
+def _scale_t(value: float, device: torch.device) -> torch.Tensor:
+    """Build a 0-d FP32 device tensor for the `output_scale` API."""
+    return torch.tensor(value, dtype=torch.float32, device=device)
+
+
+def _quantize_fp8(x: torch.Tensor, out_scale: float) -> torch.Tensor:
+    """Static-scaled FP8 cast — what `static_scaled_fp8_quant` would emit."""
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    return (x.float() / out_scale).clamp(finfo.min, finfo.max).to(torch.float8_e4m3fn)
+
+
+def _assert_fp8_close(
+    fused_fp8: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out_scale: float,
+    rtol: float = 2.0,
+    **ref_kwargs,
+) -> None:
+    """kernel_err <= rtol * eager_BF16+quant_err + ULP_atol, vs FP32 ref."""
+    out_ref_fp32, _ = attention_ref(q, k, v, None, None, upcast=True, **ref_kwargs)
+    out_pt_bf16, _ = attention_ref(
+        q, k, v, None, None, upcast=False, reorder_ops=True, **ref_kwargs,
+    )
+
+    ref_fp8 = _quantize_fp8(out_ref_fp32, out_scale)
+    pt_fp8 = _quantize_fp8(out_pt_bf16, out_scale)
+
+    fused_deq = fused_fp8.float() * out_scale
+    ref_deq = ref_fp8.float() * out_scale
+    pt_deq = pt_fp8.float() * out_scale
+
+    fwd_atol = 2 * (ref_deq + 0.3 - 0.3 - ref_deq).abs().max().item()
+    kernel_err = (fused_deq - ref_deq).abs().max().item()
+    eager_err = (pt_deq - ref_deq).abs().max().item()
+
+    assert kernel_err <= rtol * eager_err + fwd_atol, (
+        f"fused FP8 kernel max-err vs FP32 ref ({kernel_err:.4f}) > "
+        f"{rtol}x eager-BF16+post-quant max-err ({eager_err:.4f}) + "
+        f"ULP atol ({fwd_atol:.4f})"
+    )
+
+
+@skip_if_no_fp8_sm
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "head_dim,head_dim_v",
+    [(64, 64), (128, 128), (192, 128)],  # small MHA + standard + DeepSeek MLA prefill
+)
+@pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_fp8_output_matches_post_quant(
+    dtype: torch.dtype,
+    causal: bool,
+    head_dim: int,
+    head_dim_v: int,
+    mha_type: str,
+):
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, seqlen, num_heads = 2, 512, 16
+    if mha_type == "mha":
+        num_kv_heads = num_heads
+    elif mha_type == "mqa":
+        num_kv_heads = 1
+    else:  # gqa
+        num_kv_heads = 4
+
+    q = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(batch, seqlen, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v = torch.randn(batch, seqlen, num_kv_heads, head_dim_v, dtype=dtype, device=device)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+    out_scale = DEFAULT_OUT_SCALE
+
+    fused_buffer = torch.empty(
+        batch, seqlen, num_heads, head_dim_v, dtype=torch.float8_e4m3fn, device=device,
+    )
+    fused_out, _ = flash_attn_func(
+        q, k, v,
+        softmax_scale=softmax_scale, causal=causal,
+        out=fused_buffer,
+        output_scale=_scale_t(out_scale, device),
+    )
+    if is_fake_mode():
+        return  # compile-only pass; skip data-dependent comparison
+    assert fused_out.dtype == torch.float8_e4m3fn
+
+    _assert_fp8_close(fused_out, q, k, v, out_scale, causal=causal)
+
+
+@skip_if_no_fp8_sm
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_fp8_output_varlen_deepseek_mla():
+    """DeepSeek-V3 MLA prefill shape (qk=192, v=128) via the varlen API."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    seqlens = [256, 384, 512, 192]
+    total_q = sum(seqlens)
+    num_heads, num_kv_heads = 16, 1
+    head_dim, head_dim_v = 192, 128
+    dtype = torch.bfloat16
+    out_scale = DEFAULT_OUT_SCALE
+
+    q = torch.randn(total_q, num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(total_q, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v = torch.randn(total_q, num_kv_heads, head_dim_v, dtype=dtype, device=device)
+    cu_seqlens = torch.zeros(len(seqlens) + 1, dtype=torch.int32, device=device)
+    cu_seqlens[1:] = torch.tensor(seqlens, dtype=torch.int32, device=device).cumsum(0)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    fused_buffer = torch.empty(
+        total_q, num_heads, head_dim_v, dtype=torch.float8_e4m3fn, device=device,
+    )
+    fused_out, _ = flash_attn_varlen_func(
+        q, k, v,
+        cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max(seqlens), max_seqlen_k=max(seqlens),
+        softmax_scale=softmax_scale, causal=True,
+        out=fused_buffer,
+        output_scale=_scale_t(out_scale, device),
+    )
+    if is_fake_mode():
+        return
+    assert fused_out.dtype == torch.float8_e4m3fn
+
+    # attention_ref is 4D-only, so compare per-sequence and accumulate errors.
+    fwd_atol = 0.0
+    kernel_err = 0.0
+    eager_err = 0.0
+    for i, sl in enumerate(seqlens):
+        s, e = int(cu_seqlens[i].item()), int(cu_seqlens[i + 1].item())
+        qi = q[s:e].unsqueeze(0)
+        ki = k[s:e].unsqueeze(0)
+        vi = v[s:e].unsqueeze(0)
+        out_ref_fp32, _ = attention_ref(qi, ki, vi, None, None, causal=True, upcast=True)
+        out_pt_bf16, _ = attention_ref(
+            qi, ki, vi, None, None, causal=True, upcast=False, reorder_ops=True,
+        )
+        ref_fp8 = _quantize_fp8(out_ref_fp32, out_scale)
+        pt_fp8 = _quantize_fp8(out_pt_bf16, out_scale)
+        ref_deq = ref_fp8.float() * out_scale
+        pt_deq = pt_fp8.float() * out_scale
+        fused_deq = fused_out[s:e].unsqueeze(0).float() * out_scale
+        fwd_atol = max(fwd_atol, 2 * (ref_deq + 0.3 - 0.3 - ref_deq).abs().max().item())
+        kernel_err = max(kernel_err, (fused_deq - ref_deq).abs().max().item())
+        eager_err = max(eager_err, (pt_deq - ref_deq).abs().max().item())
+
+    rtol = 2.0
+    assert kernel_err <= rtol * eager_err + fwd_atol, (
+        f"varlen fused FP8 max-err vs FP32 ref ({kernel_err:.4f}) > "
+        f"{rtol}x eager max-err ({eager_err:.4f}) + ULP atol ({fwd_atol:.4f})"
+    )
+
+
+@skip_if_no_fp8_sm
+def test_fp8_output_auto_allocate():
+    """User passes output_scale without `out`; library allocates FP8 buffer."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    q = torch.randn(2, 256, 8, 128, dtype=torch.bfloat16, device=device)
+    k = torch.randn(2, 256, 8, 128, dtype=torch.bfloat16, device=device)
+    v = torch.randn(2, 256, 8, 128, dtype=torch.bfloat16, device=device)
+
+    fused_out, _ = flash_attn_func(
+        q, k, v, causal=True,
+        output_scale=_scale_t(0.05, device),
+    )
+    assert fused_out.dtype == torch.float8_e4m3fn
+    assert fused_out.shape == (2, 256, 8, 128)
+
+
+@skip_if_no_fp8_sm
+def test_fp8_output_scale_shape_variants():
+    """`output_scale` accepts both 0-d and 1-elem 1-D tensors (same bytes out)."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    q = torch.randn(2, 256, 8, 128, dtype=torch.bfloat16, device=device)
+    k = torch.randn(2, 256, 8, 128, dtype=torch.bfloat16, device=device)
+    v = torch.randn(2, 256, 8, 128, dtype=torch.bfloat16, device=device)
+
+    scale_0d = torch.tensor(0.05, dtype=torch.float32, device=device)
+    scale_1d = torch.tensor([0.05], dtype=torch.float32, device=device)
+    out_a, _ = flash_attn_func(q, k, v, causal=True, output_scale=scale_0d)
+    out_b, _ = flash_attn_func(q, k, v, causal=True, output_scale=scale_1d)
+    # Both shapes go through the same `.reshape(1)` normalization on the
+    # host, so the resulting FP8 bytes must be identical.
+    assert torch.equal(out_a.view(torch.uint8), out_b.view(torch.uint8))
+
+
+@skip_if_no_fp8_sm
+@pytest.mark.parametrize(
+    "window_size",
+    [(128, 0), (64, 64), (-1, 0)],  # left-only causal local, symmetric local, full causal
+    ids=["causal_local_left", "symmetric_local", "causal_full"],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_fp8_output_sliding_window(window_size):
+    """Local / sliding-window masking exercises a different mask_mod path."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, seqlen, num_heads = 2, 512, 8
+    head_dim = 128
+    dtype = torch.bfloat16
+    out_scale = DEFAULT_OUT_SCALE
+
+    q = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    v = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    causal = window_size == (-1, 0)
+    ws_kernel = (None, None) if causal else window_size
+    ws_ref = ws_kernel
+
+    fused_buffer = torch.empty(
+        batch, seqlen, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device,
+    )
+    fused_out, _ = flash_attn_func(
+        q, k, v, softmax_scale=softmax_scale, causal=causal, window_size=ws_kernel,
+        out=fused_buffer,
+        output_scale=_scale_t(out_scale, device),
+    )
+    if is_fake_mode():
+        return
+
+    _assert_fp8_close(
+        fused_out, q, k, v, out_scale, causal=causal, window_size=ws_ref,
+    )
+
+
+@skip_if_no_fp8_sm
+@pytest.mark.parametrize("softcap", [15.0, 30.0])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_fp8_output_softcap(softcap: float):
+    """Softcap (Gemma/GLM) wraps logits through tanh before softmax."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, seqlen, num_heads = 2, 512, 8
+    head_dim = 128
+    dtype = torch.bfloat16
+    out_scale = DEFAULT_OUT_SCALE
+
+    q = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    v = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    fused_buffer = torch.empty(
+        batch, seqlen, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device,
+    )
+    fused_out, _ = flash_attn_func(
+        q, k, v, softmax_scale=softmax_scale, causal=True, softcap=softcap,
+        out=fused_buffer,
+        output_scale=_scale_t(out_scale, device),
+    )
+    if is_fake_mode():
+        return
+
+    # Softcap matches `rtol = 3 if softcap > 0 else 2` in test_flash_attn_output.
+    _assert_fp8_close(
+        fused_out, q, k, v, out_scale, rtol=3.0, causal=True, softcap=softcap,
+    )
+
+
+@skip_if_no_fp8_sm
+@pytest.mark.parametrize(
+    "scale_factor",
+    [0.1, 1.0, 4.0],
+    ids=["scale_underuses_range", "scale_matches_peak", "scale_overuses_range"],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_fp8_output_scale_extremes(scale_factor: float):
+    """Sweep `output_scale` away from the matched-peak choice.
+
+    - small scale: values divide to >fp8_max → clamp.
+    - matched scale: roughly fills the FP8 range.
+    - large scale: values divide to << 1 → mantissa truncation.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, seqlen, num_heads = 2, 256, 8
+    head_dim = 128
+    dtype = torch.bfloat16
+    out_scale = DEFAULT_OUT_SCALE * scale_factor
+
+    q = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    v = torch.randn(batch, seqlen, num_heads, head_dim, dtype=dtype, device=device)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    fused_buffer = torch.empty(
+        batch, seqlen, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device,
+    )
+    fused_out, _ = flash_attn_func(
+        q, k, v, softmax_scale=softmax_scale, causal=True,
+        out=fused_buffer,
+        output_scale=_scale_t(out_scale, device),
+    )
+    if is_fake_mode():
+        return
+
+    _assert_fp8_close(fused_out, q, k, v, out_scale, causal=True)
+
+
+@skip_if_no_fp8_sm
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_fp8_output_split_kv():
+    """Split-KV + FP8: forward writes FP32 partials, combine emits FP8.
+
+    Triggered by short Q + long K (decode-style); we force num_splits=4 to
+    guarantee the split-KV combine path even if the auto-heuristic wouldn't
+    pick it.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, seqlen_q, seqlen_k, num_heads = 2, 1, 4096, 16
+    head_dim = 128
+    out_scale = DEFAULT_OUT_SCALE
+
+    q = torch.randn(batch, seqlen_q, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    k = torch.randn(batch, seqlen_k, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    v = torch.randn(batch, seqlen_k, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    fused_buffer = torch.empty(
+        batch, seqlen_q, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device,
+    )
+    fused_out, _ = flash_attn_func(
+        q, k, v,
+        softmax_scale=softmax_scale, causal=True, num_splits=4,
+        out=fused_buffer,
+        output_scale=_scale_t(out_scale, device),
+    )
+    if is_fake_mode():
+        return
+    assert fused_out.dtype == torch.float8_e4m3fn
+
+    _assert_fp8_close(fused_out, q, k, v, out_scale, causal=True)
+
+
+def test_fp8_output_validation_errors():
+    """Validation paths fire on any GPU (no kernel launch needed)."""
+    torch.manual_seed(0)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if device.type == "cpu":
+        pytest.skip("Validation calls into _flash_attn_fwd which expects CUDA tensors")
+    from flash_attn.cute.interface import _flash_attn_fwd
+
+    q = torch.randn(2, 64, 4, 128, dtype=torch.bfloat16, device=device)
+    k = torch.randn(2, 64, 4, 128, dtype=torch.bfloat16, device=device)
+    v = torch.randn(2, 64, 4, 128, dtype=torch.bfloat16, device=device)
+    out_fp8 = torch.empty(2, 64, 4, 128, dtype=torch.float8_e4m3fn, device=device)
+    scale = _scale_t(0.5, device)
+
+    # FP8 output without output_scale -> AssertionError
+    with pytest.raises(AssertionError, match="no output_scale was provided"):
+        _flash_attn_fwd(q, k, v, out=out_fp8, _arch=100)
+
+    # output_scale as a Python float -> AssertionError
+    with pytest.raises(AssertionError, match="must be a torch.Tensor"):
+        _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=0.5, _arch=100)
+
+    # output_scale wrong dtype -> AssertionError
+    bad_dtype = torch.tensor(0.5, dtype=torch.float64, device=device)
+    with pytest.raises(AssertionError, match="must be float32"):
+        _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=bad_dtype, _arch=100)
+
+    # output_scale with multiple elements -> AssertionError
+    bad_shape = torch.tensor([0.5, 0.6], dtype=torch.float32, device=device)
+    with pytest.raises(AssertionError, match="must be a scalar"):
+        _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=bad_shape, _arch=100)
+
+    # output_scale on a BF16 output buffer -> AssertionError (out dtype mismatch).
+    bf16_out = torch.empty(2, 64, 4, 128, dtype=torch.bfloat16, device=device)
+    with pytest.raises(AssertionError, match="torch.float8_e4m3fn"):
+        _flash_attn_fwd(q, k, v, out=bf16_out, output_scale=scale, _arch=100)
+
+    # SM80 / SM90 / SM120 reject FP8 output in each forward class's __init__.
+    with pytest.raises(AssertionError, match="FP8 output not implemented"):
+        _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=scale, _arch=80)
+    with pytest.raises(AssertionError, match="FP8 output not implemented"):
+        _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=scale, _arch=90)
+    with pytest.raises(AssertionError, match="FP8 output not implemented"):
+        _flash_attn_fwd(q, k, v, out=out_fp8, output_scale=scale, _arch=120)


### PR DESCRIPTION
## Purpose
Part of vLLM [issue#35792](https://github.com/vllm-project/vllm/issues/35792) of MLA + quant fusion. Specifically,
- FA4 is the preferred MLA prefill backend
- PR adds support for fused static per-tensor FP8 output (SM100)
- PR explores the pattern in external-facing interface and internal forward kernel, in preparation for per-group FP8 and NVFP4.
- PR reuses the concepts of `quant_key` and `quant_kwargs` from vllm.
- The quant scaling happens in one of the two places:
  - no kv split: directly in foward kernel
  - with kv split: in forward combine after kernels
- SM90 is not included in this PR, because its forward class misses o_dtype and needs bigger changes.
  - skipped to limit the scope of this change, and will make a fast follow up PR afterwards.

## Test Plan
- [x] new unit tests pass on B200
- [x] benchmark on B200
- Note: more benchmark can be performed in vLLM once the PR is merged.

## Test Results

**benchmark result**
| shape | bf16 attn | bf16+quant (unfused) | fused fp8 | saved | speedup |
|---|---|---|---|---|---|
| prefill_mla_4k (h=16/1, d=192-128)         | 119.2us / 1441 TF | 152.3us / 1128 TF | 118.0us / 1456 TF | +34.4us | 1.29x |
| prefill_mha_4k (h=32/32, d=128)            | 223.0us / 1233 TF | 273.6us / 1005 TF | 217.8us / 1262 TF | +55.8us | 1.26x |
| prefill_gqa_8k (h=32/4, d=128)             | 762.6us / 1442 TF | 850.8us / 1292 TF | 751.5us / 1463 TF | +99.3us | 1.13x |
| decode_gqa_8k (b=16, sq=1, h=16/1, d=128)  | 83.5us            | 97.8us            | 83.2us            | +14.7us | 1.18x |
| decode_mha_8k (b=16, sq=1, h=16/16, d=128) | 187.0us           | 201.4us           | 186.8us           | +14.6us | 1.08x |

note: the "fused fp8" is slighter quicker than "bf16 attn", likely due to less mem write.

**pytest result**

<details>
<summary>cute/test_flash_attn_fp8_output.py: 49 passed, 1117 warnings in 84.39s (0:01:24)</summary>
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /root/flash-attention/.venv/bin/python
cachedir: .pytest_cache
rootdir: /root/flash-attention/tests
configfile: pyproject.toml
collecting ... collected 49 items

cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-64-64-False-dtype0] PASSED [  2%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-64-64-False-dtype1] PASSED [  4%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-64-64-True-dtype0] PASSED [  6%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-64-64-True-dtype1] PASSED [  8%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-128-128-False-dtype0] PASSED [ 10%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-128-128-False-dtype1] PASSED [ 12%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-128-128-True-dtype0] PASSED [ 14%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-128-128-True-dtype1] PASSED [ 16%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-192-128-False-dtype0] PASSED [ 18%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-192-128-False-dtype1] PASSED [ 20%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-192-128-True-dtype0] PASSED [ 22%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mha-192-128-True-dtype1] PASSED [ 24%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-64-64-False-dtype0] PASSED [ 26%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-64-64-False-dtype1] PASSED [ 28%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-64-64-True-dtype0] PASSED [ 30%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-64-64-True-dtype1] PASSED [ 32%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-128-128-False-dtype0] PASSED [ 34%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-128-128-False-dtype1] PASSED [ 36%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-128-128-True-dtype0] PASSED [ 38%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-128-128-True-dtype1] PASSED [ 40%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-192-128-False-dtype0] PASSED [ 42%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-192-128-False-dtype1] PASSED [ 44%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-192-128-True-dtype0] PASSED [ 46%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[mqa-192-128-True-dtype1] PASSED [ 48%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-64-64-False-dtype0] PASSED [ 51%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-64-64-False-dtype1] PASSED [ 53%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-64-64-True-dtype0] PASSED [ 55%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-64-64-True-dtype1] PASSED [ 57%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-128-128-False-dtype0] PASSED [ 59%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-128-128-False-dtype1] PASSED [ 61%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-128-128-True-dtype0] PASSED [ 63%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-128-128-True-dtype1] PASSED [ 65%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-192-128-False-dtype0] PASSED [ 67%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-192-128-False-dtype1] PASSED [ 69%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-192-128-True-dtype0] PASSED [ 71%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_matches_post_quant[gqa-192-128-True-dtype1] PASSED [ 73%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_varlen_deepseek_mla PASSED [ 75%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_auto_allocate PASSED [ 77%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_scale_as_tensor PASSED [ 79%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_sliding_window[causal_local_left] PASSED [ 81%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_sliding_window[symmetric_local] PASSED [ 83%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_sliding_window[causal_full] PASSED [ 85%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_softcap[15.0] PASSED [ 87%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_softcap[30.0] PASSED [ 89%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_scale_extremes[scale_underuses_range] PASSED [ 91%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_scale_extremes[scale_matches_peak] PASSED [ 93%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_scale_extremes[scale_overuses_range] PASSED [ 95%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_split_kv PASSED      [ 97%]
cute/test_flash_attn_fp8_output.py::test_fp8_output_validation_errors PASSED [100%]

=============================== warnings summary ===============================
cute/test_flash_attn_fp8_output.py: 1117 warnings
  /root/flash-attention/.venv/lib/python3.12/site-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/_mlir_helpers/op.py:63: DeprecationWarning: `make_fragment` is deprecated, use `make_rmem_tensor` instead
    res_or_list = opFunc(*args, **kwargs, loc=loc)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 49 passed, 1117 warnings in 84.39s (0:01:24) =================
```
</details>