### PR TITLE
fix: derive is_varlen in get_scheduler_metadata to match mha_fwd

### DIFF
--- a/hopper/flash_api_stable.cpp
+++ b/hopper/flash_api_stable.cpp
@@ -668,7 +668,9 @@ mha_fwd_get_scheduler_metadata(
     params.page_size = page_size.has_value() ? page_size.value() : 1;
     params.page_table = !page_size.has_value() ? nullptr : reinterpret_cast<int*>(1);
 
-    bool const use_prepare_varlen = true;
+    // seqused_k is always present (required param) so does not indicate varlen
+    bool const is_varlen = is_varlen_q || is_varlen_k || seqused_q_.has_value() || leftpad_k_.has_value();
+    bool const use_prepare_varlen = is_varlen;
     params.prepare_varlen_pdl = use_prepare_varlen && params.b <= PREPARE_VARLEN_MAX_BATCHES_1CTA;
     // set to use in split heuristic
     params.num_splits_dynamic_ptr = reinterpret_cast<int*>(1);
@@ -684,8 +686,6 @@ mha_fwd_get_scheduler_metadata(
     #endif
 
     bool const use_dynamic_split = params.b <= PREPARE_VARLEN_MAX_BATCHES_1CTA && params.num_splits > 1;
-
-    bool is_varlen = true;
 
     // Otherwise the kernel will be launched from cuda:0 device
     // Cast to char to avoid compiler warning about narrowing


### PR DESCRIPTION
`get_scheduler_metadata` hardcodes `use_prepare_varlen=true` and `is_varlen=true`, but `mha_fwd` derives them from the presence of `cu_seqlens_q/k`, `seqused_q/k`, and `leftpad_k`. When called without `cu_seqlens` (e.g. DSpark speculative decoding in vLLM), the `scheduler_metadata` tensor size differs from what `mha_fwd` expects, causing:

```
scheduler_metadata dimension 0 must have size 5, got 9
```

Fix: derive `is_varlen` the same way `mha_fwd` does.

Fixes: vllm-project/vllm#48221