### PR TITLE
Fix split-KV double-counting for bidirectional `dynamic_causal` sequences (SM90)

### DIFF
--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -1117,7 +1117,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     else FastDivmodDivisor(seqlen.seqlen_k),
                 )
 
-            psc = self._mDynamicCausal[batch_idx] if const_expr(self._mDynamicCausal is not None) else None
+            psc = (
+                self._mDynamicCausal[batch_idx]
+                if const_expr(self._mDynamicCausal is not None)
+                else None
+            )
             mask = AttentionMaskCls(seqlen, dynamic_causal=psc)
             mask_fn = partial(
                 mask.apply_mask,

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -802,7 +802,19 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     if const_expr(self._mDynamicCausal is not None):
                         psc_producer = self._mDynamicCausal[batch_idx]
                         if not psc_producer:
-                            n_block_max = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
+                            # Mirror the consumer's bidirectional split range so the
+                            # producer loads exactly the K/V blocks the consumer
+                            # processes. Any divergence here deadlocks the pipeline.
+                            n_block_max_full = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
+                            if const_expr(self.is_split_kv):
+                                num_n_blocks_per_split = cute.ceil_div(n_block_max_full, num_splits)
+                                n_block_min = split_idx * num_n_blocks_per_split
+                                n_block_max = cutlass.min(
+                                    n_block_min + num_n_blocks_per_split, n_block_max_full
+                                )
+                            else:
+                                n_block_min = Int32(0)
+                                n_block_max = n_block_max_full
                     # Clamp n_block to 0 when n_block_max == 0 (can happen with causal
                     # + pack_gqa when seqlen_k < tile_n). TMA handles n_block=-1
                     # gracefully (fills zeros), but cp.async would crash on
@@ -1137,8 +1149,29 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 seqlen, m_block, split_idx, num_splits
             )
             if const_expr(self._mDynamicCausal is not None):
+                # Per-sequence causal: psc == 0 means this sequence is processed
+                # bidirectionally. get_n_block_min_max may have applied a causal
+                # upper bound (when the kernel is compiled causal) and, for
+                # split-KV, partitioned that (possibly causal) range. For a
+                # bidirectional sequence each split must instead own a DISJOINT
+                # slice of the FULL key range. Recompute [n_block_min, n_block_max)
+                # over the full range here, and IDENTICALLY on the producer side
+                # (see the K/V load loop), so the pipeline block counts agree -- a
+                # producer/consumer mismatch deadlocks the kernel (GPU spins).
+                # The previous code only reset n_block_max to the global max while
+                # leaving n_block_min at its split offset, so splits overlapped and
+                # keys were double-counted -> corrupted softmax (rel_err ~0.33).
                 if not psc:
-                    n_block_max = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
+                    n_block_max_full = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
+                    if const_expr(self.is_split_kv):
+                        num_n_blocks_per_split = cute.ceil_div(n_block_max_full, num_splits)
+                        n_block_min = split_idx * num_n_blocks_per_split
+                        n_block_max = cutlass.min(
+                            n_block_min + num_n_blocks_per_split, n_block_max_full
+                        )
+                    else:
+                        n_block_min = Int32(0)
+                        n_block_max = n_block_max_full
             n_block_max_orig = n_block_max
             pipeline_q.consumer_wait_w_index_phase(0, q_consumer_phase)
             # For performance reason, we separate out two kinds of iterations:

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -281,8 +281,7 @@ class AttentionMask:
                         col_limit_right = row_idx + causal_row_offset
                         if const_expr(self.dynamic_causal is not None):
                             col_limit_right = (
-                                col_limit_right if self.dynamic_causal
-                                else seqlenk_col_limit
+                                col_limit_right if self.dynamic_causal else seqlenk_col_limit
                             )
                         if const_expr(mask_seqlen):
                             col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)

