### PR TITLE
fix: align get_scheduler_metadata with mha_fwd in flash_api.cpp

### DIFF
--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -629,10 +629,14 @@ mha_fwd_get_scheduler_metadata(
     params.page_size = page_size.has_value() ? page_size.value() : 1;
     params.page_table = !page_size.has_value() ? nullptr : reinterpret_cast<int*>(1);
 
-    bool const use_prepare_varlen = true;
+    // Derive is_varlen the same way mha_fwd does. seqused_k is a required
+    // (non-optional) param here so it does not indicate varlen on its own.
+    bool const is_varlen = is_varlen_q || is_varlen_k || seqused_q_.has_value() || leftpad_k_.has_value();
+
+    bool const use_prepare_varlen = is_varlen;
     params.prepare_varlen_pdl = use_prepare_varlen && params.b <= PREPARE_VARLEN_MAX_BATCHES_1CTA;
-    // set to use in split heuristic
-    params.num_splits_dynamic_ptr = reinterpret_cast<int*>(1);
+    // Temporarily set num_splits_dynamic_ptr to 1 since get_num_splits checks it
+    params.num_splits_dynamic_ptr = !use_prepare_varlen ? nullptr : reinterpret_cast<int*>(1);
 
     params.pagedkv_tma = get_pagedkv_tma(params);
     params.num_splits = num_splits <= 0 ? get_num_splits(params) : num_splits;
@@ -644,9 +648,7 @@ mha_fwd_get_scheduler_metadata(
     params.pack_gqa |= params.d == params.dv;
     #endif
 
-    bool const use_dynamic_split = params.b <= PREPARE_VARLEN_MAX_BATCHES_1CTA && params.num_splits > 1;
-
-    bool is_varlen = true;
+    bool const use_dynamic_split = use_prepare_varlen && params.b <= PREPARE_VARLEN_MAX_BATCHES_1CTA && params.num_splits > 1;
 
     // Otherwise the kernel will be launched from cuda:0 device
     // Cast to char to avoid compiler warning about narrowing
@@ -655,7 +657,10 @@ mha_fwd_get_scheduler_metadata(
     auto opts = seqused_k.options();
     // This needs to be set after get_num_splits
     at::Tensor tile_count_semaphore;  // Contains the semaphore and optionally num_splits_dynamic
-    bool const scheduler_needs_semaphore = params.arch >= 90 || params.num_splits > 1;
+    // Match mha_fwd: don't use persistent scheduler if Split and not Varlen
+    bool const scheduler_needs_semaphore = params.arch >= 90
+        ? (((params.is_causal || params.is_local) && (params.num_splits == 1)) || is_varlen)
+        : ((params.is_causal && !is_varlen) || (is_varlen && params.num_splits > 1));
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
     // params.varlen_sort_batches = !params.is_local; // Use this value for Sort in scheduler template
     params.varlen_sort_batches = false;


### PR DESCRIPTION
## Summary

- `get_scheduler_metadata` in `flash_api.cpp` hardcodes `is_varlen=true`, `use_prepare_varlen=true`, and uses a simplified `scheduler_needs_semaphore` formula
- `mha_fwd` derives all three from actual tensor parameters
- This divergence causes `metadata_size` mismatches — `CHECK_SHAPE` failures or segfaults during CUDA graph replay

Aligns all parameter derivation in `get_scheduler_metadata` with `mha_fwd`:
- Derive `is_varlen` from `cu_seqlens_q/k`, `seqused_q`, `leftpad_k` presence
- Set `use_prepare_varlen = is_varlen`
- Condition `num_splits_dynamic_ptr` on `use_prepare_varlen`
- Use the full `scheduler_needs_semaphore` formula
- Guard `use_dynamic_split` with `use_prepare_varlen`

Companion to PR #161 which applies the `is_varlen` fix to `flash_api_stable.cpp`. This PR covers `flash_api.cpp` (used since PR #160 reverted #152) and additionally fixes the `scheduler_needs_semaphore` divergence.

Fixes: vllm-project/vllm#48221