### PR TITLE
[FA4] Support paged/decode compile specs in compile_flash_attn_varlen_func_from_specs

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -2435,6 +2435,7 @@ def compile_flash_attn_varlen_func_from_specs(
     v_shape: Tuple[int, ...],
     q_dtype: torch.dtype,
     v_stride: Optional[Tuple[int, ...]] = None,
+    k_stride: Optional[Tuple[int, ...]] = None,
     cu_seqlens_q_shape: Optional[Tuple[int, ...]] = None,
     cu_seqlens_k_shape: Optional[Tuple[int, ...]] = None,
     max_seqlen_q: Optional[int] = None,
@@ -2444,9 +2445,15 @@ def compile_flash_attn_varlen_func_from_specs(
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     num_splits: int = 1,
     return_lse: bool = False,
+    seqused_k_shape: Optional[Tuple[int, ...]] = None,
+    page_table_shape: Optional[Tuple[int, ...]] = None,
+    q_descale: bool = False,
+    k_descale: bool = False,
+    v_descale: bool = False,
+    softcap: Optional[float] = None,
 ):
     q = _make_compile_only_tensor_spec(q_shape, q_dtype)
-    k = _make_compile_only_tensor_spec(k_shape, q_dtype)
+    k = _make_compile_only_tensor_spec(k_shape, q_dtype, stride=k_stride)
     v = _make_compile_only_tensor_spec(v_shape, q_dtype, stride=v_stride)
     out = _make_compile_only_tensor_spec(
         (*q_shape[:-1], v_shape[-1]),
@@ -2478,16 +2485,28 @@ def compile_flash_attn_varlen_func_from_specs(
         cu_seqlens_k=_make_compile_only_tensor_spec(
             cu_seqlens_k_shape, torch.int32, 4
         ),
+        seqused_k=_make_compile_only_tensor_spec(seqused_k_shape, torch.int32, 4),
+        page_table=_make_compile_only_tensor_spec(page_table_shape, torch.int32, 4),
         max_seqlen_q=max_seqlen_q,
         max_seqlen_k=max_seqlen_k,
         softmax_scale=softmax_scale,
         causal=causal,
+        softcap=softcap,
         window_size_left=window_size[0],
         window_size_right=window_size[1],
         num_splits=num_splits,
         return_lse=return_lse,
         out=out,
         lse=lse,
+        q_descale=_make_compile_only_tensor_spec((1,), torch.float32, 4)
+        if q_descale
+        else None,
+        k_descale=_make_compile_only_tensor_spec((1,), torch.float32, 4)
+        if k_descale
+        else None,
+        v_descale=_make_compile_only_tensor_spec((1,), torch.float32, 4)
+        if v_descale
+        else None,
         compile_only=True,
     )
 


### PR DESCRIPTION
# [FA4] Support paged/decode compile specs in `compile_flash_attn_varlen_func_from_specs`

**Repo:** `vllm-project/flash-attention` · **Branch:** `fa4-dense-paged-compile-specs`

## Summary
Extend the CuTeDSL compile-only warmup helper so the **dense (non-MLA) paged**
decode/prefill specializations can be precompiled, instead of JIT-compiling during
serving. The helper previously exposed only the contiguous varlen (`cu_seqlens`) axes,
which is enough for MLA prefill but not for vLLM's standard `FLASH_ATTN` (GQA) path.

New optional parameters (all default to `None`/`False`, fully backward compatible):
- `seqused_k_shape` — paged decode uses `seqused_k` (not `cu_seqlens_k`)
- `page_table_shape` — paged KV
- `k_stride` — `key_cache` is a non-contiguous view of a `(num_blocks, 2, page_size, …)`
  cache, so its `num_blocks` stride is not the contiguous default; the compiled kernel
  bakes strides, so this must be settable
- `q_descale` / `k_descale` / `v_descale` (bool) — fp8 KV cache
- `softcap`

All of these are already parameters of `_flash_attn_fwd`; this only threads them through
the compile-only entry point.

## Why this is needed
vLLM warms FA4 kernels at startup via `compile_flash_attn_varlen_func_from_specs`. For a
standard GQA model the dense forward (`FlashAttentionForwardSm100`, `q_stage=2`, paged,
`seqused_k`) is a *different* compile key than the varlen/MLA specs this helper could
express, so it could not be precompiled and JIT-compiled on the first serving request.

## Test
- `compile_flash_attn_varlen_func_from_specs(...)` with a paged decode/prefill spec now
  compiles the exact `FlashAttentionForwardSm100` specialization vLLM serves with
  (verified by matching the `compile_key` the engine reports).
- Existing MLA-prefill callers are unaffected (new args default off).

## Note for integrators
Paired with **vllm-project/vllm#48156**, which calls these new args (dense-FA4 CuTeDSL
warmup) and bumps the flash-attn pin to this commit — see that PR for the end-to-end
performance results. Land this PR first (or together).

🤖 AI-assisted change.
