### PR TITLE
Fully yank dropout in vllm fork of FA2

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -6,8 +6,10 @@
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::Generator and at::PhiloxCudaState
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::PhiloxCudaState / at::CUDAGeneratorImpl (default-generator dropout path)
 #include "philox_unpack.cuh"  // For at::cuda::philox::unpack
+#endif
 
 #include <cutlass/numeric_types.h>
 
@@ -21,6 +23,16 @@
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 
 namespace FLASH_NAMESPACE {
+
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+// Flash_fwd_params keeps philox state as an opaque uint64_t buffer (see flash.h) so the
+// shared header avoids ATen Generator types. Validate the buffer against the real
+// at::PhiloxCudaState layout here, where the type is actually visible.
+static_assert(sizeof(at::PhiloxCudaState) <= sizeof(Flash_fwd_params::philox_args),
+              "Flash_fwd_params::philox_args buffer is too small for at::PhiloxCudaState");
+static_assert(alignof(at::PhiloxCudaState) <= alignof(decltype(Flash_fwd_params::philox_args)),
+              "Flash_fwd_params::philox_args buffer is under-aligned for at::PhiloxCudaState");
+#endif
 
 void set_params_fprop(Flash_fwd_params &params,
                       // sizes
@@ -358,8 +370,7 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
         int window_size_left,
         int window_size_right,
         const float softcap,
-        const bool return_softmax,
-        std::optional<at::Generator> gen_) {
+        const bool return_softmax) {
 
     // Otherwise the kernel will be launched from cuda:0 device
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -485,11 +496,10 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
     // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -533,8 +543,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
                int window_size_right,
                const float softcap,
                const bool return_softmax,
-               int num_splits,
-               std::optional<at::Generator> gen_) {
+               int num_splits) {
 
     // Otherwise the kernel will be launched from cuda:0 device
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -731,14 +740,13 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     // auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
     // auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // // Forward kernel will populate memory with the seed and offset.
-    // params.rng_state = reinterpret_cast<uinpft64_t*>(rng_state.data_ptr());
+    // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -818,7 +826,6 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         int window_size_right,
         const float softcap,
         const bool deterministic,
-        std::optional<at::Generator> gen_,
         std::optional<at::Tensor> &rng_state) {
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
@@ -833,7 +840,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
     bool is_sm8x_min = cc_major >= 8;
     TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    bool is_dropout = p_dropout > 0.0;
+    [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     auto q_dtype = q.dtype();
@@ -969,21 +976,20 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
 
     auto launch = &run_mha_bwd;
 
-    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-        gen_, at::cuda::detail::getDefaultCUDAGenerator());
-
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
-
     if ( rng_state.has_value() ) {
         params.rng_state = reinterpret_cast<uint64_t*>(rng_state.value().data_ptr());
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     } else if( is_dropout ) {
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
+#endif
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -1029,7 +1035,6 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
                int window_size_right,
                const float softcap,
                const bool deterministic,
-               std::optional<at::Generator> gen_,
                std::optional<at::Tensor> &rng_state) {
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
@@ -1044,7 +1049,7 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     bool is_sm8x_min = cc_major >= 8;
     TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    bool is_dropout = p_dropout > 0.0;
+    [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     auto q_dtype = q.dtype();
@@ -1198,21 +1203,20 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
 
     auto launch = &run_mha_bwd;
 
-    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-        gen_, at::cuda::detail::getDefaultCUDAGenerator());
-
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
-
     if ( rng_state.has_value() ) {
         params.rng_state = reinterpret_cast<uint64_t*>(rng_state.value().data_ptr());
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     } else if( is_dropout ) {
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
+#endif
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -6,8 +6,11 @@
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::Generator and at::PhiloxCudaState
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::PhiloxCudaState / at::CUDAGeneratorImpl (default-generator dropout path)
 #include "philox_unpack.cuh"  // For at::cuda::philox::unpack
+#include <type_traits>  // For std::is_trivially_copyable (philox_args buffer assert below)
+#endif
 
 #include <cutlass/numeric_types.h>
 
@@ -21,6 +24,21 @@
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 
 namespace FLASH_NAMESPACE {
+
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+// Flash_fwd_params keeps philox state as an opaque uint64_t buffer (see flash.h) so the
+// shared header avoids ATen Generator types. Validate the buffer against the real
+// at::PhiloxCudaState layout here, where the type is actually visible.
+static_assert(sizeof(at::PhiloxCudaState) <= sizeof(Flash_fwd_params::philox_args),
+              "Flash_fwd_params::philox_args buffer is too small for at::PhiloxCudaState");
+static_assert(alignof(at::PhiloxCudaState) <= alignof(decltype(Flash_fwd_params::philox_args)),
+              "Flash_fwd_params::philox_args buffer is under-aligned for at::PhiloxCudaState");
+static_assert(std::is_trivially_copyable<at::PhiloxCudaState>::value,
+              "at::PhiloxCudaState must be trivially copyable: it is placement-new'd into "
+              "philox_args and the whole Flash_fwd_params is copied by value to the device kernel "
+              "(so the bytes must be memcpy-safe); this also guarantees a trivial destructor, so "
+              "the placement-new needs no matching delete");
+#endif
 
 void set_params_fprop(Flash_fwd_params &params,
                       // sizes
@@ -359,7 +377,12 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
         int window_size_right,
         const float softcap,
         const bool return_softmax,
-        std::optional<at::Generator> gen_) {
+        // Retained only for backwards-compat arg positioning; must be None.
+        std::optional<at::Tensor> unused_generator_compat) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     // Otherwise the kernel will be launched from cuda:0 device
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -485,11 +508,10 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
     // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -534,7 +556,12 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
                const float softcap,
                const bool return_softmax,
                int num_splits,
-               std::optional<at::Generator> gen_) {
+               // Retained only for backwards-compat arg positioning; must be None.
+               std::optional<at::Tensor> unused_generator_compat) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     // Otherwise the kernel will be launched from cuda:0 device
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -731,14 +758,13 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     // auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
     // auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // // Forward kernel will populate memory with the seed and offset.
-    // params.rng_state = reinterpret_cast<uinpft64_t*>(rng_state.data_ptr());
+    // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -818,8 +844,13 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         int window_size_right,
         const float softcap,
         const bool deterministic,
-        std::optional<at::Generator> gen_,
+        // Retained only for backwards-compat arg positioning; must be None.
+        std::optional<at::Tensor> unused_generator_compat,
         std::optional<at::Tensor> &rng_state) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
         TORCH_CHECK(false, "This flash attention build does not support backward.");
@@ -833,7 +864,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
     bool is_sm8x_min = cc_major >= 8;
     TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    bool is_dropout = p_dropout > 0.0;
+    [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     auto q_dtype = q.dtype();
@@ -969,21 +1000,20 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
 
     auto launch = &run_mha_bwd;
 
-    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-        gen_, at::cuda::detail::getDefaultCUDAGenerator());
-
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
-
     if ( rng_state.has_value() ) {
         params.rng_state = reinterpret_cast<uint64_t*>(rng_state.value().data_ptr());
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     } else if( is_dropout ) {
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
+#endif
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -1029,8 +1059,13 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
                int window_size_right,
                const float softcap,
                const bool deterministic,
-               std::optional<at::Generator> gen_,
+               // Retained only for backwards-compat arg positioning; must be None.
+               std::optional<at::Tensor> unused_generator_compat,
                std::optional<at::Tensor> &rng_state) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
         TORCH_CHECK(false, "This flash attention build does not support backward.");
@@ -1044,7 +1079,7 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     bool is_sm8x_min = cc_major >= 8;
     TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    bool is_dropout = p_dropout > 0.0;
+    [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     auto q_dtype = q.dtype();
@@ -1198,21 +1233,20 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
 
     auto launch = &run_mha_bwd;
 
-    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-        gen_, at::cuda::detail::getDefaultCUDAGenerator());
-
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
-
     if ( rng_state.has_value() ) {
         params.rng_state = reinterpret_cast<uint64_t*>(rng_state.value().data_ptr());
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     } else if( is_dropout ) {
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
+#endif
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);

--- a/csrc/flash_attn/flash_api_sparse.cpp
+++ b/csrc/flash_attn/flash_api_sparse.cpp
@@ -2,8 +2,10 @@
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::Generator and at::PhiloxCudaState
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::PhiloxCudaState / at::CUDAGeneratorImpl (default-generator dropout path)
 #include "philox_unpack.cuh"  // For at::cuda::philox::unpack
+#endif
 
 #include <cutlass/numeric_types.h>
 
@@ -159,8 +161,7 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
                const double softmax_scale,
                bool is_causal,
                const double softcap,
-               const bool return_softmax,
-               std::optional<at::Generator> gen_) {
+               const bool return_softmax) {
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
@@ -289,11 +290,10 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
     // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     // for alibi_slopes_ cast away constness that was added for torch library
@@ -341,8 +341,7 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
                       const bool zero_tensors,
                       bool is_causal,
                       const double softcap,
-                      const bool return_softmax,
-                      std::optional<at::Generator> gen_) {
+                      const bool return_softmax) {
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
@@ -496,11 +495,10 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
     // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     // for alibi_slopes_ cast away constness that was added for torch library

--- a/csrc/flash_attn/flash_api_sparse.cpp
+++ b/csrc/flash_attn/flash_api_sparse.cpp
@@ -2,8 +2,10 @@
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::Generator and at::PhiloxCudaState
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::PhiloxCudaState / at::CUDAGeneratorImpl (default-generator dropout path)
 #include "philox_unpack.cuh"  // For at::cuda::philox::unpack
+#endif
 
 #include <cutlass/numeric_types.h>
 
@@ -160,7 +162,12 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
                bool is_causal,
                const double softcap,
                const bool return_softmax,
-               std::optional<at::Generator> gen_) {
+               // Retained only for backwards-compat arg positioning; must be None.
+               std::optional<at::Tensor> unused_generator_compat) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
@@ -289,11 +296,10 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
     // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     // for alibi_slopes_ cast away constness that was added for torch library
@@ -342,7 +348,12 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
                       bool is_causal,
                       const double softcap,
                       const bool return_softmax,
-                      std::optional<at::Generator> gen_) {
+                      // Retained only for backwards-compat arg positioning; must be None.
+                      std::optional<at::Tensor> unused_generator_compat) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
@@ -496,11 +507,10 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
     // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
+    //     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
+    //     std::lock_guard<std::mutex> lock(gen.mutex());
+    //     new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     // }
 
     // for alibi_slopes_ cast away constness that was added for torch library

--- a/csrc/flash_attn/flash_api_torch_lib.cpp
+++ b/csrc/flash_attn/flash_api_torch_lib.cpp
@@ -35,8 +35,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
                int window_size_right,
                const float softcap,
                const bool return_softmax,
-               int num_splits,
-               std::optional<at::Generator> gen_);
+               int num_splits);
 
 std::vector<at::Tensor>
 mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_heads x head_size