--- a/tests/cute/test_flash_attn_dynamic_causal.py
+++ b/tests/cute/test_flash_attn_dynamic_causal.py
@@ -1,0 +1,147 @@
+"""Regression tests for per-sequence ``dynamic_causal`` masking on SM90.
+
+These cover the split-KV bug fixed in ``flash_fwd_sm90.py``: for a
+*bidirectional* sequence (``psc == 0``) with split-KV active (``num_splits > 1``)
+and ``seqlen_q < seqlen_k`` the forward kernel used to
+
+  * leave ``n_block_min`` at its (possibly causal) split offset while only
+    resetting ``n_block_max`` to the global max, so the splits overlapped and
+    keys were double-counted -> corrupted softmax (relative error ~0.33), and
+  * compute different block ranges on the producer (K/V load) and consumer
+    sides, so the pipeline block counts disagreed and the kernel deadlocked
+    (the GPU spun indefinitely; observed during CUDA-graph capture).
+
+The fix recomputes ``[n_block_min, n_block_max)`` over the *full* key range and
+partitions it into disjoint per-split slices identically on both sides, gated
+only on ``dynamic_causal is not None`` (NOT on the kernel's ``causal`` compile
+flag -- vLLM compiles the kernel with ``causal=False`` and passes a
+``dynamic_causal`` tensor, which is exactly the path that used to hang).
+
+A regression here may hang rather than fail; rely on the CI per-test timeout.
+"""
+import pytest
+import torch
+
+from flash_attn.cute.interface import _flash_attn_fwd
+
+DEV = "cuda"
+DT = torch.bfloat16
+PAGE = 16
+
+
+def _is_sm90() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major == 9
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_sm90(), reason="dynamic_causal split-KV fix is SM90-specific"
+)
+
+
+def _rep(t, hq):
+    """Repeat KV heads to match the number of query heads (GQA/MQA)."""
+    return t.repeat_interleave(hq // t.shape[1], 1)
+
+
+def _ref_bidirectional(q, k, v, scale):
+    sq, hq, d = q.shape
+    qf = q.float().transpose(0, 1)
+    kf = _rep(k.float(), hq).transpose(0, 1)
+    vf = _rep(v.float(), hq).transpose(0, 1)
+    p = (torch.matmul(qf, kf.transpose(-1, -2)) * scale).softmax(-1)
+    return torch.matmul(p, vf).transpose(0, 1).to(DT)
+
+
+def _ref_causal(q, k, v, scale):
+    """Bottom-right aligned causal reference (query i attends to keys <= i + (Sk - Sq))."""
+    sq, hq, d = q.shape
+    sk = k.shape[0]
+    qf = q.float().transpose(0, 1)
+    kf = _rep(k.float(), hq).transpose(0, 1)
+    vf = _rep(v.float(), hq).transpose(0, 1)
+    s = torch.matmul(qf, kf.transpose(-1, -2)) * scale
+    qi = torch.arange(sq, device=DEV).view(1, sq, 1)
+    ki = torch.arange(sk, device=DEV).view(1, 1, sk)
+    s = s.masked_fill(ki > (qi + (sk - sq)), float("-inf"))
+    p = s.softmax(-1)
+    return torch.matmul(p, vf).transpose(0, 1).to(DT)
+
+
+def _run_fa(q, k, v, scale, sk, psc, num_splits, causal):
+    """Single-sequence paged forward through the low-level cute entrypoint."""
+    sq, hq, d = q.shape
+    hkv = k.shape[1]
+    num_blocks = (sk + PAGE - 1) // PAGE
+    # block 0 left unused so block_table indices start at 1 (mirrors vLLM layout)
+    kc = torch.zeros(num_blocks + 1, PAGE, hkv, d, device=DEV, dtype=DT)
+    vc = torch.zeros(num_blocks + 1, PAGE, hkv, d, device=DEV, dtype=DT)
+    for t in range(sk):
+        kc[1 + t // PAGE, t % PAGE] = k[t]
+        vc[1 + t // PAGE, t % PAGE] = v[t]
+    cu_q = torch.tensor([0, sq], device=DEV, dtype=torch.int32)
+    seqused_k = torch.tensor([sk], device=DEV, dtype=torch.int32)
+    block_table = torch.arange(1, 1 + num_blocks, device=DEV, dtype=torch.int32).reshape(1, -1)
+    dynamic_causal = torch.tensor([psc], device=DEV, dtype=torch.int32)
+    out, _ = _flash_attn_fwd(
+        q, kc, vc,
+        cu_seqlens_q=cu_q,
+        seqused_k=seqused_k,
+        max_seqlen_q=sq,
+        max_seqlen_k=sk,
+        page_table=block_table,
+        softmax_scale=scale,
+        causal=causal,
+        dynamic_causal=dynamic_causal,
+        num_splits=num_splits,
+        return_lse=True,
+    )
+    return out.reshape(sq, hq, d)
+
+
+def _rel_err(out, ref):
+    return ((out.float() - ref.float()).norm() / ref.float().norm()).item()
+
+
+# Sq < Sk is the regression-triggering shape; include num_splits > 1 for split-KV.
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(256, 512), (256, 2048), (128, 1024), (1, 512)])
+@pytest.mark.parametrize("num_splits", [1, 2, 4])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("causal_compile", [False, True])
+def test_dynamic_causal_bidirectional_splitkv(
+    seqlen_q, seqlen_k, num_splits, head_dim, causal_compile
+):
+    """psc == 0 must match a full bidirectional reference for any num_splits,
+    regardless of the kernel's causal compile flag (causal_compile=False is the
+    path vLLM uses and that previously deadlocked under split-KV)."""
+    torch.manual_seed(0)
+    q = torch.randn(seqlen_q, 16, head_dim, device=DEV, dtype=DT)
+    k = torch.randn(seqlen_k, 2, head_dim, device=DEV, dtype=DT)
+    v = torch.randn(seqlen_k, 2, head_dim, device=DEV, dtype=DT)
+    scale = head_dim ** -0.5
+
+    out = _run_fa(q, k, v, scale, seqlen_k, psc=0, num_splits=num_splits, causal=causal_compile)
+    torch.cuda.synchronize()
+    err = _rel_err(out, _ref_bidirectional(q, k, v, scale))
+    assert err < 2e-2, f"bidirectional psc=0 rel_err={err:.3e} (split double-counting regression)"
+
+
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(256, 512), (256, 2048), (128, 1024)])
+@pytest.mark.parametrize("num_splits", [1, 2, 4])
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_dynamic_causal_causal_splitkv(seqlen_q, seqlen_k, num_splits, head_dim):
+    """psc != 0 with the kernel compiled causal must match a bottom-right causal
+    reference and stay consistent across split counts (no regression on the
+    causal path from the bidirectional fix)."""
+    torch.manual_seed(0)
+    q = torch.randn(seqlen_q, 16, head_dim, device=DEV, dtype=DT)
+    k = torch.randn(seqlen_k, 2, head_dim, device=DEV, dtype=DT)
+    v = torch.randn(seqlen_k, 2, head_dim, device=DEV, dtype=DT)
+    scale = head_dim ** -0.5
+
+    out = _run_fa(q, k, v, scale, seqlen_k, psc=1, num_splits=num_splits, causal=True)
+    torch.cuda.synchronize()
+    err = _rel_err(out, _ref_causal(q, k, v, scale))
+    assert err < 2e-2, f"causal psc=1 rel_err={err:.3e}"


