### PR TITLE
Fix illegal memory access in FA2 varlen SplitKV early-exit LSE write

### DIFF
--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -542,7 +542,10 @@ inline __device__ void compute_attn_1rowblock_splitkv(const Params &params, cons
             + m_block * kBlockM * params.o_row_stride + bidh * params.o_head_stride;
         const index_t row_offset_oaccum = (((n_split_idx * params.b + bidb) * params.h + bidh) * params.seqlen_q
             + m_block * kBlockM) * params.d_rounded;
-        const index_t row_offset_lseaccum = ((n_split_idx * params.b + bidb) * params.h + bidh) * params.seqlen_q + m_block * kBlockM;
+        const index_t row_offset_lseaccum = (Split || !params.unpadded_lse
+            ? ((n_split_idx * params.b + bidb) * params.h + bidh) * params.seqlen_q
+            : bidh * params.total_q + binfo.q_offset(params.seqlen_q, 1, bidb)
+        ) + m_block * kBlockM;
         Tensor gOaccum = make_tensor(make_gmem_ptr(reinterpret_cast<ElementO *>(Split ? params.oaccum_ptr : params.o_ptr) + (Split ? row_offset_oaccum : row_offset_o)),
                                       Shape<Int<kBlockM>, Int<kHeadDim>>{},
                                      make_stride(Split ? kHeadDim : params.o_row_stride, _1{}));


### PR DESCRIPTION
## Summary

Fix the LSE write offset used by the FA2 SplitKV early-exit path when writing directly to unpadded `softmax_lse`.

Upstream varlen forward stores LSE in the packed unpadded layout by setting `params.unpadded_lse = true`. The normal epilogue path already handles this layout, but the SplitKV early-exit path still uses the padded `(batch, head, seqlen_q)` offset.

## Problem

When running a Qwen 235B model on a single node with 8x L40S GPUs after enabling DCP, execution can hang and eventually report:

`torch.AcceleratorError: CUDA error: an illegal memory access was encountered`

The issue is in the FA2 SplitKV early-exit path. It always computes `row_offset_lseaccum` with the padded SplitKV-style layout:

`((n_split_idx * b + bidb) * h + bidh) * seqlen_q + m_block * kBlockM`

That layout is correct for SplitKV/LSE accumulation buffers, but not for direct unpadded LSE output in varlen mode.

For varlen forward, `softmax_lse` is allocated as `{num_heads, total_q}` and `params.unpadded_lse` is set to `true`. In this case, the early-exit path must use the same packed varlen LSE layout as the normal epilogue path.

## Fix

Use the packed varlen LSE offset when writing directly to unpadded `softmax_lse`:

`bidh * params.total_q + binfo.q_offset(params.seqlen_q, 1, bidb) + m_block * kBlockM`

Keep the existing padded offset for SplitKV accumulation buffers and padded LSE output.

## Testing

Not run locally.