@@ -76,8 +75,7 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
                const double softmax_scale,
                bool is_causal,
                const double softcap,
-               const bool return_softmax,
-               std::optional<at::Generator> gen_);
+               const bool return_softmax);
 
 std::vector<at::Tensor>
 mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
@@ -99,8 +97,7 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
                       const bool zero_tensors,
                       bool is_causal,
                       const double softcap,
-                      const bool return_softmax,
-                      std::optional<at::Generator> gen_);
+                      const bool return_softmax);
 
 /**
  *  Torch Library Registration
@@ -110,7 +107,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor cu_seqlens_k, Tensor? seqused_k, Tensor? leftpad_k, Tensor? block_table, Tensor? alibi_slopes, "
             "int max_seqlen_q, int max_seqlen_k, float p_dropout, float softmax_scale, bool zero_tensors, "
             "bool is_causal, int window_size_left, int window_size_right, float softcap, bool return_softmax, "
-            "int num_splits, Generator? gen) -> Tensor[]");
+            "int num_splits) -> Tensor[]");
     ops.impl("varlen_fwd", torch::kCUDA, make_pytorch_shim(&mha_varlen_fwd));
 
     ops.def("fwd_kvcache(Tensor! q, Tensor kcache, Tensor vcache, Tensor? k, Tensor? v, Tensor? seqlens_k, "
@@ -123,7 +120,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor block_count, Tensor block_offset, Tensor column_count, Tensor column_index, "
             "Tensor!? out, Tensor? alibi_slopes, "
             "float p_dropout, float softmax_scale, bool is_causal, "
-            "float softcap, bool return_softmax, Generator? gen)"
+            "float softcap, bool return_softmax)"
             "-> Tensor[]");
     ops.impl("fwd_sparse", torch::kCUDA, &mha_fwd_sparse);
 
@@ -132,8 +129,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor!? out, Tensor cu_seqlens_q, "
             "Tensor cu_seqlens_k, Tensor? seqused_k, Tensor? alibi_slopes, "
             "int max_seqlen_q, int max_seqlen_k, float p_dropout, float softmax_scale, bool zero_tensors, "
-            "bool is_causal, float softcap, bool return_softmax, "
-            "Generator? gen) -> Tensor[]");
+            "bool is_causal, float softcap, bool return_softmax) -> Tensor[]");
     ops.impl("varlen_fwd_sparse", torch::kCUDA, &mha_varlen_fwd_sparse);
 }
 

--- a/csrc/flash_attn/flash_api_torch_lib.cpp
+++ b/csrc/flash_attn/flash_api_torch_lib.cpp
@@ -36,7 +36,8 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
                const float softcap,
                const bool return_softmax,
                int num_splits,
-               std::optional<at::Generator> gen_);
+               // Retained only for backwards-compat arg positioning; must be None.
+               std::optional<at::Tensor> unused_generator_compat);
 
 std::vector<at::Tensor>
 mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_heads x head_size
@@ -77,7 +78,8 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
                bool is_causal,
                const double softcap,
                const bool return_softmax,
-               std::optional<at::Generator> gen_);
+               // Retained only for backwards-compat arg positioning; must be None.
+               std::optional<at::Tensor> unused_generator_compat);
 
 std::vector<at::Tensor>
 mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
@@ -100,7 +102,8 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
                       bool is_causal,
                       const double softcap,
                       const bool return_softmax,
-                      std::optional<at::Generator> gen_);
+                      // Retained only for backwards-compat arg positioning; must be None.
+                      std::optional<at::Tensor> unused_generator_compat);
 
 /**
  *  Torch Library Registration
@@ -110,7 +113,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor cu_seqlens_k, Tensor? seqused_k, Tensor? leftpad_k, Tensor? block_table, Tensor? alibi_slopes, "
             "int max_seqlen_q, int max_seqlen_k, float p_dropout, float softmax_scale, bool zero_tensors, "
             "bool is_causal, int window_size_left, int window_size_right, float softcap, bool return_softmax, "
-            "int num_splits, Generator? gen) -> Tensor[]");
+            "int num_splits, Tensor? gen) -> Tensor[]");
     ops.impl("varlen_fwd", torch::kCUDA, make_pytorch_shim(&mha_varlen_fwd));
 
     ops.def("fwd_kvcache(Tensor! q, Tensor kcache, Tensor vcache, Tensor? k, Tensor? v, Tensor? seqlens_k, "
@@ -123,7 +126,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor block_count, Tensor block_offset, Tensor column_count, Tensor column_index, "
             "Tensor!? out, Tensor? alibi_slopes, "
             "float p_dropout, float softmax_scale, bool is_causal, "
-            "float softcap, bool return_softmax, Generator? gen)"
+            "float softcap, bool return_softmax, Tensor? gen)"
             "-> Tensor[]");
     ops.impl("fwd_sparse", torch::kCUDA, &mha_fwd_sparse);
 
@@ -132,8 +135,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor!? out, Tensor cu_seqlens_q, "
             "Tensor cu_seqlens_k, Tensor? seqused_k, Tensor? alibi_slopes, "
             "int max_seqlen_q, int max_seqlen_k, float p_dropout, float softmax_scale, bool zero_tensors, "
-            "bool is_causal, float softcap, bool return_softmax, "
-            "Generator? gen) -> Tensor[]");
+            "bool is_causal, float softcap, bool return_softmax, Tensor? gen) -> Tensor[]");
     ops.impl("varlen_fwd_sparse", torch::kCUDA, &mha_varlen_fwd_sparse);
 }
 

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -7,9 +7,8 @@
 #include "namespace_config.h"
 
 #include <cuda.h>
+#include <cstdint>
 #include <vector>
-
-#include <ATen/cuda/CUDAGeneratorImpl.h> // For at::Generator and at::PhiloxCudaState
 
 namespace FLASH_NAMESPACE {
 constexpr int TOTAL_DIM = 0;
@@ -118,8 +117,13 @@ struct Flash_fwd_params : public Qkv_params {
     int window_size_left, window_size_right;
     float softcap;
 
-    // Random state.
-    at::PhiloxCudaState philox_args;
+    // Random state, stored as an opaque buffer that will potentially hold at::PhiloxCudaState.
+    // We intentionally use an opaque buffer to allow the disabled dropout binary to stay
+    // free of unnecessary headers like <ATen/cuda/CUDAGeneratorImpl.h>.
+    // flash_api.cpp will write into this buffer via placement-new of an at::PhiloxCudaState
+    // (guarded by FLASHATTENTION_DISABLE_DROPOUT) and the forward kernel (in flash_fwd_kernel.h)
+    // will read it back via reinterpret_cast. Size validated by static_assert in flash_api.cpp.
+    uint64_t philox_args[4];
 
     // Pointer to the RNG seed (idx 0) and offset (idx 1).
     uint64_t * rng_state;

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include "namespace_config.h"
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
 #include "philox_unpack.cuh" // For at::cuda::philox::unpack
+#endif
 
+#include <tuple>
 #include <cute/tensor.hpp>
 
 #include <cutlass/cutlass.h>
@@ -66,7 +69,11 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     constexpr int kHeadDim = Kernel_traits::kHeadDim;
     constexpr int kNWarps = Kernel_traits::kNWarps;
 
-    auto seed_offset = at::cuda::philox::unpack(params.philox_args);
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+    auto seed_offset = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
+#else
+    auto seed_offset = std::make_tuple(uint64_t(0), uint64_t(0));
+#endif
     FLASH_NAMESPACE::Dropout dropout(std::get<0>(seed_offset), std::get<1>(seed_offset), params.p_dropout_in_uint8_t,
                            bidb, bidh, tidx, params.h);
 

--- a/csrc/flash_attn/src/flash_fwd_sparse_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_sparse_kernel.h
@@ -28,7 +28,11 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
     constexpr int kHeadDim = Kernel_traits::kHeadDim;
     constexpr int kNWarps = Kernel_traits::kNWarps;
 
-    auto seed_offset = at::cuda::philox::unpack(params.philox_args);
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+    auto seed_offset = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
+#else
+    auto seed_offset = std::make_tuple(uint64_t(0), uint64_t(0));
+#endif
     flash::Dropout dropout(std::get<0>(seed_offset), std::get<1>(seed_offset), params.p_dropout_in_uint8_t,
                            bidb, bidh, tidx, params.h);
 

--- a/csrc/flash_attn/src/philox_unpack.cuh
+++ b/csrc/flash_attn/src/philox_unpack.cuh
@@ -1,4 +1,5 @@
 // This is purely so that it works with torch 2.1. For torch 2.2+ we can include ATen/cuda/PhiloxUtils.cuh
 
 #pragma once
-#include <ATen/cuda/detail/UnpackRaw.cuh>
+#include <ATen/cuda/PhiloxCudaState.h>     // For at::PhiloxCudaState
+#include <ATen/cuda/detail/UnpackRaw.cuh>  // For at::cuda::philox::unpack

--- a/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm_flash_attn/flash_attn_interface.py
@@ -272,7 +272,6 @@ def flash_attn_varlen_func(
             softcap,
             return_softmax_lse and dropout_p > 0,
             num_splits,
-            None,
         )
     elif fa_version == 3:
         assert alibi_slopes is None, "Alibi is not supported in FA3"
@@ -380,7 +379,6 @@ def sparse_attn_func(
         causal,
         softcap,
         return_attn_probs and dropout_p > 0,
-        None,
     )
     return (out, softmax_lse) if return_softmax_lse else out
 
@@ -472,6 +470,5 @@ def sparse_attn_varlen_func(
         causal,
         softcap,
         return_attn_probs and dropout_p > 0,
-        None,
     )
     return (out, softmax_lse) if return_softmax_lse else out


### PR DESCRIPTION
Follows the example set in upstream https://github.com/Dao-AILab/flash-attention/pull/2669 to expand FLASHATTENTION_DISABLE_DROPOUT support. 

vLLM already defaults to using the DROPOUT free FA2 (cuz inference doesn't need dropout), and syncing with upstream means we will not compile the dropout related headers (RNG/Philox) at all. This enables us to get the vllm cuda wheel fully migrated to ABI stable by migrating FA2 to be fully ABI stable, will be be the next step!

We sync with upstream to maintain similarity as much as possible. Followup work could be done to sync the branches further (e.g., remove the commented out code as it wouldn't be used anyway), but I opted to not mess with pre-existing vLLM commits in this PR.

Test plan: 
1. Make sure this compiles from the vllm side
2. Run the relevant flash_attn tests from the vllm side https://github.com/vllm-project/vllm/pull/46640 cc @Harry-Chen