### PR DESCRIPTION
### Summary

This builds on the `dynamic_causal` per-sequence masking patch and fixes the SM90
forward kernel for the **bidirectional** case (`psc == 0`) when **split-KV** is
active (`num_splits > 1`).

In the bidirectional branch, the original code reset only `n_block_max` to the
global key max but left `n_block_min` at the split offset that
`get_n_block_min_max` had computed over the (possibly causal) range. As a result the
splits overlapped instead of partitioning the key range, so keys were counted in more
than one split and the combined softmax was corrupted (observed relative error ~0.33
vs a bidirectional reference). The case is only correct when `num_splits == 1`.

The fix recomputes `[n_block_min, n_block_max)` over the **full** key range for
bidirectional sequences, and — when split-KV is enabled — partitions that full range
into **disjoint** per-split slices using the *same* formula on both the producer and
consumer sides, so the per-split block ranges agree. The logic is gated only on
`dynamic_causal is not None`, independent of the kernel's `causal` compile flag.

### Changes

`flash_attn/cute/flash_fwd_sm90.py` — apply the same split-aware full-range logic at
both sites that handle `psc == 0`:

- consumer block-range computation, and
- producer (K/V load) block-range computation.

~~~python
if not psc:
    n_block_max_full = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
    if const_expr(self.is_split_kv):
        num_n_blocks_per_split = cute.ceil_div(n_block_max_full, num_splits)
        n_block_min = split_idx * num_n_blocks_per_split
        n_block_max = cutlass.min(
            n_block_min + num_n_blocks_per_split, n_block_max_full
        )
    else:
        n_block_min = Int32(0)
        n_block_max = n_block_max_full
~~~

### Tests

Adds `tests/cute/test_flash_attn_dynamic_causal.py`, a regression suite for
per-sequence `dynamic_causal` masking on SM90 (no prior coverage existed):

- `test_dynamic_causal_bidirectional_splitkv` — `psc == 0` must match a full
  bidirectional reference, parametrized over `seqlen_q < seqlen_k` shapes,
  `num_splits ∈ {1, 2, 4}`, `head_dim ∈ {128, 256}`, and both `causal`-compile
  flags. This is the configuration the fix targets.
- `test_dynamic_causal_causal_splitkv` — `psc != 0` with the kernel compiled causal
  must match a bottom-right causal reference across split counts, guarding the causal
  path against regressions from the bidirectional fix.

Against the pre-fix kernel, every bidirectional `num_splits > 1` case fails the
accuracy assertion (rel err ~0.33), while `num_splits == 1` and the causal path pass.
With the fix, all cases pass (rel err ~2e-3).

### Validation

- New tests above: all parametrizations pass with the fix; the split-KV bidirectional
  cases fail on the unpatched kernel, confirming the regression is caught.
- Bidirectional (`psc == 0`) split-KV output matches a full-attention reference and is
  consistent across `num_splits = 1` and `num_splits > 1`; the causal (`psc != 0`)
  path is unaffected.
