### PR TITLE
Fix compatibility with nvidia-cutlass-dsl 4.6.0

### DIFF
--- a/flash_attn/cute/cute_dsl_utils.py
+++ b/flash_attn/cute/cute_dsl_utils.py
@@ -14,6 +14,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cutlass_dsl import NumericMeta
 from cutlass.cute.runtime import from_dlpack
+from quack.compile_utils import make_fake_tensor as fake_tensor
 
 StaticTypes = (cutlass.Constexpr, NumericMeta, int, bool, str, float, type(None))
 
@@ -64,14 +65,22 @@ def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, ena
     if t is None:
         return None
     if hasattr(t, "_cute_tensor"):
-        tensor = t._cute_tensor
+        # Compile-only fake tensor. cutlass-dsl 4.6.0 removed mark_layout_dynamic()
+        # on fake tensors, so express the dynamic layout at construction instead
+        # (equivalent to from_dlpack(...).mark_layout_dynamic(leading_dim=...)).
+        cute_dtype = t._cute_tensor.element_type
+        ndim = t.ndim
         if fully_dynamic:
-            marked = tensor.mark_layout_dynamic()
-            return tensor if marked is None else marked
-        if leading_dim == -1:
-            leading_dim = t.ndim - 1
-        marked = tensor.mark_layout_dynamic(leading_dim=leading_dim)
-        return tensor if marked is None else marked
+            leading_dim = None
+        elif leading_dim == -1:
+            leading_dim = ndim - 1
+        divisibility = max(1, assumed_align * 8 // cute_dtype.width) if assumed_align else 1
+        return fake_tensor(
+            cute_dtype,
+            tuple(cute.sym_int() for _ in range(ndim)),
+            divisibility=divisibility,
+            leading_dim=leading_dim,
+        )
 
     # NOTE: torch 2.9.1 doesn't support fp8 via DLPack but 2.11.0 nightly does
     # currently export raw bytes as uint8 and tell cutlass correct type


### PR DESCRIPTION
`nvidia-cutlass-dsl` 4.6.0 removed some CuTe DSL APIs. vLLM main repository is updating cutlass wheel version https://github.com/vllm-project/vllm/pull/47442 so this change in flash-attention is needed because of some CI jobs failures in vLLM.

Align flash-attention fork accordingly:
- cute.core.ThrMma -> cute.ThrMma
- cute.make_fragment(...) -> cute.make_rmem_tensor(...)
- fmax: drop the CUDA 12.9 branch, use the new NVVM API unconditionally (mirrors Dao-AILab/flash-attention#2648)
- blackwell_helpers._tcgen05_mma_kind: accept MmaF8F6F4Op for plain FP8 (mirrors Dao-AILab/flash-attention#2640)
- to_cute_tensor: fake tensors no longer implement mark_layout_dynamic() on 4.6.0; build the dynamic layout at construction via quack make_fake_tensor (leading_dim keeps static stride 1, other strides dynamic), matching the runtime from_dlpack(...).mark_layout_dynamic(leading_dim=...) path
- pyproject/docs: bump floors to `nvidia-cutlass-dsl>=4.6.0`, `apache-tvm-ffi>=0.1.10`, `quack-kernels>=0.5.3`