### PR TITLE
Fix SM103 arch check in FA4

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -139,7 +139,19 @@ class FlashAttentionForwardSm100:
         assert self.split_P_arrive % 32 == 0
         assert self.split_P_arrive < self.n_block_size
         self.arch = BaseDSL._get_dsl().get_arch_enum()
-        assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, "Only SM 10.x and 11.x are supported"
+        is_supported_arch = (
+            Arch.sm_100 <= self.arch <= Arch.sm_100f
+            or Arch.sm_103 <= self.arch <= Arch.sm_103f
+            or Arch.sm_110 <= self.arch <= Arch.sm_110f
+        )
+        # CUDA 12.9 and older use sm_101* for Thor; CUDA 13.0+
+        # renames the same target family to sm_110*.
+        if hasattr(Arch, "sm_101") and hasattr(Arch, "sm_101f"):
+            is_supported_arch = (
+                is_supported_arch
+                or Arch.sm_101 <= self.arch <= Arch.sm_101f
+            )
+        assert is_supported_arch, "Only SM 10.x and 11.x are supported"
 
         self.cta_group_size = 2 if self.use_2cta_instrs else 1
         # cta_tiler M includes only 1 CTA, the scheduler will take into account the cluster shape


### PR DESCRIPTION
FA4 currently validates SM100-family kernels with a broad CUTLASS `Arch` enum range:

```python
Arch.sm_100 <= self.arch <= Arch.sm_110f
```

This recently started failing on an NVIDIA B300 SXM6 AC system. The failure was:

```text
AssertionError: Only SM 10.x and 11.x are supported
```

The failing path was:

```text
vllm_flash_attn/cute/interface.py
-> FlashAttentionForwardSm100
-> flash_attn/cute/flash_fwd_sm100.py
```

The machine reported the expected B300 capability and CUTLASS runtime arch:

```text
device 0: NVIDIA B300 SXM6 AC capability= (10, 3)
runtime_arch: sm_103a
runtime_arch value: (10, 3, 'a')
```

But with `nvidia-cutlass-dsl==4.5.0` on CUDA 13, `sm_103a` did not fall within the old broad range:

```text
Arch.sm_100 <= Arch.sm_103a: True
Arch.sm_103a <= Arch.sm_110f: False
Arch.sm_100 <= Arch.sm_103a <= Arch.sm_110f: False
runtime in broad sm100..sm110f: False
runtime in sm103..sm103f: True
```

The same environment also showed the CUDA 12.9/13 Thor naming alias:

```text
Arch.sm_101 == Arch.sm_110: True
sm_110f value= (10, 1, 'f')
```

So the root issue is that the old check relied on cross-family CUTLASS enum ordering to mean "all supported SM10.x/11.x targets". That assumption is not stable across CUTLASS DSL/CUDA naming changes.

This patch replaces the broad range with explicit supported-family checks for:

```text
sm_100*
sm_103*
sm_110*
sm_101* when present, for CUDA 12.9 Thor naming compatibility
```

This allows B300 `sm_103a` while avoiding assumptions about enum ordering across architecture families.