### PR TITLE
feat(cute): add SM90 FP8 KV support with in-kernel dequantization

### DIFF
--- a/flash_attn/cute/cute_dsl_utils.py
+++ b/flash_attn/cute/cute_dsl_utils.py
@@ -129,11 +129,7 @@ def get_aux_tensor_metadata(aux_tensors, aux_tensor_leading_dims=None):
     return tuple(
         (
             getattr(t, "__assumed_align__", 0),
-            (
-                leading_dim
-                if leading_dim is not None
-                else getattr(t, "__leading_dim__", -1)
-            ),
+            (leading_dim if leading_dim is not None else getattr(t, "__leading_dim__", -1)),
             leading_dim is not None or hasattr(t, "__leading_dim__"),
         )
         for t, leading_dim in zip(

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -83,6 +83,10 @@ class FlashAttentionForwardBase:
             TODO: ``"kFp8Dynamic128Sym"``, ``"kFp8Dynamic64Sym"``, ``"kNvfp4Dynamic"``
         """
         self.dtype = dtype
+        # Output dtype, defaulting to the compute dtype. Subclasses may override in
+        # __call__ (e.g. SM90 fp8-KV: compute fp16 but write a bf16 O) so the epilogue
+        # casts the fp32 accumulator straight to the output tensor's dtype.
+        self.o_dtype = dtype
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
@@ -363,13 +367,13 @@ class FlashAttentionForwardBase:
         )
 
         if const_expr(not self.is_split_kv):
-            rO = cute.make_fragment_like(acc_O, self.dtype)
-            rO.store(acc_O.load().to(self.dtype))
+            rO = cute.make_fragment_like(acc_O, self.o_dtype)
+            rO.store(acc_O.load().to(self.o_dtype))
             # Make sure all threads have finished reading V
             cute.arch.barrier(
                 barrier_id=int(NamedBarrierFwd.Epilogue), number_of_threads=self.num_epilogue_threads
             )
-            smem_copy_atom_O = utils.get_smem_store_atom(self.arch.major * 10 + self.arch.minor, self.dtype)
+            smem_copy_atom_O = utils.get_smem_store_atom(self.arch.major * 10 + self.arch.minor, self.o_dtype)
             smem_thr_copy_O = cute.make_tiled_copy_C(smem_copy_atom_O, tiled_mma).get_slice(tidx)
             taccOrO = smem_thr_copy_O.retile(rO)
             taccOsO = smem_thr_copy_O.partition_D(sO)
@@ -462,7 +466,7 @@ class FlashAttentionForwardBase:
                 )
                 gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
                 tOsO = gmem_thr_copy_O.partition_S(sO)
-                tOrO = cute.make_fragment_like(tOsO, self.dtype)
+                tOrO = cute.make_fragment_like(tOsO, self.o_dtype)
                 # load acc O from smem to rmem for wider vectorization
                 cute.autovec_copy(tOsO, tOrO)
                 if const_expr(not self.pack_gqa):

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -9,7 +9,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Int32, const_expr
+from cutlass import Float32, Float16, BFloat16, Int32, const_expr
 from cutlass.cute.nvgpu import cpasync, warpgroup
 from cutlass.utils import LayoutEnum
 import cutlass.utils.hopper_helpers as sm90_utils_basic
@@ -70,7 +70,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self.buffer_align_bytes = 1024
         self.use_tma_KV = not paged_kv_non_tma
         self.is_split_kv = is_split_kv
-        # FP8-KV in-kernel dequant path (SM90: fp16 Q + (fp8-e4m3 -> fp16) paged K/V -> fp16 O).
+        # FP8-KV scale-fold path (SM90: fp16 Q + (fp8-e4m3 -> fp16) paged K/V -> fp16 O).
         self.fp8_kv_dequant = fp8_kv_dequant
         self.kv_dtype = kv_dtype if kv_dtype is not None else self.dtype
         assert self.use_tma_KV or not (self.check_hdim_oob or self.check_hdim_v_oob), (
@@ -219,7 +219,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         """Configures and launches the flash attention kernel.
 
         mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout
-        (except the fp8-KV dequant path: fp16 Q + fp8 e4m3 K/V -> fp16 O):
+        (except the fp8-KV scale-fold path: fp16 Q + fp8 e4m3 K/V -> fp16 O):
         (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
         """
         if const_expr(not self.fp8_kv_dequant):
@@ -231,16 +231,28 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 is_split_kv=self.is_split_kv,
             )
         else:
-            # FP8-KV: Q/O are fp16 but K/V are fp8, which the symmetric _check_type rejects.
-            assert mQ.element_type == self.dtype, "fp8_kv_dequant expects fp16 Q (compute dtype)"
+            # FP8-KV: K/V are fp8 (rejected by the symmetric _check_type). Q/O may each be
+            # fp16 OR bf16 -- compute is always fp16 (the single-instruction fp8->fp16 fast
+            # path). Q is narrowed bf16->fp16 in-kernel and the fp32 accumulator is cast to
+            # mO's dtype in the epilogue, so the Q/O tensor dtypes are independent of compute.
+            assert self.dtype == Float16, "fp8_kv_dequant computes in fp16"
+            assert mQ.element_type in (Float16, BFloat16), "fp8_kv_dequant expects fp16 or bf16 Q"
             if const_expr(self.is_split_kv):
                 assert mO.element_type == Float32, (
                     "fp8_kv_dequant SplitKV expects Float32 O (partial accumulator)"
                 )
             else:
-                assert mO.element_type == self.dtype, (
-                    "fp8_kv_dequant expects fp16 O (compute dtype)"
+                assert mO.element_type in (Float16, BFloat16), (
+                    "fp8_kv_dequant expects fp16 or bf16 O"
                 )
+
+        # Q input / O output dtypes (may differ from the fp16 compute dtype on the fp8-KV
+        # path). q_dtype gates the in-kernel bf16->fp16 Q narrow; o_dtype drives the
+        # epilogue cast. SplitKV writes fp32 partials via acc_O directly, so o_dtype stays
+        # the compute dtype there (the combine kernel produces the final bf16/fp16 O).
+        self.q_dtype = mQ.element_type
+        if const_expr(self.fp8_kv_dequant):
+            self.o_dtype = mO.element_type if const_expr(not self.is_split_kv) else self.dtype
 
         self.varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
 
@@ -302,11 +314,14 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self.sQ_layout, self.sK_layout, self.sV_layout, self.sO_layout = [
             sm90_utils.make_smem_layout(dtype, LayoutEnum.ROW_MAJOR, shape, stage)
             for dtype, shape, stage in [
-                (mQ.element_type, (self.tile_m, self.tile_hdim), None),
+                # sQ holds the (possibly bf16) Q tensor as TMA'd; the fp16 compute view
+                # is an in-place recast (both are 2 bytes) -- see mma().
+                (self.q_dtype, (self.tile_m, self.tile_hdim), None),
                 (sK_dtype, (self.tile_n, self.tile_hdim), self.num_stages),
                 (sV_dtype, (self.tile_n, self.tile_hdimv), self.num_stages),
-                # sO layout dtype possibly different from mO dtype when using splitkv (fp32)
-                (mQ.element_type, (self.tile_m, self.tile_hdimv), None),
+                # sO uses the output dtype (o_dtype); for splitkv o_dtype == compute dtype
+                # (the fp32 partials are written from acc_O directly, not via sO).
+                (self.o_dtype, (self.tile_m, self.tile_hdimv), None),
             ]
         ]
         # fp8 staging tile: ONE shared buffer (tile_hdim == tile_hdimv so it serves K and V). 
@@ -625,7 +640,19 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         # ///////////////////////////////////////////////////////////////////////////////
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
-        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        # sQ is the input-dtype (q_dtype) view of the storage: the storage MemRange is
+        # typed with the compute dtype, so the TMA'd bf16 Q must be read back as q_dtype
+        # (passing dtype here, like sO below) -- otherwise bf16 bytes get read as fp16.
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner, dtype=self.q_dtype)
+        # FP8-KV bf16 Q: fp16 compute view aliasing sQ's smem (both 2 bytes, so the
+        # element layout/swizzle is identical -- reinterpret the same storage as fp16, the
+        # same way sO reuses sQ's storage below). _narrow_q_to_compute() casts sQ bf16->fp16
+        # in place per Q tile; the QK WGMMA reads sQ_mma. When Q is already fp16, sQ_mma is sQ.
+        sQ_mma = sQ
+        if const_expr(self.fp8_kv_dequant and self.q_dtype != self.dtype):
+            sQ_mma = storage.sQ.get_tensor(
+                sQ_layout.outer, swizzle=sQ_layout.inner, dtype=self.dtype
+            )
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
         if const_expr(not self.Q_in_regs):
             sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
@@ -644,8 +671,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             sStage = storage.sStage.get_tensor(
                 sStage_layout.outer, swizzle=sStage_layout.inner
             )
-        # reuse sQ's data iterator
-        sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
+        # reuse sQ's data iterator (sO uses the output dtype, both 2 bytes so they alias)
+        sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.o_dtype)
 
         block_info = BlockInfo(
             self.tile_m,
@@ -734,6 +761,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 sVt,
                 sP,
                 sO,
+                sQ_mma,
                 learnable_sink,
                 pipeline_k,
                 pipeline_v,
@@ -751,7 +779,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 aux_data,
                 fastdiv_mods,
                 num_splits,
-                # FP8-KV dequant inputs (sV/sStage/pipeline_stage; None otherwise).
+                # FP8-KV cast inputs (sV/sStage/pipeline_stage; None otherwise).
                 sV=sV if const_expr(self.fp8_kv_dequant) else None,
                 sStage=sStage,
                 pipeline_stage=pipeline_stage,
@@ -1213,6 +1241,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         sVt: cute.Tensor,
         sP: Optional[cute.Tensor],
         sO: cute.Tensor,
+        # FP8-KV bf16 Q: fp16 compute view aliasing sQ (built in kernel() from the
+        # region-local sQ_layout). Equals sQ when Q is already fp16.
+        sQ_mma: cute.Tensor,
         learnable_sink: Optional[cute.Tensor],
         pipeline_k: pipeline.PipelineAsync,
         pipeline_v: pipeline.PipelineAsync,
@@ -1230,7 +1261,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
         num_splits: Int32 = Int32(1),
-        # FP8-KV dequant inputs (None on the non-fp8 path): sV (fp16 V write target),
+        # FP8-KV cast inputs (None on the non-fp8 path): sV (fp16 V write target),
         # sStage, pipeline_stage.
         sV: Optional[cute.Tensor] = None,
         sStage: Optional[cute.Tensor] = None,
@@ -1245,8 +1276,12 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         thr_mma_qk = tiled_mma_qk.get_slice(tidx)
         wg_mma_qk = tiled_mma_qk.get_slice(warp_group_thread_layout(warp_group_idx))
         wg_mma_pv = tiled_mma_pv.get_slice(warp_group_thread_layout(warp_group_idx))
+        # FP8-KV bf16 Q: the QK WGMMA needs fp16 operands. sQ holds the bf16 Q as TMA'd;
+        # sQ_mma is the fp16 compute view (same smem) built in kernel(). _narrow_q_to_compute()
+        # casts sQ bf16->fp16 in place per tile before the QK reads sQ_mma.
+        narrow_q = const_expr(self.fp8_kv_dequant and self.q_dtype != self.dtype)
         _, tSrQ, tSrK = sm90_utils.partition_fragment_ABC(
-            wg_mma_qk, (self.tile_m, self.tile_n, self.tile_hdim), sQ, sK
+            wg_mma_qk, (self.tile_m, self.tile_n, self.tile_hdim), sQ_mma, sK
         )
         mma_qk_fn = partial(
             sm90_utils.gemm_zero_init, tiled_mma_qk, (self.tile_m, self.tile_n), tSrQ, tSrK
@@ -1303,11 +1338,26 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 tsV=thr_copy_V.partition_D(gV),
             )
 
+        # FP8-KV bf16 Q in-place narrow partitions (256-thread cooperative copy of the
+        # full Q tile; src is the bf16 sQ, dst the fp16 compute view over the same smem).
+        q_narrow_params = None
+        if const_expr(narrow_q):
+            VEC_Q = const_expr(8)
+            tiled_copy_Q = copy_utils.tiled_copy_2d(
+                self.dtype, self.tile_hdim // VEC_Q, self.num_mma_threads, num_copy_elems=VEC_Q
+            )
+            thr_copy_Q = tiled_copy_Q.get_slice(tidx)
+            q_narrow_params = SimpleNamespace(
+                tQsrc=thr_copy_Q.partition_S(sQ),
+                tQdst=thr_copy_Q.partition_D(sQ_mma),
+            )
+
         tile_scheduler = TileSchedulerCls()
         work_tile = tile_scheduler.initial_work_tile_info()
+        num_softmax_rows = const_expr(acc_O.shape[0][0] * acc_O.shape[1])
         softmax = Softmax.create(
             softmax_scale_log2,
-            num_rows=acc_O.shape[0][0] * acc_O.shape[1],
+            num_rows=num_softmax_rows,
             softmax_scale=softmax_scale,
         )
 
@@ -1346,7 +1396,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             tOrP=tOrP,
             smem_copy_params=smem_copy_params,
             scores_scale=scores_scale,
-            softmax=softmax,
             acc_O=acc_O,
             **(dict(dequant_params=dequant_params) if const_expr(self.fp8_kv_dequant) else {}),
         )
@@ -1357,7 +1406,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             pipeline_v=pipeline_v,
             mma_pv_fn=mma_pv_fn,
             scores_scale=scores_scale,
-            softmax=softmax,
             acc_O=acc_O,
             **(dict(dequant_params=dequant_params) if const_expr(self.fp8_kv_dequant) else {}),
         )
@@ -1368,8 +1416,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
 
-            # FP8-KV per-(batch, kv_head) descales, folded into the dequant cast (fp8
-            # only): q*k scales K, v scales V; see mma_one_n_block_intrawg_overlap_fp8.
+            softmax_tile = softmax
+            softmax_scale_eff = softmax_scale
+            v_descale_tile = Float32(1.0)
+            # FP8-KV per-(batch, kv_head) descales: q*k folds into the score scale
+            # while v folds into final output normalization.
             if const_expr(self.fp8_kv_dequant):
                 head_idx_kv = (
                     head_idx // self.qhead_per_kvhead
@@ -1378,6 +1429,17 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 )
                 qk_descale, v_descale_tile = self._load_effective_descales(
                     descale_tensors, batch_idx, head_idx_kv
+                )
+                if const_expr(self.score_mod is None):
+                    softmax_scale_log2_eff = softmax_scale_log2 * qk_descale
+                    softmax_scale_eff = None
+                else:
+                    softmax_scale_log2_eff = softmax_scale_log2
+                    softmax_scale_eff = softmax_scale * qk_descale
+                softmax_tile = Softmax.create(
+                    softmax_scale_log2_eff,
+                    num_rows=num_softmax_rows,
+                    softmax_scale=softmax_scale_eff,
                 )
 
             # Recompute fastdiv_mods if necessary for varlen with aux_tensors
@@ -1423,20 +1485,17 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     batch_idx,
                     head_idx,
                     m_block,
-                    softmax_scale=softmax_scale,
+                    softmax_scale=softmax_scale_eff,
                     aux_data=aux_data,
                     fastdiv_mods=fastdiv_mods,
                 )
+            process_first_half_block_tile = partial(process_first_half_block, softmax=softmax_tile)
+            process_last_half_block_tile = partial(process_last_half_block, softmax=softmax_tile)
             mma_one_n_block = partial(
                 mma_one_n_block_all,
                 seqlen=seqlen,
-                softmax=softmax,
+                softmax=softmax_tile,
                 score_mod_fn=score_mod_fn,
-                **(
-                    dict(qk_descale=qk_descale, v_descale_tile=v_descale_tile)
-                    if const_expr(self.fp8_kv_dequant)
-                    else {}
-                ),
             )
             n_block_min, n_block_max = block_info.get_n_block_min_max(
                 seqlen, m_block, split_idx, num_splits
@@ -1467,6 +1526,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         n_block_max = n_block_max_full
             n_block_max_orig = n_block_max
             pipeline_q.consumer_wait_w_index_phase(0, q_consumer_phase)
+            # FP8-KV bf16 Q: cast the just-arrived bf16 Q tile -> fp16 in place (with a
+            # 256-thread barrier) before any QK WGMMA reads it. No-op when Q is already fp16.
+            if const_expr(narrow_q):
+                self._narrow_q_to_compute(q_narrow_params)
             # For performance reason, we separate out two kinds of iterations:
             # those that need masking on S, and those that don't.
             # We need masking on S for the very last block when K and V has length not multiple of tile_n.
@@ -1483,18 +1546,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 # ==========================================
                 # First iteration with seqlen masking
                 if const_expr(self.intra_wg_overlap):
-                    kv_consumer_state = process_first_half_block(
+                    kv_consumer_state = process_first_half_block_tile(
                         n_block=n_block_max - 1,
                         seqlen=seqlen,
                         kv_consumer_state=kv_consumer_state,
                         mask_fn=partial(mask_fn, mask_mod=self.mask_mod),
                         score_mod_fn=score_mod_fn,
                         is_first_block=True,
-                        **(
-                            dict(qk_descale=qk_descale)
-                            if const_expr(self.fp8_kv_dequant)
-                            else {}
-                        ),
                     )
                 else:
                     self.warp_scheduler_barrier_sync()
@@ -1560,14 +1618,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 pipeline_q.consumer_release_w_index(0)
                 # Last "half" iteration
                 if const_expr(self.intra_wg_overlap):
-                    kv_consumer_state = process_last_half_block(
+                    kv_consumer_state = process_last_half_block_tile(
                         kv_consumer_state=kv_consumer_state,
                         zero_init=not O_should_accumulate,
-                        **(
-                            dict(v_descale_tile=v_descale_tile)
-                            if const_expr(self.fp8_kv_dequant)
-                            else {}
-                        ),
                     )
                     O_should_accumulate = True
                 else:
@@ -1586,8 +1639,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     kv_consumer_state,
                     mma_pv_fn,
                     mma_one_n_block,
-                    process_first_half_block,
-                    process_last_half_block,
+                    process_first_half_block_tile,
+                    process_last_half_block_tile,
                     mask_fn,
                     score_mod_fn,
                     O_should_accumulate,
@@ -1605,7 +1658,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
 
                 # Handle empty case (when no blocks to process)
                 if not processed_any:
-                    softmax.reset()
+                    softmax_tile.reset()
                     acc_O.fill(0.0)
 
             q_consumer_phase ^= 1
@@ -1615,7 +1668,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 if const_expr(not self.pack_gqa):
                     sink_val = Float32(learnable_sink[head_idx])
                 else:  # Each thread might have a different sink value due to different q_head
-                    sink_val = cute.make_rmem_tensor_like(softmax.row_max, Float32)
+                    sink_val = cute.make_rmem_tensor_like(softmax_tile.row_max, Float32)
                     cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
                     tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma_qk.partition_C(cS))
                     for r in cutlass.range(cute.size(sink_val), unroll_full=True):
@@ -1630,21 +1683,21 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                             sink_val.fill(-Float32.inf)
 
             # normalize acc_O by row_sum and calculate the lse
-            row_scale = softmax.finalize(sink_val=sink_val)
-            softmax.rescale_O(acc_O, row_scale)
+            row_scale = softmax_tile.finalize(final_scale=v_descale_tile, sink_val=sink_val)
+            softmax_tile.rescale_O(acc_O, row_scale)
 
             # Override empty splits so combine kernel gives zero weight
             if const_expr(self.is_split_kv):
                 if n_block_min >= n_block_max_orig:
                     acc_O.fill(Float32(0.0))
-                    softmax.row_sum.fill(-Float32.inf)
+                    softmax_tile.row_sum.fill(-Float32.inf)
 
             # ///////////////////////////////////////////////////////////////////////////////
             # Epilogue
             # ///////////////////////////////////////////////////////////////////////////////
             self.epilogue(
                 acc_O,
-                softmax.row_sum,
+                softmax_tile.row_sum,
                 mO,
                 mLSE,
                 sO,
@@ -1720,7 +1773,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
 
     @cute.jit
     def _load_effective_descales(self, descale_tensors, batch_idx: Int32, kv_head_idx: Int32):
-        """Load effective QK and V descales, defaulting unspecified tensors to identity."""
+        """Load effective QK score and V output descales, defaulting to identity."""
         qk_descale = Float32(1.0)
         v_descale = Float32(1.0)
         if const_expr(descale_tensors is not None):
@@ -1733,13 +1786,36 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         return qk_descale, v_descale
 
     @cute.jit
-    def _dequant_tile(self, pipeline_stage, tStage, tsDst, descale, phase):
-        """Dequant one staged fp8 tile -> fp16 smem (descale folded in). """
+    def _narrow_q_to_compute(self, q_narrow_params):
+        """In-place narrow the bf16 Q tile -> fp16 compute dtype. src/dst alias the same
+        smem (both 2 bytes), so each thread reads bf16 into registers, converts, and writes
+        fp16 back. A 256-thread NarrowQ barrier publishes the fp16 Q to both MMA warpgroups
+        before the QK WGMMA. Called once per Q tile (Q is reused across all KV blocks)."""
+        # The in-place aliasing (sQ_mma reinterprets sQ's storage) is only valid when the
+        # Q-input and compute dtypes have the same width -- bf16<->fp16 are both 16-bit. A
+        # different width would make sQ_mma's elements overlap sQ's incorrectly.
+        assert self.q_dtype.width == self.dtype.width, (
+            "in-place Q narrow requires q_dtype and compute dtype of equal width"
+        )
+        qp = q_narrow_params
+        rS = cute.make_rmem_tensor_like(qp.tQsrc)
+        rD = cute.make_rmem_tensor_like(qp.tQdst)
+        cute.autovec_copy(qp.tQsrc, rS)
+        rD.store(rS.load().to(self.dtype))
+        cute.autovec_copy(rD, qp.tQdst)
+        cute.arch.fence_view_async_shared()
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.NarrowQ), number_of_threads=self.num_mma_threads
+        )
+
+    @cute.jit
+    def _cast_tile_fp8_to_f16(self, pipeline_stage, tStage, tsDst, phase):
+        """Cast one staged fp8 tile -> fp16 smem without applying a descale."""
         rS = cute.make_rmem_tensor_like(tStage)
         rD = cute.make_rmem_tensor_like(tsDst)
         pipeline_stage.consumer_wait_w_index_phase(0, phase)
         cute.autovec_copy(tStage, rS)
-        rD.store((utils.cvt_fp8_to_f16_packed(rS.load(), self.dtype) * descale).to(self.dtype))
+        rD.store(utils.cvt_fp8_to_f16_packed(rS.load(), self.dtype))
         cute.autovec_copy(rD, tsDst)
         pipeline_stage.consumer_release_w_index(0)
         cute.arch.fence_view_async_shared()
@@ -1761,13 +1837,12 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         score_mod_fn: Optional[Callable] = None,
         is_first_block: bool = False,
         dequant_params: Optional[SimpleNamespace] = None,
-        qk_descale=None,
     ):
-        """FP8-KV first-half block: cooperative 256-thread dequant of the first K tile
-        (q*k descale folded in) + DequantK barrier, then the synchronous QK."""
+        """FP8-KV first-half block: cooperative 256-thread cast of the first K tile
+        + DequantK barrier, then the synchronous QK."""
         dp = dequant_params
         nthr = const_expr(self.num_mma_threads)
-        self._dequant_tile(dp.pipeline_stage, dp.tStage_K, dp.tsK, qk_descale, Int32(0))
+        self._cast_tile_fp8_to_f16(dp.pipeline_stage, dp.tStage_K, dp.tsK, Int32(0))
         cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantK), number_of_threads=nthr)
         acc_S = mma_qk_fn(B_idx=kv_consumer_state.index, wg_wait=0)
 
@@ -1817,15 +1892,14 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         softmax: Optional[Softmax] = None,
         acc_O: Optional[cute.Tensor] = None,
         dequant_params: Optional[SimpleNamespace] = None,
-        v_descale_tile=None,
     ):
-        """FP8-KV final PV: each WG dequants its own hdimv-half of the last V tile
-        (v descale folded in) + WG-local DequantV barrier, then the synchronous PV."""
+        """FP8-KV final PV: each WG casts its own hdimv-half of the last V tile
+        + WG-local DequantV barrier, then the synchronous PV."""
         if const_expr(self.rescale_O_before_gemm):
             softmax.rescale_O(acc_O, scores_scale)
         dp = dequant_params
         nthr_wg = const_expr(self.num_threads_per_warp_group)
-        self._dequant_tile(dp.pipeline_stage, dp.tStage_V, dp.tsV, v_descale_tile, Int32(1))
+        self._cast_tile_fp8_to_f16(dp.pipeline_stage, dp.tStage_V, dp.tsV, Int32(1))
         if dp.warp_group_idx == 0:
             cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantV0), number_of_threads=nthr_wg)
         else:
@@ -1984,27 +2058,25 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mask_fn: Optional[Callable] = None,
         check_inf: cutlass.Constexpr = True,
         dequant_params: Optional[SimpleNamespace] = None,
-        qk_descale=None,
-        v_descale_tile=None,
     ):
-        # FP8-KV dequant intra-WG overlap: dequant K[n] for QK[n], then dequant
-        # V[n_prev] under the QK WGMMA for PV[n_prev]. Descales folded into
-        # the casts. Separate from the generic overlap to keep that path unchanged.
+        # FP8-KV intra-WG overlap: cast K[n] for QK[n], then cast V[n_prev]
+        # under the QK WGMMA for PV[n_prev]. Separate from the generic overlap
+        # to keep that path unchanged.
         smem_pipe_read_v = smem_pipe_read.clone()
         smem_pipe_read.advance()
         dp = dequant_params
         nthr = const_expr(self.num_mma_threads)
         nthr_wg = const_expr(self.num_threads_per_warp_group)
-        # ---- 1. dequant K[n] -> sK (cooperative 256-thread, staging phase 1) ----
-        self._dequant_tile(dp.pipeline_stage, dp.tStage_K, dp.tsK, qk_descale, Int32(1))
+        # ---- 1. cast K[n] -> sK (cooperative 256-thread, staging phase 1) ----
+        self._cast_tile_fp8_to_f16(dp.pipeline_stage, dp.tStage_K, dp.tsK, Int32(1))
         cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantK), number_of_threads=nthr)
         # ---- 2. S = Q @ K.T (async) ----
         self.warp_scheduler_barrier_sync()
         acc_S = mma_qk_fn(B_idx=smem_pipe_read.index, wg_wait=-1)
         if const_expr(self.rescale_O_before_gemm):
             softmax.rescale_O(acc_O, scores_scale)
-        # ---- 3. dequant V[n_prev] -> sV (WG-split, phase 0) WHILE QK[n] runs ----
-        self._dequant_tile(dp.pipeline_stage, dp.tStage_V, dp.tsV, v_descale_tile, Int32(0))
+        # ---- 3. cast V[n_prev] -> sV (WG-split, phase 0) WHILE QK[n] runs ----
+        self._cast_tile_fp8_to_f16(dp.pipeline_stage, dp.tStage_V, dp.tsV, Int32(0))
         if dp.warp_group_idx == 0:
             cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantV0), number_of_threads=nthr_wg)
         else:

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -324,7 +324,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 (self.o_dtype, (self.tile_m, self.tile_hdimv), None),
             ]
         ]
-        # fp8 staging tile: ONE shared buffer (tile_hdim == tile_hdimv so it serves K and V). 
+        # fp8 staging tile: ONE shared buffer (tile_hdim == tile_hdimv so it serves K and V).
         self.sStage_layout = None
         if const_expr(self.fp8_kv_dequant):
             self.sStage_layout = sm90_utils.make_smem_layout(
@@ -668,9 +668,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         # fp8 staging buffer (TMA dst, dequant src).
         sStage = None
         if const_expr(self.fp8_kv_dequant):
-            sStage = storage.sStage.get_tensor(
-                sStage_layout.outer, swizzle=sStage_layout.inner
-            )
+            sStage = storage.sStage.get_tensor(sStage_layout.outer, swizzle=sStage_layout.inner)
         # reuse sQ's data iterator (sO uses the output dtype, both 2 bytes so they alias)
         sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.o_dtype)
 
@@ -933,10 +931,22 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         if const_expr(self.fp8_kv_dequant):
             # fp8_kv_dequant path uses different load logic, separate from the non-fp8 path.
             self.load_fp8(
-                mQ, mK, mV, sQ, sStage,
-                tma_atom_Q, tma_atom_K, tma_atom_V,
-                pipeline_q, pipeline_stage, gmem_tiled_copy_Q, mPageTable,
-                block_info, SeqlenInfoCls, TileSchedulerCls, num_splits,
+                mQ,
+                mK,
+                mV,
+                sQ,
+                sStage,
+                tma_atom_Q,
+                tma_atom_K,
+                tma_atom_V,
+                pipeline_q,
+                pipeline_stage,
+                gmem_tiled_copy_Q,
+                mPageTable,
+                block_info,
+                SeqlenInfoCls,
+                TileSchedulerCls,
+                num_splits,
             )
             return
 
@@ -1308,9 +1318,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             pipeline.PipelineUserType.Consumer, self.num_stages
         )
 
-        # FP8-KV MMA WGs side dequant setup: 
-        # K: cooperative 256-thread(2 WGs) copy of the full tile; 
-        # V: each WG copies only its own hdimv-half. 
+        # FP8-KV MMA WGs side dequant setup:
+        # K: cooperative 256-thread(2 WGs) copy of the full tile;
+        # V: each WG copies only its own hdimv-half.
         dequant_params = None
         if const_expr(self.fp8_kv_dequant):
             sStage2 = sStage[None, None, 0]
@@ -1423,9 +1433,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             # while v folds into final output normalization.
             if const_expr(self.fp8_kv_dequant):
                 head_idx_kv = (
-                    head_idx // self.qhead_per_kvhead
-                    if const_expr(not self.pack_gqa)
-                    else head_idx
+                    head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
                 )
                 qk_descale, v_descale_tile = self._load_effective_descales(
                     descale_tensors, batch_idx, head_idx_kv

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -57,6 +57,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mma_pv_is_rs: bool = True,
         paged_kv_non_tma: bool = False,
         is_split_kv: bool = False,
+        kv_dtype=None,
+        fp8_kv_dequant: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -68,6 +70,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self.buffer_align_bytes = 1024
         self.use_tma_KV = not paged_kv_non_tma
         self.is_split_kv = is_split_kv
+        # FP8-KV in-kernel dequant path (SM90: fp16 Q + (fp8-e4m3 -> fp16) paged K/V -> fp16 O).
+        self.fp8_kv_dequant = fp8_kv_dequant
+        self.kv_dtype = kv_dtype if kv_dtype is not None else self.dtype
         assert self.use_tma_KV or not (self.check_hdim_oob or self.check_hdim_v_oob), (
             "Paged KV does not support irregular head dim"
         )
@@ -143,6 +148,27 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mbar_ptr_K_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
         mbar_ptr_V_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
 
+        if const_expr(self.fp8_kv_dequant):
+            # sStage: the fp8 staging buffer; its num_stages=1 TMA pipeline gates GMEM->sStage.
+            sStage_struct = cute.struct.Align[
+                cute.struct.MemRange[self.kv_dtype, cute.cosize(self.sStage_layout)],
+                self.buffer_align_bytes,
+            ]
+            mbar_ptr_Stage_struct = cute.struct.MemRange[cutlass.Int64, 1 * 2]
+
+            @cute.struct
+            class SharedStorageQKVDequant:
+                mbar_ptr_Q: mbar_ptr_Q_struct
+                mbar_ptr_K: mbar_ptr_K_struct
+                mbar_ptr_V: mbar_ptr_V_struct
+                mbar_ptr_Stage: mbar_ptr_Stage_struct
+                sV: sV_struct
+                sQ: sQ_struct
+                sK: sK_struct
+                sStage: sStage_struct
+
+            return SharedStorageQKVDequant
+
         @cute.struct
         class SharedStorageQKV:
             mbar_ptr_Q: mbar_ptr_Q_struct
@@ -184,22 +210,37 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
+        # FP8-KV: per-(batch, kv_head) f32 q/k/v descales (any may be None).
+        descale_tensors=None,
         output_scale: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
         """Configures and launches the flash attention kernel.
 
-        mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
+        mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout
+        (except the fp8-KV dequant path: fp16 Q + fp8 e4m3 K/V -> fp16 O):
         (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
         """
-        self._check_type(
-            *(
-                t.element_type if t is not None else None
-                for t in (mQ, mK, mV, mO, mLSE, mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)
-            ),
-            is_split_kv=self.is_split_kv,
-        )
+        if const_expr(not self.fp8_kv_dequant):
+            self._check_type(
+                *(
+                    t.element_type if t is not None else None
+                    for t in (mQ, mK, mV, mO, mLSE, mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)
+                ),
+                is_split_kv=self.is_split_kv,
+            )
+        else:
+            # FP8-KV: Q/O are fp16 but K/V are fp8, which the symmetric _check_type rejects.
+            assert mQ.element_type == self.dtype, "fp8_kv_dequant expects fp16 Q (compute dtype)"
+            if const_expr(self.is_split_kv):
+                assert mO.element_type == Float32, (
+                    "fp8_kv_dequant SplitKV expects Float32 O (partial accumulator)"
+                )
+            else:
+                assert mO.element_type == self.dtype, (
+                    "fp8_kv_dequant expects fp16 O (compute dtype)"
+                )
 
         self.varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
 
@@ -254,16 +295,26 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self.rescale_O_before_gemm = self.tile_hdimv > 128 and self.intra_wg_overlap
         self._setup_attributes()
         # TODO: we prob don't need most of what's in _setup_attributes
+        # Per-tensor smem dtypes. FP8-KV is the one special case: sK/sV hold the fp16
+        # dequant target (self.dtype), not mK/mV's fp8 source.
+        sK_dtype = self.dtype if const_expr(self.fp8_kv_dequant) else mK.element_type
+        sV_dtype = self.dtype if const_expr(self.fp8_kv_dequant) else mV.element_type
         self.sQ_layout, self.sK_layout, self.sV_layout, self.sO_layout = [
-            sm90_utils.make_smem_layout(mX.element_type, LayoutEnum.ROW_MAJOR, shape, stage)
-            for mX, shape, stage in [
-                (mQ, (self.tile_m, self.tile_hdim), None),
-                (mK, (self.tile_n, self.tile_hdim), self.num_stages),
-                (mV, (self.tile_n, self.tile_hdimv), self.num_stages),
+            sm90_utils.make_smem_layout(dtype, LayoutEnum.ROW_MAJOR, shape, stage)
+            for dtype, shape, stage in [
+                (mQ.element_type, (self.tile_m, self.tile_hdim), None),
+                (sK_dtype, (self.tile_n, self.tile_hdim), self.num_stages),
+                (sV_dtype, (self.tile_n, self.tile_hdimv), self.num_stages),
                 # sO layout dtype possibly different from mO dtype when using splitkv (fp32)
-                (mQ, (self.tile_m, self.tile_hdimv), None),
+                (mQ.element_type, (self.tile_m, self.tile_hdimv), None),
             ]
         ]
+        # fp8 staging tile: ONE shared buffer (tile_hdim == tile_hdimv so it serves K and V). 
+        self.sStage_layout = None
+        if const_expr(self.fp8_kv_dequant):
+            self.sStage_layout = sm90_utils.make_smem_layout(
+                self.kv_dtype, LayoutEnum.ROW_MAJOR, (self.tile_n, self.tile_hdim), 1
+            )
         self.sP_layout = None
         if const_expr(not self.mma_pv_is_rs):
             self.sP_layout = sm90_utils.make_smem_layout(
@@ -308,17 +359,26 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         tma_atom_K, tma_tensor_K = None, None
         tma_atom_V, tma_tensor_V = None, None
         if const_expr(self.use_tma_KV):
+            # FP8-KV: K and V from GMEM land in sStage for the consumer to dequant(instead of sK/sV)
+            sK_tma_box = cute.select(
+                self.sStage_layout if const_expr(self.fp8_kv_dequant) else self.sK_layout,
+                mode=[0, 1],
+            )
+            sV_tma_box = cute.select(
+                self.sStage_layout if const_expr(self.fp8_kv_dequant) else self.sV_layout,
+                mode=[0, 1],
+            )
             tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
                 gmem_tiled_copy_KV,
                 mK,
-                cute.select(self.sK_layout, mode=[0, 1]),
+                sK_tma_box,
                 (self.tile_n, self.tile_hdim),
                 1,  # No mcast for now
             )
             tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
                 gmem_tiled_copy_KV,
                 mV,
-                cute.select(self.sV_layout, mode=[0, 1]),
+                sV_tma_box,
                 (self.tile_n, self.tile_hdimv),
                 1,  # No mcast for now
             )
@@ -405,6 +465,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             self.sV_layout,
             self.sO_layout,
             self.sP_layout,
+            self.sStage_layout,
             self.gmem_tiled_copy_Q,
             self.gmem_tiled_copy_K,
             self.gmem_tiled_copy_V,
@@ -418,6 +479,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             aux_data,
             fastdiv_mods,
             output_scale,
+            descale_tensors,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -454,6 +516,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         sV_layout: cute.ComposedLayout,
         sO_layout: cute.ComposedLayout,
         sP_layout: cute.ComposedLayout | None,
+        sStage_layout: cute.ComposedLayout | None,
         gmem_tiled_copy_Q: cute.TiledCopy,
         gmem_tiled_copy_K: cute.TiledCopy,
         gmem_tiled_copy_V: cute.TiledCopy,
@@ -467,6 +530,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
         output_scale: Optional[cute.Tensor] = None,
+        descale_tensors=None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # Prefetch tma descriptor
@@ -484,6 +548,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         ThreadCooperativeGroup = partial(pipeline.CooperativeGroup, pipeline.Agent.Thread)
         tma_warp = ThreadCooperativeGroup(1)
         load_threads = ThreadCooperativeGroup(self.num_threads_per_warp_group)
+        load_warps = ThreadCooperativeGroup(self.num_threads_per_warp_group // cute.arch.WARP_SIZE)
         mma_warps = ThreadCooperativeGroup(self.num_mma_threads // cute.arch.WARP_SIZE)
         if const_expr(self.use_tma_Q):
             pipeline_q = pipeline_custom.PipelineTmaAsync.create(
@@ -505,7 +570,19 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 syncwarp_before_release=False,
             )
 
-        if const_expr(self.use_tma_KV):
+        pipeline_stage = None
+        if const_expr(self.fp8_kv_dequant):
+            pipeline_k = None
+            pipeline_v = None
+            pipeline_stage = pipeline_custom.PipelineTmaAsync.create(
+                barrier_storage=storage.mbar_ptr_Stage.data_ptr(),
+                num_stages=1,
+                producer_group=tma_warp,
+                consumer_group=mma_warps,
+                tx_count=self.tma_copy_bytes["K"],
+                defer_sync=True,
+            )
+        elif const_expr(self.use_tma_KV):
             pipeline_k = pipeline_custom.PipelineTmaAsync.create(
                 barrier_storage=storage.mbar_ptr_K.data_ptr(),
                 num_stages=self.num_stages,
@@ -561,6 +638,12 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         sP = None
         if const_expr(sP_layout is not None):
             sP = storage.sP.get_tensor(sP_layout.outer, swizzle=sP_layout.inner)
+        # fp8 staging buffer (TMA dst, dequant src).
+        sStage = None
+        if const_expr(self.fp8_kv_dequant):
+            sStage = storage.sStage.get_tensor(
+                sStage_layout.outer, swizzle=sStage_layout.inner
+            )
         # reuse sQ's data iterator
         sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
 
@@ -630,6 +713,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 SeqlenInfoCls,
                 TileSchedulerCls,
                 num_splits,
+                sStage,
+                pipeline_stage,
             )
 
         else:  # Consumer
@@ -666,7 +751,128 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 aux_data,
                 fastdiv_mods,
                 num_splits,
+                # FP8-KV dequant inputs (sV/sStage/pipeline_stage; None otherwise).
+                sV=sV if const_expr(self.fp8_kv_dequant) else None,
+                sStage=sStage,
+                pipeline_stage=pipeline_stage,
+                descale_tensors=descale_tensors,
             )
+
+    @cute.jit
+    def load_fp8(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        sQ: cute.Tensor,
+        sStage: cute.Tensor,
+        tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_K: Optional[cute.CopyAtom],
+        tma_atom_V: Optional[cute.CopyAtom],
+        pipeline_q: pipeline.PipelineAsync,
+        pipeline_stage: pipeline.PipelineAsync,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        mPageTable: Optional[cute.Tensor],
+        block_info: BlockInfo,
+        SeqlenInfoCls: Callable,
+        TileSchedulerCls: Callable,
+        num_splits: Int32 = Int32(1),
+    ):
+        """FP8-KV producer: warp 0 TMAs fp8 K/V tiles from GMEM -> the single staging buffer
+        sStage, staggered to match the consumer's intra-WG overlap."""
+        warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+        tidx, _, _ = cute.arch.thread_idx()
+        stage_full_bar = pipeline_stage.sync_object_full.get_barrier(0)
+        q_producer_phase = Int32(1)
+        # Staging producer phase (num_stages=1): toggles once per staged tile.
+        stage_producer_phase = Int32(1)
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+            head_idx_kv = (
+                head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+            )
+
+            # Q stays fp16 (no dequant)
+            load_Q = None
+            pack_gqa = None
+            if const_expr(self.use_tma_Q):
+                gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
+                load_Q, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True
+                )
+            else:
+                pack_gqa = PackGQA(
+                    self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
+                )
+
+            # Paged TMA tiles, keeping the page dimension indexable (page_idx).
+            mK_cur = mK[None, None, head_idx_kv, None]
+            mV_cur = mV[None, None, head_idx_kv, None]
+            gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (0, 0, None))
+            gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdimv), (0, 0, None))
+
+            stage_copy_K, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_K, 0, cute.make_layout(1), gK, sStage
+            )
+            stage_copy_V, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_V, 0, cute.make_layout(1), gV, sStage
+            )
+
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen, m_block, split_idx, num_splits
+            )
+
+            # ---- Prologue emit: stage K[n_block_max - 1] (warp 0 only) ----
+            if warp_idx_in_wg == 0:
+                page_idx = mPageTable[batch_idx, n_block_max - 1]
+                pipeline_stage.producer_acquire_w_index_phase(0, stage_producer_phase)
+                stage_copy_K(src_idx=page_idx, dst_idx=0, tma_bar_ptr=stage_full_bar)
+                stage_producer_phase ^= 1
+
+            # Q load (warp 0 for TMA, all 128 for pack_gqa cp.async).
+            if const_expr(self.use_tma_Q):
+                if warp_idx_in_wg == 0:
+                    pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
+                    load_Q(tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(0))
+                    q_producer_phase ^= 1
+            else:
+                pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
+                pack_gqa.load_Q(mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q)
+                cute.arch.cp_async_commit_group()
+                pipeline_q.producer_commit_w_index(0)
+                q_producer_phase ^= 1
+
+            # ---- Mainloop + epilogue: stage K[n] then V[n_prev], then V[min]. All TMA
+            # staging is warp-0 only; the other producer warps just advance the tile
+            # scheduler in lockstep below. ----
+            if warp_idx_in_wg == 0:
+                for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
+                    n_block_prev = n_block_max - i - 1
+                    n_block = n_block_prev - 1
+                    page_idx = mPageTable[batch_idx, n_block]
+                    page_idx_prev = mPageTable[batch_idx, n_block_prev]
+                    # stage K[n]
+                    pipeline_stage.producer_acquire_w_index_phase(0, stage_producer_phase)
+                    stage_copy_K(src_idx=page_idx, dst_idx=0, tma_bar_ptr=stage_full_bar)
+                    stage_producer_phase ^= 1
+                    # stage V[n_prev]
+                    pipeline_stage.producer_acquire_w_index_phase(0, stage_producer_phase)
+                    stage_copy_V(src_idx=page_idx_prev, dst_idx=0, tma_bar_ptr=stage_full_bar)
+                    stage_producer_phase ^= 1
+
+                # ---- Epilogue emit: stage V[n_block_min] ----
+                page_idx = mPageTable[batch_idx, n_block_min]
+                pipeline_stage.producer_acquire_w_index_phase(0, stage_producer_phase)
+                stage_copy_V(src_idx=page_idx, dst_idx=0, tma_bar_ptr=stage_full_bar)
+                stage_producer_phase ^= 1
+
+            tile_scheduler.prefetch_next_work()
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
 
     @cute.jit
     def load(
@@ -690,9 +896,21 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
         num_splits: Int32 = Int32(1),
+        sStage: Optional[cute.Tensor] = None,
+        pipeline_stage: Optional[pipeline.PipelineAsync] = None,
     ):
         warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
         tidx, _, _ = cute.arch.thread_idx()
+
+        if const_expr(self.fp8_kv_dequant):
+            # fp8_kv_dequant path uses different load logic, separate from the non-fp8 path.
+            self.load_fp8(
+                mQ, mK, mV, sQ, sStage,
+                tma_atom_Q, tma_atom_K, tma_atom_V,
+                pipeline_q, pipeline_stage, gmem_tiled_copy_Q, mPageTable,
+                block_info, SeqlenInfoCls, TileSchedulerCls, num_splits,
+            )
+            return
 
         # TMA: only warp 0 loads. cp_async: all warps load.
         # When not use_tma_Q, all 128 producer threads participate in Q loading.
@@ -1012,6 +1230,12 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
         num_splits: Int32 = Int32(1),
+        # FP8-KV dequant inputs (None on the non-fp8 path): sV (fp16 V write target),
+        # sStage, pipeline_stage.
+        sV: Optional[cute.Tensor] = None,
+        sStage: Optional[cute.Tensor] = None,
+        pipeline_stage: Optional[pipeline.PipelineAsync] = None,
+        descale_tensors=None,
     ):
         aux_tensors = aux_data.tensors
         warp_group_idx = cute.arch.make_warp_uniform(tidx // self.num_threads_per_warp_group)
@@ -1049,6 +1273,36 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             pipeline.PipelineUserType.Consumer, self.num_stages
         )
 
+        # FP8-KV MMA WGs side dequant setup: 
+        # K: cooperative 256-thread(2 WGs) copy of the full tile; 
+        # V: each WG copies only its own hdimv-half. 
+        dequant_params = None
+        if const_expr(self.fp8_kv_dequant):
+            sStage2 = sStage[None, None, 0]
+            sK2 = sK[None, None, 0]
+            sV2 = sV[None, None, 0]
+            half = const_expr(min(256, self.tile_hdimv))
+            VEC = const_expr(8)  # 8 fp16 == 128-bit store; 8 fp8 == 64-bit load
+            tiled_copy_K = copy_utils.tiled_copy_2d(
+                self.dtype, self.tile_hdim // VEC, self.num_mma_threads, num_copy_elems=VEC
+            )
+            tiled_copy_V = copy_utils.tiled_copy_2d(
+                self.dtype, half // VEC, self.num_threads_per_warp_group, num_copy_elems=VEC
+            )
+            thr_copy_K = tiled_copy_K.get_slice(tidx)
+            thr_copy_V = tiled_copy_V.get_slice(tidx % self.num_threads_per_warp_group)
+            # WG-local hdimv-half sub-views (tile coord (0, warp_group_idx)).
+            gStage_V = cute.local_tile(sStage2, (self.tile_n, half), (0, warp_group_idx))
+            gV = cute.local_tile(sV2, (self.tile_n, half), (0, warp_group_idx))
+            dequant_params = SimpleNamespace(
+                pipeline_stage=pipeline_stage,
+                warp_group_idx=warp_group_idx,
+                tStage_K=thr_copy_K.partition_S(sStage2),
+                tsK=thr_copy_K.partition_D(sK2),
+                tStage_V=thr_copy_V.partition_S(gStage_V),
+                tsV=thr_copy_V.partition_D(gV),
+            )
+
         tile_scheduler = TileSchedulerCls()
         work_tile = tile_scheduler.initial_work_tile_info()
         softmax = Softmax.create(
@@ -1062,10 +1316,16 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         if const_expr(self.rescale_O_before_gemm):
             scores_scale = cute.make_rmem_tensor_like(softmax.row_max, Float32)
 
+        # FP8-KV uses separate *_fp8 consumer functions (selected via const_expr) so the
+        # generic functions stay unchanged.
         mma_one_n_block_all = partial(
-            self.mma_one_n_block_intrawg_overlap
-            if const_expr(self.intra_wg_overlap)
-            else self.mma_one_n_block,
+            self.mma_one_n_block_intrawg_overlap_fp8
+            if const_expr(self.fp8_kv_dequant)
+            else (
+                self.mma_one_n_block_intrawg_overlap
+                if const_expr(self.intra_wg_overlap)
+                else self.mma_one_n_block
+            ),
             mma_qk_fn=mma_qk_fn,
             pipeline_k=pipeline_k,
             pipeline_v=pipeline_v,
@@ -1074,10 +1334,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             smem_copy_params=smem_copy_params,
             check_inf=True,
             scores_scale=scores_scale,
+            **(dict(dequant_params=dequant_params) if const_expr(self.fp8_kv_dequant) else {}),
         )
 
         process_first_half_block = partial(
-            self.first_half_block_overlap,
+            self.first_half_block_overlap_fp8
+            if const_expr(self.fp8_kv_dequant)
+            else self.first_half_block_overlap,
             mma_qk_fn=mma_qk_fn,
             pipeline_k=pipeline_k,
             tOrP=tOrP,
@@ -1085,14 +1348,18 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             scores_scale=scores_scale,
             softmax=softmax,
             acc_O=acc_O,
+            **(dict(dequant_params=dequant_params) if const_expr(self.fp8_kv_dequant) else {}),
         )
         process_last_half_block = partial(
-            self.last_half_block_overlap,
+            self.last_half_block_overlap_fp8
+            if const_expr(self.fp8_kv_dequant)
+            else self.last_half_block_overlap,
             pipeline_v=pipeline_v,
             mma_pv_fn=mma_pv_fn,
             scores_scale=scores_scale,
             softmax=softmax,
             acc_O=acc_O,
+            **(dict(dequant_params=dequant_params) if const_expr(self.fp8_kv_dequant) else {}),
         )
         while work_tile.is_valid_tile:
             # if work_tile.is_valid_tile:
@@ -1100,6 +1367,18 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             # shape: (atom_v_m * rest_m)
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+
+            # FP8-KV per-(batch, kv_head) descales, folded into the dequant cast (fp8
+            # only): q*k scales K, v scales V; see mma_one_n_block_intrawg_overlap_fp8.
+            if const_expr(self.fp8_kv_dequant):
+                head_idx_kv = (
+                    head_idx // self.qhead_per_kvhead
+                    if const_expr(not self.pack_gqa)
+                    else head_idx
+                )
+                qk_descale, v_descale_tile = self._load_effective_descales(
+                    descale_tensors, batch_idx, head_idx_kv
+                )
 
             # Recompute fastdiv_mods if necessary for varlen with aux_tensors
             recompute_fastdiv_mods_q = cutlass.const_expr(
@@ -1149,7 +1428,15 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     fastdiv_mods=fastdiv_mods,
                 )
             mma_one_n_block = partial(
-                mma_one_n_block_all, seqlen=seqlen, softmax=softmax, score_mod_fn=score_mod_fn
+                mma_one_n_block_all,
+                seqlen=seqlen,
+                softmax=softmax,
+                score_mod_fn=score_mod_fn,
+                **(
+                    dict(qk_descale=qk_descale, v_descale_tile=v_descale_tile)
+                    if const_expr(self.fp8_kv_dequant)
+                    else {}
+                ),
             )
             n_block_min, n_block_max = block_info.get_n_block_min_max(
                 seqlen, m_block, split_idx, num_splits
@@ -1203,6 +1490,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         mask_fn=partial(mask_fn, mask_mod=self.mask_mod),
                         score_mod_fn=score_mod_fn,
                         is_first_block=True,
+                        **(
+                            dict(qk_descale=qk_descale)
+                            if const_expr(self.fp8_kv_dequant)
+                            else {}
+                        ),
                     )
                 else:
                     self.warp_scheduler_barrier_sync()
@@ -1271,6 +1563,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     kv_consumer_state = process_last_half_block(
                         kv_consumer_state=kv_consumer_state,
                         zero_init=not O_should_accumulate,
+                        **(
+                            dict(v_descale_tile=v_descale_tile)
+                            if const_expr(self.fp8_kv_dequant)
+                            else {}
+                        ),
                     )
                     O_should_accumulate = True
                 else:
@@ -1422,6 +1719,71 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         return kv_consumer_state
 
     @cute.jit
+    def _load_effective_descales(self, descale_tensors, batch_idx: Int32, kv_head_idx: Int32):
+        """Load effective QK and V descales, defaulting unspecified tensors to identity."""
+        qk_descale = Float32(1.0)
+        v_descale = Float32(1.0)
+        if const_expr(descale_tensors is not None):
+            if const_expr(descale_tensors.q_descale is not None):
+                qk_descale = qk_descale * Float32(descale_tensors.q_descale[batch_idx, kv_head_idx])
+            if const_expr(descale_tensors.k_descale is not None):
+                qk_descale = qk_descale * Float32(descale_tensors.k_descale[batch_idx, kv_head_idx])
+            if const_expr(descale_tensors.v_descale is not None):
+                v_descale = Float32(descale_tensors.v_descale[batch_idx, kv_head_idx])
+        return qk_descale, v_descale
+
+    @cute.jit
+    def _dequant_tile(self, pipeline_stage, tStage, tsDst, descale, phase):
+        """Dequant one staged fp8 tile -> fp16 smem (descale folded in). """
+        rS = cute.make_rmem_tensor_like(tStage)
+        rD = cute.make_rmem_tensor_like(tsDst)
+        pipeline_stage.consumer_wait_w_index_phase(0, phase)
+        cute.autovec_copy(tStage, rS)
+        rD.store((utils.cvt_fp8_to_f16_packed(rS.load(), self.dtype) * descale).to(self.dtype))
+        cute.autovec_copy(rD, tsDst)
+        pipeline_stage.consumer_release_w_index(0)
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def first_half_block_overlap_fp8(
+        self,
+        n_block: Int32,
+        mma_qk_fn: Callable,
+        kv_consumer_state,
+        pipeline_k,
+        tOrP: cute.Tensor,
+        smem_copy_params: SimpleNamespace,
+        softmax: Softmax,
+        seqlen: SeqlenInfoQK,
+        scores_scale: Optional[cute.Tensor] = None,
+        acc_O: Optional[cute.Tensor] = None,
+        mask_fn: Callable = None,
+        score_mod_fn: Optional[Callable] = None,
+        is_first_block: bool = False,
+        dequant_params: Optional[SimpleNamespace] = None,
+        qk_descale=None,
+    ):
+        """FP8-KV first-half block: cooperative 256-thread dequant of the first K tile
+        (q*k descale folded in) + DequantK barrier, then the synchronous QK."""
+        dp = dequant_params
+        nthr = const_expr(self.num_mma_threads)
+        self._dequant_tile(dp.pipeline_stage, dp.tStage_K, dp.tsK, qk_descale, Int32(0))
+        cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantK), number_of_threads=nthr)
+        acc_S = mma_qk_fn(B_idx=kv_consumer_state.index, wg_wait=0)
+
+        if const_expr(score_mod_fn is not None):
+            score_mod_fn(acc_S, n_block=n_block, seqlen=seqlen)
+        mask_fn(acc_S, n_block=n_block, mask_seqlen=True)
+        row_scale = softmax.online_softmax(acc_S, is_first=is_first_block)
+        tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
+        tOrP_cur = tOrP
+        tOrP_cur.store(tOrP_acc.load().to(self.dtype))
+        if const_expr(self.rescale_O_before_gemm):
+            acc_O.fill(0.0)
+            scores_scale.store(row_scale.load())
+        return kv_consumer_state
+
+    @cute.jit
     def last_half_block_overlap(
         self,
         kv_consumer_state,
@@ -1441,6 +1803,34 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         pipeline_v.consumer_wait(kv_consumer_state, pipeline_v.consumer_try_wait(kv_consumer_state))
         mma_pv_fn(B_idx=kv_consumer_state.index, zero_init=zero_init, wg_wait=0)
         pipeline_v.consumer_release(kv_consumer_state)
+        kv_consumer_state.advance()
+        return kv_consumer_state
+
+    @cute.jit
+    def last_half_block_overlap_fp8(
+        self,
+        kv_consumer_state,
+        pipeline_v,
+        mma_pv_fn: Callable,
+        zero_init: bool,
+        scores_scale: Optional[cute.Tensor] = None,
+        softmax: Optional[Softmax] = None,
+        acc_O: Optional[cute.Tensor] = None,
+        dequant_params: Optional[SimpleNamespace] = None,
+        v_descale_tile=None,
+    ):
+        """FP8-KV final PV: each WG dequants its own hdimv-half of the last V tile
+        (v descale folded in) + WG-local DequantV barrier, then the synchronous PV."""
+        if const_expr(self.rescale_O_before_gemm):
+            softmax.rescale_O(acc_O, scores_scale)
+        dp = dequant_params
+        nthr_wg = const_expr(self.num_threads_per_warp_group)
+        self._dequant_tile(dp.pipeline_stage, dp.tStage_V, dp.tsV, v_descale_tile, Int32(1))
+        if dp.warp_group_idx == 0:
+            cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantV0), number_of_threads=nthr_wg)
+        else:
+            cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantV1), number_of_threads=nthr_wg)
+        mma_pv_fn(B_idx=kv_consumer_state.index, zero_init=zero_init, wg_wait=0)
         kv_consumer_state.advance()
         return kv_consumer_state
 
@@ -1573,6 +1963,69 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             # Fence and barrier to make sure smem store is visible to WGMMA
             cute.arch.fence_view_async_shared()
             cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
+        return smem_pipe_read
+
+    @cute.jit
+    def mma_one_n_block_intrawg_overlap_fp8(
+        self,
+        smem_pipe_read: pipeline.PipelineState | pipeline_custom.PipelineStateSimple,
+        n_block: Int32,
+        mma_qk_fn: Callable,
+        mma_pv_fn: Callable,
+        pipeline_k: pipeline.PipelineAsync,
+        pipeline_v: pipeline.PipelineAsync,
+        acc_O: cute.Tensor,
+        tOrP: cute.Tensor,
+        smem_copy_params: SimpleNamespace,
+        softmax: Softmax,
+        seqlen: SeqlenInfoQK,
+        scores_scale: Optional[cute.Tensor] = None,
+        score_mod_fn: Optional[Callable] = None,
+        mask_fn: Optional[Callable] = None,
+        check_inf: cutlass.Constexpr = True,
+        dequant_params: Optional[SimpleNamespace] = None,
+        qk_descale=None,
+        v_descale_tile=None,
+    ):
+        # FP8-KV dequant intra-WG overlap: dequant K[n] for QK[n], then dequant
+        # V[n_prev] under the QK WGMMA for PV[n_prev]. Descales folded into
+        # the casts. Separate from the generic overlap to keep that path unchanged.
+        smem_pipe_read_v = smem_pipe_read.clone()
+        smem_pipe_read.advance()
+        dp = dequant_params
+        nthr = const_expr(self.num_mma_threads)
+        nthr_wg = const_expr(self.num_threads_per_warp_group)
+        # ---- 1. dequant K[n] -> sK (cooperative 256-thread, staging phase 1) ----
+        self._dequant_tile(dp.pipeline_stage, dp.tStage_K, dp.tsK, qk_descale, Int32(1))
+        cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantK), number_of_threads=nthr)
+        # ---- 2. S = Q @ K.T (async) ----
+        self.warp_scheduler_barrier_sync()
+        acc_S = mma_qk_fn(B_idx=smem_pipe_read.index, wg_wait=-1)
+        if const_expr(self.rescale_O_before_gemm):
+            softmax.rescale_O(acc_O, scores_scale)
+        # ---- 3. dequant V[n_prev] -> sV (WG-split, phase 0) WHILE QK[n] runs ----
+        self._dequant_tile(dp.pipeline_stage, dp.tStage_V, dp.tsV, v_descale_tile, Int32(0))
+        if dp.warp_group_idx == 0:
+            cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantV0), number_of_threads=nthr_wg)
+        else:
+            cute.arch.barrier(barrier_id=int(NamedBarrierFwd.DequantV1), number_of_threads=nthr_wg)
+        # ---- 4. O += P @ V (async), then wait QK then PV ----
+        mma_pv_fn(B_idx=smem_pipe_read_v.index, wg_wait=-1)
+        self.warp_scheduler_barrier_arrive()
+        warpgroup.wait_group(1)
+        if const_expr(score_mod_fn is not None):
+            score_mod_fn(acc_S, n_block=n_block, seqlen=seqlen)
+        if const_expr(mask_fn is not None):
+            mask_fn(acc_S=acc_S, n_block=n_block)
+        row_scale = softmax.online_softmax(acc_S, check_inf=check_inf)
+        warpgroup.wait_group(0)
+        tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
+        tOrP_cur = tOrP
+        utils.cvt_f16(tOrP_acc, tOrP_cur)
+        if const_expr(not self.rescale_O_before_gemm):
+            softmax.rescale_O(acc_O, row_scale)
+        if const_expr(self.rescale_O_before_gemm):
+            scores_scale.store(row_scale.load())
         return smem_pipe_read
 
     @cute.jit

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -479,9 +479,13 @@ def _flash_attn_fwd(
         "inputs must be float16, bfloat16, fp8 e4m3fn, or fp8 e5m2"
     )
     if fp8_kv_dequant:
-        # FP8-KV in-place dequant: fp16 Q + fp8 e4m3 K/V (dequantized in-kernel to
-        # fp16 for precision), bf16/fp16 O. Only the SM90 path.
-        assert q.dtype == torch.float16, "fp8_kv_dequant requires fp16 Q (compute is fp16)"
+        # FP8-KV in-kernel dequant: fp16/bf16 Q + fp8 e4m3 K/V (dequantized in-kernel to
+        # fp16), fp16/bf16 O. Compute is always fp16 (the single-instruction fp8->fp16 fast
+        # path); a bf16 Q is narrowed to fp16 in-kernel and the fp32 accumulator is cast to
+        # O's dtype in the epilogue, so Q/O dtypes are independent of compute. SM90 only.
+        assert q.dtype in (torch.float16, torch.bfloat16), (
+            "fp8_kv_dequant requires fp16 or bf16 Q"
+        )
         assert k.dtype == v.dtype == torch.float8_e4m3fn, (
             "fp8_kv_dequant requires fp8 e4m3 K/V"
         )
@@ -619,6 +623,11 @@ def _flash_attn_fwd(
     kv_dtype = torch2cute_dtype_map[k.dtype] if fp8_kv_dequant else dtype
     if fp8_kv_dequant:
         assert arch // 10 == 9, "fp8_kv_dequant is an SM90-only forward (compute capability 9.x)"
+        # Compute is fp16 regardless of the (fp16/bf16) Q dtype: the fp8->fp16 cvt is the
+        # only single-instruction widening on SM90. The kernel derives the Q/O tensor
+        # dtypes from mQ/mO (which keep q.dtype / out_torch_dtype), narrowing bf16 Q to
+        # fp16 in-kernel and casting the fp32 accumulator to O's dtype in the epilogue.
+        dtype = torch2cute_dtype_map[torch.float16]
     if is_fp8:
         assert arch // 10 == 10, "FP8 is only supported on SM100 (compute capability 10.x) for FA4 CuTe."
     use_block_sparsity = block_sparse_tensors is not None
@@ -914,6 +923,11 @@ def _flash_attn_fwd(
         fa_logging.get_fa_log_level(),
         output_quant_key,
         fp8_kv_dequant,
+        # fp8_kv_dequant forces compute dtype = fp16, so the Q/O tensor dtypes (which the
+        # kernel derives from mQ/mO and which select the in-kernel narrow/widen) are no
+        # longer captured by `dtype` above -- key on them explicitly. Redundant elsewhere.
+        q.dtype,
+        out_torch_dtype,
     )
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
@@ -1240,7 +1254,7 @@ def _flash_attn_fwd(
                 for t in (q_call, k_call, v_call, qv_call)
             ]
         elif fp8_kv_dequant:
-            # FP8-KV dequant: Q is fp16 but K/V are fp8 e4m3 -- apply the same uint8
+            # FP8-KV dequant: Q is fp16/bf16 but K/V are fp8 e4m3 -- apply the same uint8
             # FFI workaround to K/V only (the compiled kernel takes them as uint8).
             k_call = k_call.view(torch.uint8)
             v_call = v_call.view(torch.uint8)

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -402,6 +402,7 @@ def _flash_attn_fwd(
     gather_kv_indices: Optional[torch.Tensor] = None,
     output_scale: Optional[torch.Tensor] = None,
     compile_only: bool = False,
+    fp8_kv_dequant: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """Forward pass for FlashAttention.
 
@@ -477,17 +478,24 @@ def _flash_attn_fwd(
     assert v.dtype in [torch.float16, torch.bfloat16, torch.float8_e4m3fn, torch.float8_e5m2], (
         "inputs must be float16, bfloat16, fp8 e4m3fn, or fp8 e5m2"
     )
-    
-    input_tensors = {"q": q, "k": k, "v": v, "qv": qv}
-    present = {name: t for name, t in input_tensors.items() if t is not None}
-    names = list(present.keys())
-    for i in range(len(names)):
-        for j in range(i + 1, len(names)):
-            a, b = names[i], names[j]
-            assert present[a].dtype == present[b].dtype, f"{a}.dtype {present[a].dtype} != {b}.dtype {present[b].dtype}"
+    if fp8_kv_dequant:
+        # FP8-KV in-place dequant: fp16 Q + fp8 e4m3 K/V (dequantized in-kernel to
+        # fp16 for precision), bf16/fp16 O. Only the SM90 path.
+        assert q.dtype == torch.float16, "fp8_kv_dequant requires fp16 Q (compute is fp16)"
+        assert k.dtype == v.dtype == torch.float8_e4m3fn, (
+            "fp8_kv_dequant requires fp8 e4m3 K/V"
+        )
+        assert page_table is not None, "fp8_kv_dequant requires paged KV (page_table)"
+    else:
+        input_tensors = {"q": q, "k": k, "v": v, "qv": qv}
+        present = {name: t for name, t in input_tensors.items() if t is not None}
+        names = list(present.keys())
+        for i in range(len(names)):
+            for j in range(i + 1, len(names)):
+                a, b = names[i], names[j]
+                assert present[a].dtype == present[b].dtype, f"{a}.dtype {present[a].dtype} != {b}.dtype {present[b].dtype}"
 
     q_dtype = q.dtype if q is not None else qv.dtype
-
     for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
         if t is not None:
             assert t.dtype == torch.int32, (
@@ -539,7 +547,7 @@ def _flash_attn_fwd(
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
 
-    is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2) and not fp8_kv_dequant
     requires_grad = any(t is not None and t.requires_grad for t in [q, k, v, qv])
     if is_fp8 and requires_grad:
         raise NotImplementedError("FA4 CuTe FP8 backward is not supported yet (forward-only).")
@@ -589,7 +597,7 @@ def _flash_attn_fwd(
             lse.fill_(float("-inf"))
         return out, lse, None, None
 
-    if is_fp8:
+    if is_fp8 or fp8_kv_dequant:
         for t, name in ((q_descale, "q_descale"), (k_descale, "k_descale"), (v_descale, "v_descale")):
             if t is not None:
                 _validate_tensor(t, name, (batch_size, num_head_kv), torch.float32, device)
@@ -598,7 +606,19 @@ def _flash_attn_fwd(
             "q_descale/k_descale/v_descale are only supported for FP8 inputs"
         )
 
+    if fp8_kv_dequant and q_descale is None:
+        # fp16 Q has no q-scale; materialize an identity (1.0) q_descale so the
+        # DescaleTensors struct has all three fields present (identity q is a no-op).
+        _ref_descale = k_descale if k_descale is not None else v_descale
+        q_descale = (
+            torch.ones_like(_ref_descale)
+            if _ref_descale is not None
+            else torch.ones((batch_size, num_head_kv), dtype=torch.float32, device=q.device)
+        )
     dtype = torch2cute_dtype_map[q_dtype]
+    kv_dtype = torch2cute_dtype_map[k.dtype] if fp8_kv_dequant else dtype
+    if fp8_kv_dequant:
+        assert arch // 10 == 9, "fp8_kv_dequant is an SM90-only forward (compute capability 9.x)"
     if is_fp8:
         assert arch // 10 == 10, "FP8 is only supported on SM100 (compute capability 10.x) for FA4 CuTe."
     use_block_sparsity = block_sparse_tensors is not None
@@ -638,6 +658,22 @@ def _flash_attn_fwd(
         mma_pv_is_rs = fwd_cfg.mma_pv_is_rs
     if intra_wg_overlap is None:
         intra_wg_overlap = fwd_cfg.intra_wg_overlap
+    if fp8_kv_dequant:
+        # Force RS-mode PV: frees sP for the fp8 staging buffer, keeping smem within
+        # budget at d=512 while preserving intra-WG overlap.
+        mma_pv_is_rs = True
+        # The SM90 fp8-KV-dequant producer is TMA-only (no cp.async fallback): a paged
+        # page_size != tile_n gives use_tma_KV=False -> a None TMA atom. Assert here so
+        # it fails with a clear message instead of crashing later.
+        assert page_size == tile_n, (
+            f"FA4 SM90 fp8-KV-dequant requires the paged-KV page_size == tile_n ({tile_n}); "
+            f"got page_size={page_size}. "
+        )
+        # Currently in this path we use one sStage buffer for both K and V, it needs more changes if head_dim != head_dim_v.
+        assert head_dim == head_dim_v, (
+            f"FA4 SM90 fp8-KV-dequant requires head_dim == head_dim_v (one staging buffer "
+            f"serves K and V); got head_dim={head_dim}, head_dim_v={head_dim_v}."
+        )
 
     if max_seqlen_q is None:
         max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
@@ -877,6 +913,7 @@ def _flash_attn_fwd(
         disable_sparse_kv_bitmask,
         fa_logging.get_fa_log_level(),
         output_quant_key,
+        fp8_kv_dequant,
     )
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
@@ -993,6 +1030,8 @@ def _flash_attn_fwd(
                 paged_kv_non_tma=page_size not in [None, tile_n],
                 # SplitKV: forward writes FP32 partials, combine does the fold.
                 output_quant_key=output_quant_key if not is_split_kv else None,
+                kv_dtype=kv_dtype,  # K/V storage dtype (fp8)
+                fp8_kv_dequant=fp8_kv_dequant,
             )
         elif arch // 10 in [10, 11]:
             if output_quant_key is not None:
@@ -1172,6 +1211,10 @@ def _flash_attn_fwd(
                 sparse_tensors,
                 AuxData(cute_aux_tensors, aux_scalars),
             ])
+            if arch // 10 == 9:
+                # SM90 fp8-KV descale slot: after aux, before output_scale (None unless
+                # fp8_kv_dequant), mirroring the SM90 kernel positional signature.
+                compile_args.append(descale_tensors_tensor)
             # TODO: thread output_scale into the hd256 (BlackwellFusedMultiHeadAttentionForward)
             # and MLA (FlashAttentionMLAForwardSm100) kernels so fused FP8 output works there
             # too, then drop this special-casing and the qv/hd256 fp8-output guards above.
@@ -1196,6 +1239,11 @@ def _flash_attn_fwd(
                 t.view(torch.uint8) if t is not None else None
                 for t in (q_call, k_call, v_call, qv_call)
             ]
+        elif fp8_kv_dequant:
+            # FP8-KV dequant: Q is fp16 but K/V are fp8 e4m3 -- apply the same uint8
+            # FFI workaround to K/V only (the compiled kernel takes them as uint8).
+            k_call = k_call.view(torch.uint8)
+            v_call = v_call.view(torch.uint8)
         out_call = out.detach()
         if out_call.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
             out_call = out_call.view(torch.uint8)
@@ -1260,6 +1308,10 @@ def _flash_attn_fwd(
                 else None,
                 AuxData(aux_tensors, aux_scalars),
             ])
+            # SM90 descale slot (mirrors the compile_args insert): after aux_tensors,
+            # before output_scale. None unless fp8_kv_dequant.
+            if arch // 10 == 9:
+                call_args.append(descale_tensors)
             # See the TODO above: hd256/MLA kernels don't take output_scale yet.
             if not use_dedicated_hd256_kernel:
                 call_args.append(output_scale)

--- a/flash_attn/cute/named_barrier.py
+++ b/flash_attn/cute/named_barrier.py
@@ -10,6 +10,12 @@ class NamedBarrierFwd(enum.IntEnum):
     WarpSchedulerWG3 = enum.auto()
     PFull = enum.auto()
     PEmpty = enum.auto()
+    # FP8-KV consumer-side dequant (flash_fwd_sm90.py). DequantK: 256-thread sync so the
+    # full fp16 K is visible to both MMA warpgroups before QK. DequantV0/DequantV1:
+    # per-warpgroup 128-thread sync (each WG dequants only its own V half).
+    DequantK = enum.auto()
+    DequantV0 = enum.auto()
+    DequantV1 = enum.auto()
 
 
 class NamedBarrierFwdSm100(enum.IntEnum):

--- a/flash_attn/cute/named_barrier.py
+++ b/flash_attn/cute/named_barrier.py
@@ -16,6 +16,9 @@ class NamedBarrierFwd(enum.IntEnum):
     DequantK = enum.auto()
     DequantV0 = enum.auto()
     DequantV1 = enum.auto()
+    # FP8-KV bf16-Q in-place narrow (flash_fwd_sm90.py): 256-thread sync so the full
+    # fp16 Q (cast in place from bf16) is visible to both MMA warpgroups before QK.
+    NarrowQ = enum.auto()
 
 
 class NamedBarrierFwdSm100(enum.IntEnum):

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -14,7 +14,7 @@ from cutlass import Float32, Int32, const_expr
 from cutlass.cute import FastDivmodDivisor
 from cutlass.cutlass_dsl import T, dsl_user_op
 from cutlass._mlir.dialects import nvvm, llvm, nvgpu
-from cutlass.base_dsl._mlir_helpers.arith import recast_type
+from cutlass._mlir_helpers.arith import recast_type
 from cutlass.cute.tensor import TensorSSA
 from cutlass.cute.runtime import from_dlpack
 

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -13,7 +13,9 @@ import cutlass.cute as cute
 from cutlass import Float32, Int32, const_expr
 from cutlass.cute import FastDivmodDivisor
 from cutlass.cutlass_dsl import T, dsl_user_op
-from cutlass._mlir.dialects import nvvm, llvm
+from cutlass._mlir.dialects import nvvm, llvm, nvgpu
+from cutlass.base_dsl._mlir_helpers.arith import recast_type
+from cutlass.cute.tensor import TensorSSA
 from cutlass.cute.runtime import from_dlpack
 
 
@@ -672,6 +674,16 @@ def cvt_f16(src: cute.Tensor, dst_or_dtype):
         assert cute.size(dst_i32.shape) * 2 == cute.size(src.shape)
         for i in cutlass.range_constexpr(cute.size(dst_i32)):
             dst_i32[i] = cvt_f16x2_f32(src[2 * i], src[2 * i + 1], dst.element_type)
+
+
+def cvt_fp8_to_f16_packed(src_ssa: cute.TensorSSA, dtype) -> cute.TensorSSA:
+    """
+    fp8 e4m3 -> fp16 via the packed hardware cvt only (no f32 round-trip).
+    TODO(qixiangl): drop once TensorSSA.to() handles fp8->fp16 correctly. It emits a
+    degenerate extf that fails IR verification (nvidia-cutlass-dsl 4.4.2).
+    """
+    res_ty = recast_type(src_ssa.type, dtype.mlir_type)
+    return TensorSSA(nvgpu.cvt_fpext(res_ty, src_ssa), src_ssa.shape, dtype)
 
 
 @dsl_user_op

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1835,6 +1835,91 @@ def _generate_block_kvcache(
     return k_cache, v_cache, page_table, k_cache_paged, v_cache_paged, num_blocks
 
 
+@pytest.mark.skipif(not IS_SM90, reason="fp8-KV dequant forward is SM90-only")
+@pytest.mark.parametrize("mha_type", ["mha", "gqa"])
+@pytest.mark.parametrize("k_scale,v_scale", [(1.0, 1.0), (0.5, 0.25)])
+@pytest.mark.parametrize("num_splits", [1, 2])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_kvcache_fp8_dequant_sm90(num_splits, k_scale, v_scale, mha_type):
+    """SM90 fp16-Q + fp8-KV-cache dequant paged forward (d=512).
+
+    fp16 Q with per-tensor FP8 (e4m3) paged K/V dequantized in-kernel to fp16 (the
+    compute/output dtype). Per-(batch, kv_head) k/v descales are folded by the kernel
+    (q*k into the score scale, v into the output). The reference reads the exact paged
+    FP8 bytes the kernel indexes (gathered through page_table, cast to fp16) and applies
+    the same descales via attention_ref (dequantize-then-attend). num_splits=2 exercises
+    the SplitKV path (fp32 partials combined back to fp16). Q is true fp16 -> q_descale
+    is identity (None on both sides). page_size must equal tile_n (64 for d=512 on SM90).
+    """
+    device, d, page_size, causal = "cuda", 512, 64, True
+    batch_size, nheads, seqlen_q, seqlen_k = 2, 4, 5, 256
+    nheads_k = nheads if mha_type == "mha" else 2
+    torch.random.manual_seed(0)
+
+    # fp16 Q (true precision -> no q_descale); bf16 paged K/V from the shared builder.
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=torch.float16)
+    _, _, page_table, k_cache_paged, v_cache_paged, _ = _generate_block_kvcache(
+        seqlen_k, page_size, batch_size, nheads_k, d, d, device, torch.bfloat16, torch.bfloat16
+    )
+
+    # Static per-tensor fp8 quantization of the paged buffers the kernel indexes.
+    quant = lambda x, s: (x / s).to(torch.float8_e4m3fn)
+    k_paged_fp8, v_paged_fp8 = quant(k_cache_paged, k_scale), quant(v_cache_paged, v_scale)
+    descale = lambda s: torch.full((batch_size, nheads_k), s, device=device, dtype=torch.float32)
+    k_descale, v_descale = descale(k_scale), descale(v_scale)
+
+    # Deterministic cache lengths so num_splits=2 actually splits (4 and 3 blocks @ page=64).
+    cache_seqlens = torch.tensor(
+        [seqlen_k - (i % 2) * page_size for i in range(batch_size)],
+        dtype=torch.int32,
+        device=device,
+    )
+    arange = rearrange(torch.arange(seqlen_k, device=device), "s -> 1 s")
+    key_padding_mask = arange < rearrange(cache_seqlens, "b -> b 1")
+
+    # Reference reads the EXACT fp8 bytes the kernel reads: gather the paged fp8 through the
+    # page table into dense (b, seqlen_k, nheads_k, d), then to fp16 (the kernel dequants
+    # fp8 -> fp16). attention_ref applies k/v_descale = dequant; out is fp16 (== kernel O dtype).
+    gather = lambda paged: rearrange(
+        paged[page_table.flatten()], "(b n) p ... -> b (n p) ...", b=batch_size
+    )[:, :seqlen_k].to(torch.float16)
+    k_ref, v_ref = gather(k_paged_fp8), gather(v_paged_fp8)
+    common = dict(causal=causal, k_descale=k_descale, v_descale=v_descale)
+    out_ref, _ = attention_ref(q, k_ref, v_ref, None, key_padding_mask, **common)
+    # out_pt models fp16 arithmetic (NO fp8 intermediate_dtype) -> sets the error bar.
+    out_pt, _ = attention_ref(
+        q, k_ref, v_ref, None, key_padding_mask, upcast=False, reorder_ops=True, **common
+    )
+
+    # ---- kernel under test: fp16 Q + fp8 paged K/V, dequantized in-kernel ----
+    out, _ = _flash_attn_fwd(
+        q=q,
+        k=k_paged_fp8,
+        v=v_paged_fp8,
+        causal=causal,
+        page_table=page_table,
+        seqused_k=cache_seqlens,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_k,
+        num_splits=num_splits,
+        q_descale=None,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        fp8_kv_dequant=True,
+    )
+    if is_fake_mode():
+        return
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
+    print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
+
+    # Same max/mean multiplier style as test_flash_attn_kvcache (fp8 bar).
+    assert (out - out_ref).abs().max().item() <= 4 * (out_pt - out_ref).abs().max().item() + 1e-5
+    assert (out - out_ref).abs().mean().item() <= 3 * (out_pt - out_ref).abs().mean().item()
+
+
 @pytest.mark.parametrize("page_size", [16, 64, 256])
 @pytest.mark.parametrize("seqlen_q", [64, 128, 256])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1843,13 +1843,14 @@ def _generate_block_kvcache(
 def test_flash_attn_kvcache_fp8_dequant_sm90(num_splits, k_scale, v_scale, mha_type):
     """SM90 fp16-Q + fp8-KV-cache dequant paged forward (d=512).
 
-    fp16 Q with per-tensor FP8 (e4m3) paged K/V dequantized in-kernel to fp16 (the
-    compute/output dtype). Per-(batch, kv_head) k/v descales are folded by the kernel
-    (q*k into the score scale, v into the output). The reference reads the exact paged
-    FP8 bytes the kernel indexes (gathered through page_table, cast to fp16) and applies
-    the same descales via attention_ref (dequantize-then-attend). num_splits=2 exercises
-    the SplitKV path (fp32 partials combined back to fp16). Q is true fp16 -> q_descale
-    is identity (None on both sides). page_size must equal tile_n (64 for d=512 on SM90).
+    fp16 Q with per-tensor FP8 (e4m3) paged K/V cast in-kernel to fp16 (the
+    compute/output dtype). Per-(batch, kv_head) descales are folded by the kernel
+    (q*k into the score scale, v into final output normalization/final_scale). The
+    reference reads the exact paged FP8 bytes the kernel indexes (gathered through
+    page_table, cast to fp16) and applies the same descales via attention_ref
+    (dequantize-then-attend). num_splits=2 exercises the SplitKV path (fp32
+    partials combined back to fp16). Q is true fp16 -> q_descale is identity
+    (None on both sides). page_size must equal tile_n (64 for d=512 on SM90).
     """
     device, d, page_size, causal = "cuda", 512, 64, True
     batch_size, nheads, seqlen_q, seqlen_k = 2, 4, 5, 256
@@ -1878,7 +1879,7 @@ def test_flash_attn_kvcache_fp8_dequant_sm90(num_splits, k_scale, v_scale, mha_t
     key_padding_mask = arange < rearrange(cache_seqlens, "b -> b 1")
 
     # Reference reads the EXACT fp8 bytes the kernel reads: gather the paged fp8 through the
-    # page table into dense (b, seqlen_k, nheads_k, d), then to fp16 (the kernel dequants
+    # page table into dense (b, seqlen_k, nheads_k, d), then to fp16 (the kernel casts
     # fp8 -> fp16). attention_ref applies k/v_descale = dequant; out is fp16 (== kernel O dtype).
     gather = lambda paged: rearrange(
         paged[page_table.flatten()], "(b n) p ... -> b (n p) ...", b=batch_size
@@ -1891,7 +1892,7 @@ def test_flash_attn_kvcache_fp8_dequant_sm90(num_splits, k_scale, v_scale, mha_t
         q, k_ref, v_ref, None, key_padding_mask, upcast=False, reorder_ops=True, **common
     )
 
-    # ---- kernel under test: fp16 Q + fp8 paged K/V, dequantized in-kernel ----
+    # ---- kernel under test: fp16 Q + fp8 paged K/V, cast in-kernel ----
     out, _ = _flash_attn_fwd(
         q=q,
         k=k_paged_fp8,

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1893,7 +1893,7 @@ def test_flash_attn_kvcache_fp8_dequant_sm90(num_splits, k_scale, v_scale, mha_t
     )
 
     # ---- kernel under test: fp16 Q + fp8 paged K/V, cast in-kernel ----
-    out, _ = _flash_attn_fwd(
+    out, *_ = _flash_attn_fwd(
         q=q,
         k=k_paged_fp8,
         v=v_paged_fp8,

--- a/tests/cute/test_flash_attn_fp8_kv_cache.py
+++ b/tests/cute/test_flash_attn_fp8_kv_cache.py
@@ -64,14 +64,15 @@ def _cute_dequant_paged_attention(
     softmax_scale: float = GEMMA4_SOFTMAX_SCALE,
     num_splits: int = 1,
 ) -> torch.Tensor:
-    """Run the SM90 fp16-Q + fp8-KV-cache dequant forward (fp16 Q + fp8 paged K/V -> fp16 O).
+    """Run the SM90 fp16/bf16-Q + fp8-KV-cache dequant forward (-> O matching Q dtype).
 
-    Q is cast to fp16 (the compute dtype; no q_descale). The fp8 K/V are dequantized
-    in-kernel to fp16; per-tensor k/v scales are passed as the descales the kernel
-    folds (k into the score scale, v into the output). This matches the fp16-Q Triton
-    path, which dequantizes the fp8 cache and runs the matmuls in fp16.
+    Q is passed in its caller dtype (fp16 OR bf16): compute is always fp16, so a bf16
+    Q is narrowed bf16->fp16 in-kernel and the fp32 accumulator is cast back to the Q
+    dtype for O. No q_descale. The fp8 K/V are cast in-kernel to fp16; per-tensor k/v
+    scales are passed as descale tensors the kernel folds (k into the score scale, v
+    into final output normalization/final_scale). This matches the fp16-Q Triton path,
+    which dequantizes the fp8 cache and runs the matmuls in fp16.
     """
-    query = query.half()
     num_seqs = len(query_lens)
     num_kv_heads = key_cache_fp8.shape[2]
     cu_query_lens = torch.tensor(
@@ -464,17 +465,22 @@ def _triton_unified_attention_ref(
 @pytest.mark.parametrize(
     "scale_case", SCALE_CASES, ids=lambda scale_case: scale_case.id
 )
+@pytest.mark.parametrize(
+    "qo_dtype", [torch.float16, torch.bfloat16], ids=["q_fp16", "q_bf16"]
+)
 @torch.inference_mode()
 def test_gemma4_fp16q_fp8kv_dequant_matches_triton_unified_attention(
     attention_case: AttentionCase,
     scale_case: ScaleCase,
+    qo_dtype: torch.dtype,
 ):
-    """Gemma4 full-attention cases: fp16-Q + fp8-KV-cache dequant forward, fp16 Q
-    with per-tensor FP8 paged KV cache dequantized in-kernel to fp16 (the consumer
-    MMA warpgroups do the fp8->fp16 dequant; O is fp16).
+    """Gemma4 full-attention cases: fp16/bf16-Q + fp8-KV-cache dequant forward, with
+    per-tensor FP8 paged KV cache cast in-kernel to fp16 (the consumer MMA warpgroups
+    do the fp8->fp16 cast). Q is fp16 OR bf16 (bf16 is narrowed bf16->fp16 in-kernel),
+    and O matches the Q dtype (the fp32 accumulator is cast to O's dtype in the epilogue).
 
-    Q is true fp16 (no q_descale); only K/V are fp8. This is the production
-    fp16-Q + fp8-KV regime, and the fp16-Q Triton path dequantizes the cache and
+    Q carries no q_descale (true Q); only K/V are fp8. This is the production
+    Q + fp8-KV regime, and the fp16-Q Triton path dequantizes the cache and
     runs the matmuls in fp16 -- a faithful, apples-to-apples oracle (unlike fp8-Q
     which would run fp8 MMA). Reports three divergences each run: CuteDSL-vs-
     Reference, Triton-vs-Reference, and CuteDSL-vs-Triton. The two CuteDSL
@@ -483,18 +489,22 @@ def test_gemma4_fp16q_fp8kv_dequant_matches_triton_unified_attention(
     if _cute_flash_attn_fwd is None:
         pytest.skip("FA4 CuTe interface is not importable in this environment")
 
-    # The dequant path now folds the per-(batch, kv_head) k/v descales: q*k into the
-    # per-tile softmax score scale and v into the final O scale (the dequant cast
-    # stays a pure fp8->fp16 cast). So non-unity k/v scales match too.
+    # The scale-fold path folds per-(batch, kv_head) descales differently for K and V:
+    # q*k into the per-tile softmax score scale, and v into final output
+    # normalization/final_scale.
+    # So non-unity k/v scales match too.
 
     ins = _build_case_inputs(attention_case, scale_case)
     query_lens = ins["query_lens"]
     kv_lens = ins["kv_lens"]
     q_scale, k_scale, v_scale = ins["q_scale"], ins["k_scale"], ins["v_scale"]
-    # Compute dtype is fp16: feed fp16 Q to the kernel, the Triton oracle, and the
-    # reference (the reference upcasts to f32, so its result is ~unchanged). Using the
-    # same fp16 tensor for both reference calls keeps the paging cross-check exact.
+    # Oracles run in fp16: feed fp16 Q to the Triton oracle and the reference (the
+    # reference upcasts to f32, so its result is ~unchanged). Using the same fp16 tensor
+    # for both reference calls keeps the paging cross-check exact. The kernel under test
+    # gets Q in qo_dtype (fp16 or bf16); bf16 is narrowed bf16->fp16 in-kernel (near
+    # lossless: fp16 has more mantissa bits than bf16) and O comes back in qo_dtype.
     q16 = ins["query"].half()
+    q_in = ins["query"].to(qo_dtype)
     # fp16 Q is true precision -> q_descale is identity (1.0) in the reference.
     q_scale_one = torch.tensor(1.0, device=ins["query"].device, dtype=torch.float32)
 
@@ -528,10 +538,13 @@ def test_gemma4_fp16q_fp8kv_dequant_matches_triton_unified_attention(
         query_lens, kv_lens, ins["page_table"], q_scale, k_scale, v_scale,
         torch.bfloat16,
     )
-    # ---- FA4 CuTe fp16-Q + fp8-KV dequant SM90 forward (the kernel under test) ----
+    # ---- FA4 CuTe fp16/bf16-Q + fp8-KV scale-fold SM90 forward (the kernel under test) ----
     cute_output = _cute_dequant_paged_attention(
-        q16, ins["key_cache_fp8"], ins["value_cache_fp8"],
+        q_in, ins["key_cache_fp8"], ins["value_cache_fp8"],
         query_lens, kv_lens, ins["page_table"], k_scale, v_scale,
+    )
+    assert cute_output.dtype == qo_dtype, (
+        f"expected O dtype {qo_dtype} to match Q, got {cute_output.dtype}"
     )
 
     # Report all three divergences (pytest warnings summary; no -s needed).
@@ -541,7 +554,7 @@ def test_gemma4_fp16q_fp8kv_dequant_matches_triton_unified_attention(
         _divergence(triton_output, reference_output),
         _divergence(cute_output, triton_output),
     )
-    case_label = f"{attention_case.id}/{scale_case.id}"
+    case_label = f"{attention_case.id}/{scale_case.id}/{'bf16' if qo_dtype == torch.bfloat16 else 'fp16'}q"
     warnings.warn(
         f"[fp8-kv {case_label}] divergence (FP8 bar atol=rtol={FP8_KV_ATOL}):\n"
         f"    CuteDSL vs Reference [GATED]: max_abs={cr[0]:.4f} max_rel={cr[1]:.3f} mean_abs={cr[2]:.4f}\n"
@@ -552,8 +565,8 @@ def test_gemma4_fp16q_fp8kv_dequant_matches_triton_unified_attention(
 
     # Gates: the kernel must match the fp32 reference AND the production Triton
     # path (vLLM FP8 bar). Triton-vs-Reference is intentionally NOT gated.
-    # check_dtype=False: the dequant kernel's O is fp16 (compute dtype) while the
-    # references are bf16; the values are compared (upcast to fp32 by assert_close),
+    # check_dtype=False: the dequant kernel's O is qo_dtype (fp16 or bf16) while the
+    # references/Triton are bf16; the values are compared (upcast to fp32 by assert_close),
     # not the storage dtype (the fp32 divergence above is the real accuracy gate).
     torch.testing.assert_close(
         cute_output, reference_output, atol=FP8_KV_ATOL, rtol=FP8_KV_RTOL, check_dtype=False
@@ -572,15 +585,19 @@ SPLITKV_SELF_ATOL = SPLITKV_SELF_RTOL = 1e-2
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    "qo_dtype", [torch.float16, torch.bfloat16], ids=["q_fp16", "q_bf16"]
+)
 @torch.inference_mode()
-def test_gemma4_fp16q_fp8kv_dequant_splitkv_matches_reference():
-    """SplitKV variant of the fp16-Q + fp8-KV dequant forward.
+def test_gemma4_fp16q_fp8kv_dequant_splitkv_matches_reference(qo_dtype: torch.dtype):
+    """SplitKV variant of the fp16/bf16-Q + fp8-KV scale-fold forward.
 
     Forces num_splits=2 on the long-KV decode case (gemma4_offline_lockstep_decode,
     kv~=28000 -> enough n-blocks to actually split). This exercises the SplitKV path
     on the dequant kernel, which writes the fp32 partial accumulator (mO is Float32)
-    that the combine kernel merges to the final fp16 O -- the path the hardcoded
+    that the combine kernel merges to the final qo_dtype O -- the path the hardcoded
     `assert mO.element_type == self.dtype` previously made impossible to compile.
+    For bf16 Q this also covers the in-kernel bf16->fp16 narrow under SplitKV.
 
     Gates:
       (a) the SplitKV output is finite;
@@ -603,6 +620,7 @@ def test_gemma4_fp16q_fp8kv_dequant_splitkv_matches_reference():
     kv_lens = ins["kv_lens"]
     k_scale, v_scale = ins["k_scale"], ins["v_scale"]
     q16 = ins["query"].half()
+    q_in = ins["query"].to(qo_dtype)
     q_scale_one = torch.tensor(1.0, device=ins["query"].device, dtype=torch.float32)
 
     # fp32 reference (same builder as the non-split test).
@@ -614,13 +632,14 @@ def test_gemma4_fp16q_fp8kv_dequant_splitkv_matches_reference():
     # The dequant kernel with num_splits=2 (the previously-impossible SplitKV path)
     # and its num_splits=1 counterpart on identical inputs.
     cute_split = _cute_dequant_paged_attention(
-        q16, ins["key_cache_fp8"], ins["value_cache_fp8"],
+        q_in, ins["key_cache_fp8"], ins["value_cache_fp8"],
         query_lens, kv_lens, ins["page_table"], k_scale, v_scale, num_splits=2,
     )
     cute_nosplit = _cute_dequant_paged_attention(
-        q16, ins["key_cache_fp8"], ins["value_cache_fp8"],
+        q_in, ins["key_cache_fp8"], ins["value_cache_fp8"],
         query_lens, kv_lens, ins["page_table"], k_scale, v_scale, num_splits=1,
     )
+    assert cute_split.dtype == qo_dtype and cute_nosplit.dtype == qo_dtype
 
     sr = _divergence(cute_split, reference_output)
     ss = _divergence(cute_split, cute_nosplit)
@@ -869,7 +888,7 @@ def _bench_capturable_fn(backend: str, ins: dict):
     )
 
     # Static, pre-allocated output buffer (stable pointer across replays). The
-    # fp8-dequant path computes in fp16 and writes fp16 O (== compute dtype), so its
+    # fp8 scale-fold path computes in fp16 and writes fp16 O (== compute dtype), so its
     # buffer must be fp16; all other backends write bf16.
     out_buf = torch.empty(
         (total_q, num_query_heads, head_size),
@@ -913,9 +932,9 @@ def _bench_capturable_fn(backend: str, ins: dict):
         return fn, out_buf
 
     if backend == "fa4_dequant":
-        # fp16-Q + fp8-KV dequant forward: fp16 Q + fp8 paged K/V dequantized in-kernel.
+        # fp16-Q + fp8-KV scale-fold forward: fp16 Q + fp8 paged K/V cast in-kernel.
         # Cast to fp16 ONCE here (one-time alloc, stable pointer) -- this capturable
-        # path calls the kernel directly and the dequant path requires fp16 Q.
+        # path calls the kernel directly and the scale-fold path requires fp16 Q.
         q = ins["query"].half()  # fp16 (true precision; not query_fp8)
         k8 = ins["key_cache_fp8"]
         v8 = ins["value_cache_fp8"]

--- a/tests/cute/test_flash_attn_fp8_kv_cache.py
+++ b/tests/cute/test_flash_attn_fp8_kv_cache.py
@@ -1,0 +1,1321 @@
+# Copyright (c) 2026, Tri Dao.
+
+import math
+import sys
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import torch
+from einops import rearrange
+
+_WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
+_VLLM_ROOT = _WORKSPACE_ROOT / "vllm"
+if _VLLM_ROOT.exists() and str(_VLLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_VLLM_ROOT))
+
+try:
+    from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+    from vllm.v1.kv_cache_interface import KVQuantMode
+except ImportError:
+    pytest.skip(
+        "Sibling vLLM repo is required for Triton reference",
+        allow_module_level=True,
+    )
+
+try:
+    from vllm import _custom_ops as vllm_ops
+except Exception:
+    vllm_ops = None
+
+# FA4 CuTe fp16-Q + fp8-KV-cache dequant SM90 forward (the kernel under test).
+# flash_attn/__init__ eagerly imports the compiled FA2 extension (flash_attn_2_cuda);
+# stub it so the pure-Python cute path imports without a built FA2 wheel.
+import types as _types
+
+sys.modules.setdefault("flash_attn_2_cuda", _types.ModuleType("flash_attn_2_cuda"))
+try:
+    from flash_attn.cute.interface import _flash_attn_fwd as _cute_flash_attn_fwd
+    from flash_attn.cute.testing import attention_ref
+except Exception:  # pragma: no cover - exercised only when the cute path is unavailable
+    _cute_flash_attn_fwd = None
+    attention_ref = None
+
+
+# Gemma4 uses softmax scale = 1.0 (gemma4.py self.scaling=1.0; learnable QK-norm handles
+# scaling implicitly), NOT head_dim**-0.5. This is the scale the kernels actually receive
+# from vLLM. The earlier hardcoded head_dim**-0.5 (~0.044 for hd512) under-represented the
+# real score magnitude by ~22x, so the op-level test never exercised the production regime.
+GEMMA4_SOFTMAX_SCALE = 1.0
+# The legacy scale the test previously hardcoded; kept for the scale-contrast diagnostic.
+LEGACY_INVSQRT_SOFTMAX_SCALE = 512 ** -0.5
+
+
+def _cute_dequant_paged_attention(
+    query: torch.Tensor,
+    key_cache_fp8: torch.Tensor,
+    value_cache_fp8: torch.Tensor,
+    query_lens: list[int],
+    kv_lens: list[int],
+    page_table: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    softmax_scale: float = GEMMA4_SOFTMAX_SCALE,
+    num_splits: int = 1,
+) -> torch.Tensor:
+    """Run the SM90 fp16-Q + fp8-KV-cache dequant forward (fp16 Q + fp8 paged K/V -> fp16 O).
+
+    Q is cast to fp16 (the compute dtype; no q_descale). The fp8 K/V are dequantized
+    in-kernel to fp16; per-tensor k/v scales are passed as the descales the kernel
+    folds (k into the score scale, v into the output). This matches the fp16-Q Triton
+    path, which dequantizes the fp8 cache and runs the matmuls in fp16.
+    """
+    query = query.half()
+    num_seqs = len(query_lens)
+    num_kv_heads = key_cache_fp8.shape[2]
+    cu_query_lens = torch.tensor(
+        [0] + query_lens, device=query.device, dtype=torch.int32
+    ).cumsum(dim=0, dtype=torch.int32)
+    kv_lens_t = torch.tensor(kv_lens, device=query.device, dtype=torch.int32)
+    scale_shape = (num_seqs, num_kv_heads)
+    k_descale = torch.full(scale_shape, k_scale.item(), device=query.device, dtype=torch.float32)
+    v_descale = torch.full(scale_shape, v_scale.item(), device=query.device, dtype=torch.float32)
+    out = _cute_flash_attn_fwd(
+        q=query,
+        k=key_cache_fp8,
+        v=value_cache_fp8,
+        softmax_scale=softmax_scale,
+        causal=True,
+        q_descale=None,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_t,
+        max_seqlen_q=max(query_lens),
+        max_seqlen_k=max(kv_lens),
+        page_table=page_table,
+        num_splits=num_splits,
+        fp8_kv_dequant=True,
+    )
+    if isinstance(out, (tuple, list)):
+        out = out[0]
+    return out
+
+
+@dataclass(frozen=True)
+class AttentionCase:
+    id: str
+    num_query_heads: int
+    num_kv_heads: int
+    head_size: int
+    block_size: int
+    query_lens: tuple[int, ...]
+    kv_lens: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class ScaleCase:
+    id: str
+    q: float
+    k: float
+    v: float
+
+
+ATTENTION_CASES = (
+    AttentionCase(
+        id="mini_gemma4",
+        num_query_heads=8, # tp4
+        num_kv_heads=4, # tp4
+        head_size=512,
+        block_size=64,
+        query_lens=(1, 5),
+        kv_lens=(33, 47),
+    ),
+    AttentionCase(
+        id="gemma4_offline_lockstep_decode",
+        num_query_heads=8, # tp4
+        num_kv_heads=4, # tp4
+        head_size=512,
+        block_size=64,
+        query_lens=(1,) * 4,
+        kv_lens=(28000,) * 4,
+    ),
+    AttentionCase(
+        id="gemma4_offline_lockstep_prefill",
+        num_query_heads=8, # tp4
+        num_kv_heads=4, # tp4
+        head_size=512,
+        block_size=64,
+        query_lens=(3000,) * 4,
+        kv_lens=(28000,) * 4,
+    ),
+)
+
+SCALE_CASES = (
+    ScaleCase(id="default_unity_scales", q=1.0, k=1.0, v=1.0),
+    ScaleCase(id="non_default_scales", q=0.5, k=0.5, v=0.25),
+)
+# ---------------------------------------------------------------------------
+# Committed accuracy bars, named so they cannot silently drift (this replaces the
+# old source-reading `test_committed_tolerances_unchanged` guard):
+#   * FP8_KV_*:     the vLLM Triton FP8 bar shared by every FP8 comparison, see
+#     vllm/tests/kernels/attention/test_triton_unified_attention.py.
+#   * REF_XCHECK_*: the tight bar for the dense-vs-paged reference cross-check
+#     (both formulations describe identical K/V, so this is near-exact).
+# ---------------------------------------------------------------------------
+FP8_KV_ATOL = FP8_KV_RTOL = 1.5e-1
+REF_XCHECK_ATOL = REF_XCHECK_RTOL = 1e-2
+
+
+def _quantize_per_tensor_fp8(tensor: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Static per-tensor FP8 quantization, matching vLLM's Q/cache convention."""
+    if vllm_ops is not None:
+        try:
+            flat = tensor.contiguous().reshape(-1, tensor.shape[-1])
+            quantized, _ = vllm_ops.scaled_fp8_quant(
+                flat,
+                scale,
+                group_shape=(-1, -1),
+            )
+            return quantized.reshape(tensor.shape)
+        except Exception:
+            pass
+
+    return (tensor / scale).to(torch.float8_e4m3fn)
+
+
+# Local copy of the paged-KV builder used by tests/cute/test_flash_attn.py
+# (its module-level `_generate_block_kvcache`; it is NOT exported from
+# flash_attn.cute.testing). Inlined so this standalone vLLM/Triton-parity +
+# benchmark harness imports no other flash-attention test module. The first-class
+# FP8 paged correctness test now lives in test_flash_attn.py::test_flash_attn_kvcache.
+def _generate_block_kvcache(
+    seqlen_k, page_size, batch_size, nheads_k, d, dv, device, dtype, dtype_ref
+):
+    num_blocks = math.ceil(seqlen_k / page_size) * batch_size * 3
+    k_cache_paged = (
+        torch.randn(num_blocks, page_size, nheads_k, d, device=device, dtype=dtype_ref)
+        .to(dtype)
+        .to(dtype_ref)
+    )
+    v_cache_paged = (
+        torch.randn(num_blocks, page_size, nheads_k, dv, device=device, dtype=dtype_ref)
+        .to(dtype)
+        .to(dtype_ref)
+    )
+    page_table = rearrange(
+        torch.randperm(num_blocks, dtype=torch.int32, device=device),
+        "(b nblocks) -> b nblocks",
+        b=batch_size,
+    )
+    k_cache = rearrange(
+        k_cache_paged[page_table.flatten()],
+        "(b nblocks) block_size ... -> b (nblocks block_size) ...",
+        b=batch_size,
+    )[:, :seqlen_k]
+    v_cache = rearrange(
+        v_cache_paged[page_table.flatten()],
+        "(b nblocks) block_size ... -> b (nblocks block_size) ...",
+        b=batch_size,
+    )[:, :seqlen_k]
+    return k_cache, v_cache, page_table, k_cache_paged, v_cache_paged, num_blocks
+
+
+def _build_case_inputs(attention_case: "AttentionCase", scale_case: "ScaleCase") -> dict:
+    """Single source of truth for case tensors, shared by the pytest test and the
+    __main__ benchmark.
+
+    Builds the bf16 originals (dense + paged via the shared
+    ``flash_attn.cute.testing._generate_block_kvcache``) plus the per-tensor FP8
+    quantized variants the kernel / Triton / reference consume. Per-sequence
+    lengths are carried as ``kv_lens`` (the kernel's ``seqused_k``); the cache is
+    allocated uniformly at ``max(kv_lens)``.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    torch.random.manual_seed(0)
+
+    num_query_heads = attention_case.num_query_heads
+    num_kv_heads = attention_case.num_kv_heads
+    head_size = attention_case.head_size
+    block_size = attention_case.block_size
+    query_lens = list(attention_case.query_lens)
+    kv_lens = list(attention_case.kv_lens)
+    seqlen_k = max(kv_lens)
+
+    k_cache, v_cache, page_table, k_cache_paged, v_cache_paged, _num_blocks = (
+        _generate_block_kvcache(
+            seqlen_k, block_size, len(kv_lens), num_kv_heads, head_size, head_size,
+            device, dtype, dtype,
+        )
+    )
+
+    query = torch.randn(
+        sum(query_lens), num_query_heads, head_size, device=device, dtype=dtype
+    )
+
+    q_scale = torch.tensor(scale_case.q, device=device, dtype=torch.float32)
+    k_scale = torch.tensor(scale_case.k, device=device, dtype=torch.float32)
+    v_scale = torch.tensor(scale_case.v, device=device, dtype=torch.float32)
+
+    query_fp8 = _quantize_per_tensor_fp8(query, q_scale)
+    # Paged FP8 (kernel + Triton index these through the page table).
+    key_cache_fp8 = _quantize_per_tensor_fp8(k_cache_paged, k_scale)
+    value_cache_fp8 = _quantize_per_tensor_fp8(v_cache_paged, v_scale)
+    # Dense FP8 (the reference reads these directly); identical bytes to the paged
+    # buffers gathered through the page table, since quantization is elementwise.
+    key_dense_fp8 = _quantize_per_tensor_fp8(k_cache, k_scale)
+    value_dense_fp8 = _quantize_per_tensor_fp8(v_cache, v_scale)
+
+    # Dense bf16 caches were only needed to derive the dense FP8 reference inputs.
+    del k_cache, v_cache
+    torch.cuda.empty_cache()
+
+    return {
+        "query_lens": query_lens,
+        "kv_lens": kv_lens,
+        "page_table": page_table,
+        "head_size": head_size,
+        "num_query_heads": num_query_heads,
+        "num_kv_heads": num_kv_heads,
+        "query": query,
+        "key_cache": k_cache_paged,
+        "value_cache": v_cache_paged,
+        "query_fp8": query_fp8,
+        "key_cache_fp8": key_cache_fp8,
+        "value_cache_fp8": value_cache_fp8,
+        "key_dense_fp8": key_dense_fp8,
+        "value_dense_fp8": value_dense_fp8,
+        "q_scale": q_scale,
+        "k_scale": k_scale,
+        "v_scale": v_scale,
+    }
+
+
+def _reference_paged_fp8_attention(
+    query_fp8: torch.Tensor,
+    key_dense_fp8: torch.Tensor,
+    value_dense_fp8: torch.Tensor,
+    query_lens: list[int],
+    kv_lens: list[int],
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    softmax_scale: float = GEMMA4_SOFTMAX_SCALE,
+) -> torch.Tensor:
+    """Per-sequence FP8 reference via the shared ``attention_ref``.
+
+    The FP8 inputs are handed over as a bf16 *container* (so attention_ref's final
+    ``.to(dtype_og)`` does not re-quantize the output) together with per-tensor
+    descales; attention_ref upcasts to fp32 and applies the descales, i.e.
+    dequantize-then-attend. This replaces the hand-rolled causal/paged references.
+    """
+    num_kv_heads = key_dense_fp8.shape[2]
+    device = query_fp8.device
+    # attention_ref applies 1/sqrt(d) internally (after q_descale). Fold the target
+    # softmax_scale into q_descale so the reference uses the SAME effective scale as the
+    # kernels under test: q_descale_eff = q_scale * softmax_scale * sqrt(d). At the legacy
+    # softmax_scale = 1/sqrt(d) this reduces to q_scale (back-compatible).
+    _scale_fold = softmax_scale * (query_fp8.shape[-1] ** 0.5)
+    q_desc = torch.full(
+        (1, num_kv_heads), float(q_scale) * _scale_fold, device=device, dtype=torch.float32
+    )
+    k_desc = torch.full((1, num_kv_heads), float(k_scale), device=device, dtype=torch.float32)
+    v_desc = torch.full((1, num_kv_heads), float(v_scale), device=device, dtype=torch.float32)
+
+    outputs: list[torch.Tensor] = []
+    q_start = 0
+    for batch_idx, (query_len, kv_len) in enumerate(zip(query_lens, kv_lens)):
+        out_i, _ = attention_ref(
+            query_fp8[q_start : q_start + query_len][None].to(torch.bfloat16),
+            key_dense_fp8[batch_idx, :kv_len][None].to(torch.bfloat16),
+            value_dense_fp8[batch_idx, :kv_len][None].to(torch.bfloat16),
+            causal=True,
+            upcast=True,
+            q_descale=q_desc,
+            k_descale=k_desc,
+            v_descale=v_desc,
+        )
+        outputs.append(out_i[0])
+        q_start += query_len
+    return torch.cat(outputs, dim=0)
+
+
+def _gather_paged_to_dense_fp8(
+    key_cache_fp8: torch.Tensor,
+    value_cache_fp8: torch.Tensor,
+    page_table: torch.Tensor,
+    kv_lens: list[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather the paged FP8 buffers the kernel indexes back into dense
+    ``(batch, max(kv_lens), num_kv_heads, head_size)`` views.
+
+    Lets the reference run on the EXACT bytes the kernel reads, so the dense-vs-
+    paged cross-check validates the page table / paged construction itself.
+    """
+    block_size = key_cache_fp8.shape[1]
+    num_kv_heads = key_cache_fp8.shape[2]
+    head_size = key_cache_fp8.shape[3]
+    head_size_v = value_cache_fp8.shape[3]
+    max_kv_len = max(kv_lens)
+    key_dense = key_cache_fp8.new_zeros((len(kv_lens), max_kv_len, num_kv_heads, head_size))
+    value_dense = value_cache_fp8.new_zeros(
+        (len(kv_lens), max_kv_len, num_kv_heads, head_size_v)
+    )
+    for batch_idx, kv_len in enumerate(kv_lens):
+        num_kv_blocks = (kv_len + block_size - 1) // block_size
+        blocks = page_table[batch_idx, :num_kv_blocks].long()
+        key_dense[batch_idx, :kv_len] = key_cache_fp8[blocks].reshape(
+            -1, num_kv_heads, head_size
+        )[:kv_len]
+        value_dense[batch_idx, :kv_len] = value_cache_fp8[blocks].reshape(
+            -1, num_kv_heads, head_size_v
+        )[:kv_len]
+    return key_dense, value_dense
+
+
+def _divergence(actual: torch.Tensor, expected: torch.Tensor) -> tuple[float, float, float]:
+    """(max_abs, max_rel, mean_abs) of actual vs expected, computed in fp32."""
+    a, e = actual.float(), expected.float()
+    diff = (a - e).abs()
+    max_abs = diff.max().item()
+    max_rel = (diff / e.abs().clamp_min(1e-6)).max().item()
+    mean_abs = diff.mean().item()
+    return max_abs, max_rel, mean_abs
+
+
+def _triton_unified_attention_ref(
+    query_fp8: torch.Tensor,
+    key_cache_fp8: torch.Tensor,
+    value_cache_fp8: torch.Tensor,
+    query_lens: list[int],
+    kv_lens: list[int],
+    page_table: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    output_dtype: torch.dtype,
+    softmax_scale: float = GEMMA4_SOFTMAX_SCALE,
+) -> torch.Tensor:
+    """Call vLLM's Triton FP8 Q + FP8 KV-cache path with expected shapes.
+
+    Shapes:
+      query_fp8: (sum(query_lens), num_query_heads, head_size)
+      key_cache_fp8/value_cache_fp8:
+        (num_blocks, block_size, num_kv_heads, head_size)
+      page_table: (num_seqs, max_num_blocks_per_seq)
+      q_scale/k_scale/v_scale: scalar per-tensor FP32 scales in this test
+      q_descale: scalar
+      k_descale/v_descale: (num_seqs, num_kv_heads)
+
+    vLLM's TritonAttentionImpl gets key/value cache by unbinding an outer
+    kv_cache shaped (num_blocks, 2, block_size, num_kv_heads, head_size).
+    For FP8_PER_TENSOR on CUDA, vLLM also statically quantizes Q and passes
+    scalar layer._q_scale plus expanded layer._k_scale/layer._v_scale.
+    """
+    num_seqs = len(query_lens)
+    num_query_heads = query_fp8.shape[1]
+    num_kv_heads = key_cache_fp8.shape[2]
+    cu_query_lens = torch.tensor(
+        [0] + query_lens, device=query_fp8.device, dtype=torch.int32
+    ).cumsum(dim=0, dtype=torch.int32)
+    kv_lens_t = torch.tensor(kv_lens, device=query_fp8.device, dtype=torch.int32)
+    scale_shape = (num_seqs, num_kv_heads)
+    k_descale = torch.full(
+        scale_shape, k_scale.item(), device=query_fp8.device, dtype=torch.float32
+    )
+    v_descale = torch.full(
+        scale_shape, v_scale.item(), device=query_fp8.device, dtype=torch.float32
+    )
+    out = torch.empty(
+        query_fp8.shape,
+        device=query_fp8.device,
+        dtype=output_dtype,
+    )
+
+    unified_attention(
+        q=query_fp8,
+        k=key_cache_fp8,
+        v=value_cache_fp8,
+        out=out,
+        cu_seqlens_q=cu_query_lens,
+        max_seqlen_q=max(query_lens),
+        seqused_k=kv_lens_t,
+        max_seqlen_k=max(kv_lens),
+        softmax_scale=softmax_scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=page_table,
+        softcap=0,
+        q_descale=q_scale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        kv_quant_mode=KVQuantMode.FP8_PER_TENSOR,
+    )
+    assert out.shape == (sum(query_lens), num_query_heads, query_fp8.shape[-1])
+    return out
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    "attention_case", ATTENTION_CASES, ids=lambda attention_case: attention_case.id
+)
+@pytest.mark.parametrize(
+    "scale_case", SCALE_CASES, ids=lambda scale_case: scale_case.id
+)
+@torch.inference_mode()
+def test_gemma4_fp16q_fp8kv_dequant_matches_triton_unified_attention(
+    attention_case: AttentionCase,
+    scale_case: ScaleCase,
+):
+    """Gemma4 full-attention cases: fp16-Q + fp8-KV-cache dequant forward, fp16 Q
+    with per-tensor FP8 paged KV cache dequantized in-kernel to fp16 (the consumer
+    MMA warpgroups do the fp8->fp16 dequant; O is fp16).
+
+    Q is true fp16 (no q_descale); only K/V are fp8. This is the production
+    fp16-Q + fp8-KV regime, and the fp16-Q Triton path dequantizes the cache and
+    runs the matmuls in fp16 -- a faithful, apples-to-apples oracle (unlike fp8-Q
+    which would run fp8 MMA). Reports three divergences each run: CuteDSL-vs-
+    Reference, Triton-vs-Reference, and CuteDSL-vs-Triton. The two CuteDSL
+    comparisons are GATED at the vLLM bar (FP8_KV_*); Triton-vs-Reference is info.
+    """
+    if _cute_flash_attn_fwd is None:
+        pytest.skip("FA4 CuTe interface is not importable in this environment")
+
+    # The dequant path now folds the per-(batch, kv_head) k/v descales: q*k into the
+    # per-tile softmax score scale and v into the final O scale (the dequant cast
+    # stays a pure fp8->fp16 cast). So non-unity k/v scales match too.
+
+    ins = _build_case_inputs(attention_case, scale_case)
+    query_lens = ins["query_lens"]
+    kv_lens = ins["kv_lens"]
+    q_scale, k_scale, v_scale = ins["q_scale"], ins["k_scale"], ins["v_scale"]
+    # Compute dtype is fp16: feed fp16 Q to the kernel, the Triton oracle, and the
+    # reference (the reference upcasts to f32, so its result is ~unchanged). Using the
+    # same fp16 tensor for both reference calls keeps the paging cross-check exact.
+    q16 = ins["query"].half()
+    # fp16 Q is true precision -> q_descale is identity (1.0) in the reference.
+    q_scale_one = torch.tensor(1.0, device=ins["query"].device, dtype=torch.float32)
+
+    # Reference on fp16 Q + dense FP8 K/V (attention_ref dequantizes K/V via descales).
+    reference_output = _reference_paged_fp8_attention(
+        q16, ins["key_dense_fp8"], ins["value_dense_fp8"],
+        query_lens, kv_lens, q_scale_one, k_scale, v_scale,
+    )
+    # Cross-check: the paged buffers the kernel indexes gather back to the same
+    # dense K/V (guards the page table / paged construction). Near-exact bar.
+    key_gathered, value_gathered = _gather_paged_to_dense_fp8(
+        ins["key_cache_fp8"], ins["value_cache_fp8"], ins["page_table"], kv_lens,
+    )
+    paged_reference_output = _reference_paged_fp8_attention(
+        q16, key_gathered, value_gathered,
+        query_lens, kv_lens, q_scale_one, k_scale, v_scale,
+    )
+    torch.testing.assert_close(
+        reference_output, paged_reference_output,
+        atol=REF_XCHECK_ATOL, rtol=REF_XCHECK_RTOL,
+    )
+
+    # Sanity: per-tensor FP8 quantization actually perturbed the KV cache.
+    key_dequant = ins["key_cache_fp8"].to(torch.bfloat16).float() * k_scale
+    assert (key_dequant - ins["key_cache"].float()).abs().max() > 0
+
+    # fp16-Q Triton: Q_IS_FP8 is False, so it dequantizes the fp8 cache to fp16 and
+    # runs fp16 matmuls (the same computation as the kernel under test).
+    triton_output = _triton_unified_attention_ref(
+        q16, ins["key_cache_fp8"], ins["value_cache_fp8"],
+        query_lens, kv_lens, ins["page_table"], q_scale, k_scale, v_scale,
+        torch.bfloat16,
+    )
+    # ---- FA4 CuTe fp16-Q + fp8-KV dequant SM90 forward (the kernel under test) ----
+    cute_output = _cute_dequant_paged_attention(
+        q16, ins["key_cache_fp8"], ins["value_cache_fp8"],
+        query_lens, kv_lens, ins["page_table"], k_scale, v_scale,
+    )
+
+    # Report all three divergences (pytest warnings summary; no -s needed).
+    # Emitted BEFORE the gates so the numbers show even when a gate fails.
+    cr, tr, ct = (
+        _divergence(cute_output, reference_output),
+        _divergence(triton_output, reference_output),
+        _divergence(cute_output, triton_output),
+    )
+    case_label = f"{attention_case.id}/{scale_case.id}"
+    warnings.warn(
+        f"[fp8-kv {case_label}] divergence (FP8 bar atol=rtol={FP8_KV_ATOL}):\n"
+        f"    CuteDSL vs Reference [GATED]: max_abs={cr[0]:.4f} max_rel={cr[1]:.3f} mean_abs={cr[2]:.4f}\n"
+        f"    Triton  vs Reference [info ]: max_abs={tr[0]:.4f} max_rel={tr[1]:.3f} mean_abs={tr[2]:.4f}\n"
+        f"    CuteDSL vs Triton    [GATED]: max_abs={ct[0]:.4f} max_rel={ct[1]:.3f} mean_abs={ct[2]:.4f}",
+        stacklevel=2,
+    )
+
+    # Gates: the kernel must match the fp32 reference AND the production Triton
+    # path (vLLM FP8 bar). Triton-vs-Reference is intentionally NOT gated.
+    # check_dtype=False: the dequant kernel's O is fp16 (compute dtype) while the
+    # references are bf16; the values are compared (upcast to fp32 by assert_close),
+    # not the storage dtype (the fp32 divergence above is the real accuracy gate).
+    torch.testing.assert_close(
+        cute_output, reference_output, atol=FP8_KV_ATOL, rtol=FP8_KV_RTOL, check_dtype=False
+    )
+    torch.testing.assert_close(
+        cute_output, triton_output, atol=FP8_KV_ATOL, rtol=FP8_KV_RTOL, check_dtype=False
+    )
+
+
+# SplitKV bar for the dequant kernel vs its own num_splits=1 output. SplitKV is a
+# reduction reordering of the SAME math (the combine kernel merges the fp32 partials),
+# so the two should agree far tighter than the FP8 oracle bar -- but the partials are
+# stored/combined in fp32 and the non-split path accumulates in-register, so allow a
+# small fp32-combine slack rather than near-exact.
+SPLITKV_SELF_ATOL = SPLITKV_SELF_RTOL = 1e-2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@torch.inference_mode()
+def test_gemma4_fp16q_fp8kv_dequant_splitkv_matches_reference():
+    """SplitKV variant of the fp16-Q + fp8-KV dequant forward.
+
+    Forces num_splits=2 on the long-KV decode case (gemma4_offline_lockstep_decode,
+    kv~=28000 -> enough n-blocks to actually split). This exercises the SplitKV path
+    on the dequant kernel, which writes the fp32 partial accumulator (mO is Float32)
+    that the combine kernel merges to the final fp16 O -- the path the hardcoded
+    `assert mO.element_type == self.dtype` previously made impossible to compile.
+
+    Gates:
+      (a) the SplitKV output is finite;
+      (b) it matches the SAME fp32 reference at the SAME FP8 bar (FP8_KV_*) as the
+          non-split test;
+      (c) it is close to the num_splits=1 cute output (SplitKV is just a reduction
+          reordering of identical math).
+    """
+    if _cute_flash_attn_fwd is None:
+        pytest.skip("FA4 CuTe interface is not importable in this environment")
+
+    # Long-KV decode case forces multiple n-blocks per sequence so num_splits=2 splits.
+    attention_case = next(
+        c for c in ATTENTION_CASES if c.id == "gemma4_offline_lockstep_decode"
+    )
+    scale_case = SCALE_CASES[0]  # default unity scales (matches the non-split smoke)
+
+    ins = _build_case_inputs(attention_case, scale_case)
+    query_lens = ins["query_lens"]
+    kv_lens = ins["kv_lens"]
+    k_scale, v_scale = ins["k_scale"], ins["v_scale"]
+    q16 = ins["query"].half()
+    q_scale_one = torch.tensor(1.0, device=ins["query"].device, dtype=torch.float32)
+
+    # fp32 reference (same builder as the non-split test).
+    reference_output = _reference_paged_fp8_attention(
+        q16, ins["key_dense_fp8"], ins["value_dense_fp8"],
+        query_lens, kv_lens, q_scale_one, k_scale, v_scale,
+    )
+
+    # The dequant kernel with num_splits=2 (the previously-impossible SplitKV path)
+    # and its num_splits=1 counterpart on identical inputs.
+    cute_split = _cute_dequant_paged_attention(
+        q16, ins["key_cache_fp8"], ins["value_cache_fp8"],
+        query_lens, kv_lens, ins["page_table"], k_scale, v_scale, num_splits=2,
+    )
+    cute_nosplit = _cute_dequant_paged_attention(
+        q16, ins["key_cache_fp8"], ins["value_cache_fp8"],
+        query_lens, kv_lens, ins["page_table"], k_scale, v_scale, num_splits=1,
+    )
+
+    sr = _divergence(cute_split, reference_output)
+    ss = _divergence(cute_split, cute_nosplit)
+    warnings.warn(
+        f"[fp8-kv splitkv {attention_case.id}/{scale_case.id}] divergence "
+        f"(FP8 bar atol=rtol={FP8_KV_ATOL}, self bar atol=rtol={SPLITKV_SELF_ATOL}):\n"
+        f"    SplitKV vs Reference     [GATED]: max_abs={sr[0]:.4f} max_rel={sr[1]:.3f} mean_abs={sr[2]:.4f}\n"
+        f"    SplitKV vs num_splits=1  [GATED]: max_abs={ss[0]:.4f} max_rel={ss[1]:.3f} mean_abs={ss[2]:.4f}",
+        stacklevel=2,
+    )
+
+    # (a) finite.
+    assert torch.isfinite(cute_split.float()).all(), "non-finite values in SplitKV output"
+    # (b) matches the fp32 reference at the SAME existing FP8 bar.
+    torch.testing.assert_close(
+        cute_split, reference_output, atol=FP8_KV_ATOL, rtol=FP8_KV_RTOL, check_dtype=False
+    )
+    # (c) close to the num_splits=1 cute output (same math, reduction reordered).
+    torch.testing.assert_close(
+        cute_split, cute_nosplit, atol=SPLITKV_SELF_ATOL, rtol=SPLITKV_SELF_RTOL,
+        check_dtype=False,
+    )
+
+
+# ===========================================================================
+# Lightweight perf benchmark (NOT collected by pytest: not a test_* function,
+# lives behind __main__). Shares `_build_case_inputs` with the pytest test above
+# so the benchmark and the test exercise identical case construction.
+#
+# Compares these backends on the gemma4 decode + prefill cases:
+#   * FA4-dequant  : our SM90 fp16-Q + fp8-KV in-kernel-dequant forward
+#   * Triton-fp16q : vLLM unified_attention, fp16 Q + fp8 KV (the apples-to-apples oracle)
+#   * Triton-fp8   : vLLM unified_attention FP8_PER_TENSOR (the customer backend)
+#   * FA4-bf16     : the existing SM90 bf16 paged forward (the bf16 baseline)
+#
+# Run:
+#   FLASH_ATTENTION_FAKE_TENSOR=0 FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 \
+#       python tests/cute/test_flash_attn_fp8_kv_cache.py
+# ===========================================================================
+
+
+def _bench_fa4_bf16_paged(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    query_lens: list[int],
+    kv_lens: list[int],
+    page_table: torch.Tensor,
+) -> torch.Tensor:
+    """Run the EXISTING SM90 bf16 paged forward on the un-quantized bf16 inputs.
+
+    Mirrors the arg construction in `_cute_dequant_paged_attention` but with the bf16
+    originals and NO descales -- this is the existing bf16 SM90 paged forward, the
+    baseline that the FP8 path is meant to beat.
+    """
+    cu_query_lens = torch.tensor(
+        [0] + query_lens, device=query.device, dtype=torch.int32
+    ).cumsum(dim=0, dtype=torch.int32)
+    kv_lens_t = torch.tensor(kv_lens, device=query.device, dtype=torch.int32)
+    out = _cute_flash_attn_fwd(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        softmax_scale=query.shape[-1] ** -0.5,
+        causal=True,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_t,
+        max_seqlen_q=max(query_lens),
+        max_seqlen_k=max(kv_lens),
+        page_table=page_table,
+    )
+    if isinstance(out, (tuple, list)):
+        out = out[0]
+    return out
+
+
+def _bench_make_fn(backend: str, ins: dict):
+    """Return a zero-arg callable that runs one backend on the prebuilt inputs."""
+    ql = ins["query_lens"]
+    kl = ins["kv_lens"]
+    pt = ins["page_table"]
+    if backend == "fa4_dequant":
+        return lambda: _cute_dequant_paged_attention(
+            ins["query"], ins["key_cache_fp8"], ins["value_cache_fp8"],
+            ql, kl, pt, ins["k_scale"], ins["v_scale"],
+        )
+    if backend == "triton_fp16q":
+        # fp16-Q Triton: dequantizes the fp8 cache to fp16 and runs fp16 matmuls (the
+        # same computation as fa4_dequant) -- the apples-to-apples production oracle.
+        return lambda: _triton_unified_attention_ref(
+            ins["query"].half(), ins["key_cache_fp8"], ins["value_cache_fp8"],
+            ql, kl, pt, ins["q_scale"], ins["k_scale"], ins["v_scale"],
+            output_dtype=torch.bfloat16,
+        )
+    if backend == "triton_fp8":
+        return lambda: _triton_unified_attention_ref(
+            ins["query_fp8"], ins["key_cache_fp8"], ins["value_cache_fp8"],
+            ql, kl, pt, ins["q_scale"], ins["k_scale"], ins["v_scale"],
+            output_dtype=torch.bfloat16,
+        )
+    if backend == "fa4_bf16":
+        return lambda: _bench_fa4_bf16_paged(
+            ins["query"], ins["key_cache"], ins["value_cache"], ql, kl, pt,
+        )
+    raise ValueError(f"unknown backend {backend!r}")
+
+
+def _bench_correctness_guard(out: torch.Tensor, ins: dict) -> None:
+    """Correctness-before-timing: assert shape/dtype/finiteness so we never
+    benchmark a NaN or a broken config (kernels are already test-validated)."""
+    expected_shape = (sum(ins["query_lens"]), ins["num_query_heads"], ins["head_size"])
+    assert tuple(out.shape) == expected_shape, (
+        f"unexpected output shape {tuple(out.shape)} != {expected_shape}"
+    )
+    assert out.dtype in (torch.bfloat16, torch.float16), (
+        f"expected bf16/fp16 output, got {out.dtype}"
+    )
+    assert torch.isfinite(out.float()).all(), "non-finite values in output"
+
+
+def _bench_flops_bytes(ins: dict):
+    """FLOPs and HBM bytes summed per-sequence over the uniform case (batch=1 per
+    seq). Uses bench_utils.flops / bandwidth_fwd_bytes. fp8 K/V => 1 byte; the
+    FA4-bf16 baseline reads bf16 K/V => 2 bytes. Q/O are bf16-ish either way but
+    bandwidth_fwd_bytes uses a single dtype_bytes; we report decode bytes at the
+    backend's KV dtype below by passing the right dtype_bytes per backend.
+
+    Returns (total_flops, fp8_bytes, bf16_bytes).
+    """
+    from flash_attn.cute.bench_utils import flops, bandwidth_fwd_bytes
+
+    nheads = ins["num_query_heads"]
+    nheads_kv = ins["num_kv_heads"]
+    hd = ins["head_size"]
+    total_flops = 0.0
+    fp8_bytes = 0.0
+    bf16_bytes = 0.0
+    for sq, sk in zip(ins["query_lens"], ins["kv_lens"]):
+        total_flops += flops(
+            batch=1, nheads=nheads, seqlen_q=sq, seqlen_k=sk,
+            headdim=hd, headdim_v=hd, causal=True,
+        )
+        fp8_bytes += bandwidth_fwd_bytes(
+            batch=1, nheads=nheads, nheads_kv=nheads_kv, seqlen_q=sq, seqlen_k=sk,
+            headdim=hd, headdim_v=hd, dtype_bytes=1,
+        )
+        bf16_bytes += bandwidth_fwd_bytes(
+            batch=1, nheads=nheads, nheads_kv=nheads_kv, seqlen_q=sq, seqlen_k=sk,
+            headdim=hd, headdim_v=hd, dtype_bytes=2,
+        )
+    return total_flops, fp8_bytes, bf16_bytes
+
+
+def _bench_time_one(fn, *, is_decode: bool, cudagraph: str, warmup: int, rep: int):
+    """Time a single backend closure. Returns (median_ms, method).
+
+    decode + cudagraph in {auto,on}: try do_bench_cudagraph on a fresh stream
+    (hopper/benchmark_mla_decode.py idiom); on ANY exception fall back to
+    do_bench. prefill (or cudagraph==off): plain do_bench.
+
+    NOTE on units: triton.do_bench / do_bench_cudagraph build `times` from
+    cuda.Event.elapsed_time(), which returns MILLISECONDS. (The repo's
+    benchmark_mla_decode.py multiplies the result by 1e3 to print microseconds,
+    confirming the return value is ms.) We therefore report the median in ms
+    directly with NO 1e-3 rescale. We pass return_mode="median" for the median.
+    """
+    from triton.testing import do_bench, do_bench_cudagraph
+
+    use_cg = is_decode and cudagraph in ("auto", "on")
+    if use_cg:
+        try:
+            torch.cuda.synchronize()
+            with torch.cuda.stream(torch.cuda.Stream()):
+                med_ms = do_bench_cudagraph(fn, rep=rep, return_mode="median")
+            return float(med_ms), "cudagraph"
+        except Exception as exc:  # noqa: BLE001 -- graceful fallback by design
+            if cudagraph == "on":
+                # Explicit on: surface why it could not capture, but still fall back.
+                print(f"        [cudagraph capture failed: {type(exc).__name__}: {exc}]")
+    med_ms = do_bench(fn, warmup=warmup, rep=rep, return_mode="median")
+    return float(med_ms), "do_bench"
+
+
+# ---------------------------------------------------------------------------
+# CUDA-graph-capturable decode timing (additive; decode-cudagraph path only).
+#
+# The existing decode closures (`_cute_dequant_paged_attention`,
+# `_triton_unified_attention_ref`, `_bench_fa4_bf16_paged`) rebuild device args on
+# EVERY call -- `torch.tensor([0]+query_lens).cumsum(...)`, `torch.tensor(kv_lens)`,
+# `torch.full(...).item()` k/v descales (a host-device sync!), and Triton also
+# `torch.empty(...)` for `out` per call. Host syncs + per-call allocations abort
+# the capture, so `do_bench_cudagraph` recorded an EMPTY graph and silently fell
+# back to launch-overhead-inclusive `do_bench` timing.
+#
+# `_bench_capturable_fn` hoists ALL device-arg construction (the `.item()`,
+# `torch.tensor`, `torch.full`, `torch.empty`, and the q_descale expansion) OUT of
+# the timed closure so the closure is pure-launch (in-place into a pre-allocated
+# `out_buf`). `_bench_time_cudagraph` then captures + times via `do_bench_cudagraph`.
+# These are used ONLY for the decode case; prefill keeps plain `do_bench`.
+# ---------------------------------------------------------------------------
+
+
+def _bench_capturable_fn(backend: str, ins: dict):
+    """Build ALL device args ONCE and return a pure-launch zero-arg closure.
+
+    Every host-device sync (`.item()`) and every allocation (`torch.tensor`,
+    `torch.full`, `torch.empty`, the `q_descale` expand) happens HERE, before
+    capture -- never inside the returned closure. The closure runs in-place into
+    a pre-allocated `out_buf` so the output pointer is stable across replays.
+
+    Returns (fn, out_buf). `out_buf` is the static output the caller clones.
+    """
+    device = torch.device("cuda")
+    query_lens = ins["query_lens"]
+    kv_lens = ins["kv_lens"]
+    pt = ins["page_table"]
+    num_seqs = len(query_lens)
+    num_kv_heads = ins["num_kv_heads"]
+    num_query_heads = ins["num_query_heads"]
+    head_size = ins["head_size"]
+    total_q = sum(query_lens)
+
+    # --- one-time device-arg construction (NO per-call host work) ---
+    cu = torch.tensor(
+        [0] + list(query_lens), device=device, dtype=torch.int32
+    ).cumsum(dim=0, dtype=torch.int32)
+    seqused = torch.tensor(list(kv_lens), device=device, dtype=torch.int32)
+    mq = int(max(query_lens))
+    mk = int(max(kv_lens))
+
+    q_scale = ins["q_scale"]
+    k_scale = ins["k_scale"]
+    v_scale = ins["v_scale"]
+    # k/v descales as (num_seqs, num_kv_heads) f32; do the .item() ONCE here.
+    k_descale = torch.full(
+        (num_seqs, num_kv_heads), k_scale.item(), device=device, dtype=torch.float32
+    )
+    v_descale = torch.full(
+        (num_seqs, num_kv_heads), v_scale.item(), device=device, dtype=torch.float32
+    )
+    # Pre-expand q_descale to (num_seqs, num_kv_heads) f32 so interface.py's per-call
+    # `q_descale.reshape(1).expand(...).contiguous()` (only fires when numel == 1) is
+    # SKIPPED -- otherwise a fresh GPU tensor is allocated inside every replay.
+    q_descale_exp = (
+        q_scale.reshape(1).expand(num_seqs, num_kv_heads).contiguous().float()
+    )
+
+    # Static, pre-allocated output buffer (stable pointer across replays). The
+    # fp8-dequant path computes in fp16 and writes fp16 O (== compute dtype), so its
+    # buffer must be fp16; all other backends write bf16.
+    out_buf = torch.empty(
+        (total_q, num_query_heads, head_size),
+        dtype=torch.float16 if backend == "fa4_dequant" else torch.bfloat16,
+        device=device,
+    )
+    softmax_scale = head_size ** -0.5
+
+    if backend == "fa4_bf16":
+        q = ins["query"]
+        k = ins["key_cache"]
+        v = ins["value_cache"]
+
+        def fn():
+            _cute_flash_attn_fwd(
+                q=q, k=k, v=v,
+                softmax_scale=softmax_scale, causal=True,
+                cu_seqlens_q=cu, seqused_k=seqused,
+                max_seqlen_q=mq, max_seqlen_k=mk,
+                page_table=pt, out=out_buf,
+            )
+
+        return fn, out_buf
+
+    if backend == "triton_fp8":
+        q8 = ins["query_fp8"]
+        k8 = ins["key_cache_fp8"]
+        v8 = ins["value_cache_fp8"]
+
+        def fn():
+            unified_attention(
+                q=q8, k=k8, v=v8, out=out_buf,
+                cu_seqlens_q=cu, max_seqlen_q=mq,
+                seqused_k=seqused, max_seqlen_k=mk,
+                softmax_scale=softmax_scale, causal=True,
+                window_size=(-1, -1), block_table=pt, softcap=0,
+                q_descale=q_descale_exp, k_descale=k_descale, v_descale=v_descale,
+                kv_quant_mode=KVQuantMode.FP8_PER_TENSOR,
+            )
+
+        return fn, out_buf
+
+    if backend == "fa4_dequant":
+        # fp16-Q + fp8-KV dequant forward: fp16 Q + fp8 paged K/V dequantized in-kernel.
+        # Cast to fp16 ONCE here (one-time alloc, stable pointer) -- this capturable
+        # path calls the kernel directly and the dequant path requires fp16 Q.
+        q = ins["query"].half()  # fp16 (true precision; not query_fp8)
+        k8 = ins["key_cache_fp8"]
+        v8 = ins["value_cache_fp8"]
+        # Pre-built identity q_descale: fp16 Q needs no q-descale, and a STATIC tensor
+        # avoids interface.py materializing torch.ones(...) inside every graph replay
+        # (which would break cudagraph capture).
+        q_descale_id = torch.ones(
+            (num_seqs, num_kv_heads), device=device, dtype=torch.float32
+        )
+
+        def fn():
+            _cute_flash_attn_fwd(
+                q=q, k=k8, v=v8,
+                softmax_scale=softmax_scale, causal=True,
+                q_descale=q_descale_id, k_descale=k_descale, v_descale=v_descale,
+                cu_seqlens_q=cu, seqused_k=seqused,
+                max_seqlen_q=mq, max_seqlen_k=mk,
+                page_table=pt, out=out_buf, fp8_kv_dequant=True,
+            )
+
+        return fn, out_buf
+
+    if backend == "triton_fp16q":
+        # fp16-Q Triton: Q_IS_FP8 is False -> dequantizes the fp8 cache to fp16 and runs
+        # fp16 matmuls (the apples-to-apples oracle for fa4_dequant). q_descale is unused here.
+        q = ins["query"].half()  # fp16
+        k8 = ins["key_cache_fp8"]
+        v8 = ins["value_cache_fp8"]
+
+        def fn():
+            unified_attention(
+                q=q, k=k8, v=v8, out=out_buf,
+                cu_seqlens_q=cu, max_seqlen_q=mq,
+                seqused_k=seqused, max_seqlen_k=mk,
+                softmax_scale=softmax_scale, causal=True,
+                window_size=(-1, -1), block_table=pt, softcap=0,
+                q_descale=q_descale_exp, k_descale=k_descale, v_descale=v_descale,
+                kv_quant_mode=KVQuantMode.FP8_PER_TENSOR,
+            )
+
+        return fn, out_buf
+
+    raise ValueError(f"unknown backend {backend!r}")
+
+
+def _bench_time_cudagraph(fn, *, rep: int):
+    """CUDA-graph capture + replay timing via triton's `do_bench_cudagraph`.
+
+    Returns (median_ms, method). The closure must be pure-launch (every device-arg
+    allocation + `.item()` sync hoisted out by `_bench_capturable_fn`) so the
+    capture is NON-empty. We warm on a side stream first (FA4 JIT-compile + Triton
+    autotune settle OFF the capture path), then let `do_bench_cudagraph` capture +
+    time on a fresh stream (the hopper/benchmark_mla_decode.py idiom). On ANY
+    capture failure we fall back to `do_bench` and tag the method, so the table
+    never silently mixes capture results with launch-overhead-inclusive numbers.
+    """
+    from triton.testing import do_bench, do_bench_cudagraph
+
+    try:
+        torch.cuda.synchronize()
+        # Warm on a side stream -- triggers FA4 JIT + Triton autotune off the
+        # capture stream (so neither happens DURING capture).
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                fn()
+        torch.cuda.current_stream().wait_stream(s)
+        torch.cuda.synchronize()
+        with torch.cuda.stream(torch.cuda.Stream()):
+            med_ms = do_bench_cudagraph(fn, rep=rep, return_mode="median")
+        return float(med_ms), "cudagraph"
+    except Exception as exc:  # noqa: BLE001 -- graceful fallback by design
+        print(f"        [cudagraph capture failed: {type(exc).__name__}: {exc}]")
+        med_ms = do_bench(fn, rep=rep, return_mode="median")
+        return float(med_ms), "do_bench"
+
+
+def _bench_run(args) -> None:
+    import time
+
+    if _cute_flash_attn_fwd is None:
+        print("FA4 CuTe interface is not importable; cannot benchmark. Aborting.")
+        return
+
+    # Pick a free GPU if the caller did not pin one.
+    if "CUDA_VISIBLE_DEVICES" not in os.environ:
+        try:
+            import subprocess
+            out = subprocess.check_output(
+                ["nvidia-smi", "--query-gpu=index,memory.used",
+                 "--format=csv,noheader,nounits"],
+                text=True,
+            )
+            rows = [r.split(",") for r in out.strip().splitlines()]
+            free = sorted(rows, key=lambda r: int(r[1]))[0][0].strip()
+            os.environ["CUDA_VISIBLE_DEVICES"] = free
+            print(f"[auto] CUDA_VISIBLE_DEVICES={free} (lowest memory.used)")
+        except Exception as exc:  # noqa: BLE001
+            print(f"[auto] GPU auto-pick failed ({exc}); using default device")
+
+    case_by_id = {c.id: c for c in ATTENTION_CASES}
+    decode_case = case_by_id["gemma4_offline_lockstep_decode"]
+    prefill_case = case_by_id["gemma4_offline_lockstep_prefill"]
+    scale_by_key = {"unity": SCALE_CASES[0], "non_default": SCALE_CASES[1]}
+
+    want_cases = []
+    if "decode" in args.cases:
+        want_cases.append(("decode", decode_case, True))
+    if "prefill" in args.cases:
+        want_cases.append(("prefill", prefill_case, False))
+
+    backend_label = {
+        "fa4_dequant": "FA4-dequant",
+        "triton_fp8": "Triton-fp8",
+        "triton_fp16q": "Triton-fp16q",
+        "fa4_bf16": "FA4-bf16",
+    }
+
+    for case_key, case, is_decode in want_cases:
+        for scale_key in args.scales:
+            scale_case = scale_by_key[scale_key]
+            print()
+            print("=" * 78)
+            print(f"CASE: {case_key}  ({case.id})   SCALE: {scale_key} "
+                  f"(q={scale_case.q}, k={scale_case.k}, v={scale_case.v})")
+            print(f"  query_lens={case.query_lens}  kv_lens={case.kv_lens}  "
+                  f"nheads={case.num_query_heads}/{case.num_kv_heads}  "
+                  f"head_size={case.head_size}  block_size={case.block_size}")
+            print("=" * 78)
+
+            ins = _build_case_inputs(case, scale_case)
+            total_flops, fp8_bytes, bf16_bytes = _bench_flops_bytes(ins)
+
+            results = []  # (backend, method, median_ms, kv_bytes)
+            for backend in args.backends:
+                fn = _bench_make_fn(backend, ins)
+                # --- mandatory prewarm (JIT-compile + autotune OUT of timing,
+                #     and required before cudagraph capture) + correctness guard.
+                ok = True
+                last_out = None
+                try:
+                    for _ in range(args.prewarm_iters):
+                        last_out = fn()
+                    torch.cuda.synchronize()
+                    _bench_correctness_guard(last_out, ins)
+                except Exception as exc:  # noqa: BLE001 -- graceful per-backend skip
+                    ok = False
+                    print(f"  [{backend_label[backend]}] prewarm/guard FAILED -> "
+                          f"skipping: {type(exc).__name__}: {exc}")
+                if not ok:
+                    results.append((backend, "—", None, None))
+                    continue
+
+                kv_bytes = bf16_bytes if backend == "fa4_bf16" else fp8_bytes
+                time.sleep(1)  # throttling settle before the timed measurement
+                if is_decode and args.cudagraph in ("auto", "on"):
+                    # Decode CUDA-graph path: time a pure-launch closure (all device
+                    # args hoisted out -> capture is NON-empty) via do_bench_cudagraph.
+                    # `_bench_time_cudagraph` tags "cudagraph" on a real capture and
+                    # "do_bench" only if capture genuinely fails.
+                    cap_fn, _out_buf = _bench_capturable_fn(backend, ins)
+                    med_ms, method = _bench_time_cudagraph(cap_fn, rep=args.rep)
+                else:
+                    med_ms, method = _bench_time_one(
+                        fn, is_decode=is_decode, cudagraph=args.cudagraph,
+                        warmup=args.warmup, rep=args.rep,
+                    )
+                results.append((backend, method, med_ms, kv_bytes))
+
+            # FA4-bf16 baseline for the speedup column.
+            fa4_bf16_ms = next(
+                (ms for (b, m, ms, kb) in results if b == "fa4_bf16" and ms is not None),
+                None,
+            )
+
+            metric_name = "TFLOPS" if not is_decode else "GB/s"
+            print()
+            print(f"  {'backend':<11} | {'method':<10} | {'median_ms':>10} | "
+                  f"{'speedup_vs_FA4bf16':>18} | {metric_name:>10}")
+            print("  " + "-" * 72)
+            for backend, method, med_ms, kv_bytes in results:
+                label = backend_label[backend]
+                if med_ms is None:
+                    print(f"  {label:<11} | {'—':<10} | {'—':>10} | "
+                          f"{'—':>18} | {'—':>10}")
+                    continue
+                med_s = med_ms * 1e-3
+                if not is_decode:
+                    metric = total_flops * 1e-12 / med_s  # TFLOPS
+                else:
+                    metric = kv_bytes * 1e-9 / med_s  # GB/s
+                if fa4_bf16_ms is not None and med_ms > 0:
+                    speedup = f"{fa4_bf16_ms / med_ms:.3f}x"
+                else:
+                    speedup = "—"
+                print(f"  {label:<11} | {method:<10} | {med_ms:>10.4f} | "
+                      f"{speedup:>18} | {metric:>10.1f}")
+
+            # Tidy up before the next (case, scale): drop everything and reclaim.
+            del ins, results
+            torch.cuda.empty_cache()
+
+
+# --------------------------------------------------------------------------- #
+# nsys capture mode (additive; __main__-only, gated behind --nsys).
+#
+# Goal: collect a CONCISE, cudaProfilerApi-bounded kernel-level trace so we can
+# read true per-kernel GPU durations + kernel names/grids and attribute them to
+# (case, backend) via NVTX ranges. We deliberately split into two phases:
+#
+#   Phase 1 (OUTSIDE the profiled window): build inputs and the PURE-LAUNCH
+#     closures (reusing `_bench_capturable_fn` -- works for decode AND prefill),
+#     then prewarm each closure so FA4 JIT-compile and Triton autotune settle
+#     here, NOT inside the capture. Closures (and their `ins`) stay resident.
+#
+#   Phase 2 (the capture window): cudaProfilerStart() ... per (case, backend,
+#     scale) wrap `args.nsys_iters` pure-launch replays in an NVTX range, sync,
+#     then cudaProfilerStop(). The trace therefore contains ONLY steady-state
+#     kernel launches, each attributable to a labeled (case, backend, scale).
+# --------------------------------------------------------------------------- #
+def _bench_run_nsys(args) -> None:
+    """Concise cudaProfilerApi-bounded nsys driver. Phase 1 prewarms outside the
+    capture; Phase 2 replays the pure-launch closures inside the profiler window
+    under NVTX ranges so kernels attribute to (case, backend, scale)."""
+    if _cute_flash_attn_fwd is None:
+        print("FA4 CuTe interface is not importable; cannot benchmark. Aborting.")
+        return
+
+    # Pick a free GPU if the caller did not pin one (mirrors `_bench_run`).
+    if "CUDA_VISIBLE_DEVICES" not in os.environ:
+        try:
+            import subprocess
+            out = subprocess.check_output(
+                ["nvidia-smi", "--query-gpu=index,memory.used",
+                 "--format=csv,noheader,nounits"],
+                text=True,
+            )
+            rows = [r.split(",") for r in out.strip().splitlines()]
+            free = sorted(rows, key=lambda r: int(r[1]))[0][0].strip()
+            os.environ["CUDA_VISIBLE_DEVICES"] = free
+            print(f"[auto] CUDA_VISIBLE_DEVICES={free} (lowest memory.used)")
+        except Exception as exc:  # noqa: BLE001
+            print(f"[auto] GPU auto-pick failed ({exc}); using default device")
+
+    case_by_id = {c.id: c for c in ATTENTION_CASES}
+    decode_case = case_by_id["gemma4_offline_lockstep_decode"]
+    prefill_case = case_by_id["gemma4_offline_lockstep_prefill"]
+    scale_by_key = {"unity": SCALE_CASES[0], "non_default": SCALE_CASES[1]}
+
+    want_cases = []
+    if "decode" in args.cases:
+        want_cases.append(("decode", decode_case))
+    if "prefill" in args.cases:
+        want_cases.append(("prefill", prefill_case))
+
+    backend_label = {
+        "fa4_dequant": "FA4-dequant",
+        "triton_fp8": "Triton-fp8",
+        "triton_fp16q": "Triton-fp16q",
+        "fa4_bf16": "FA4-bf16",
+    }
+
+    # --- Phase 1: build inputs + pure-launch closures, prewarm OUTSIDE capture.
+    # Each entry: (label, case_key, backend, scale_key, cap_fn). We keep `ins`
+    # and `cap_fn` resident (held by `keepalive`) so device pointers stay valid
+    # through the capture window.
+    plan = []          # list of (label, case_key, backend, scale_key, cap_fn)
+    keepalive = []     # holds `ins` dicts + out_bufs so nothing is GC'd/freed
+    print()
+    print("=" * 78)
+    print("nsys mode: Phase 1 -- build inputs + prewarm (OUTSIDE capture window)")
+    print("=" * 78)
+    for case_key, case in want_cases:
+        for scale_key in args.scales:
+            scale_case = scale_by_key[scale_key]
+            print(f"  building {case_key}/{scale_key}  "
+                  f"query_lens={case.query_lens}  kv_lens={case.kv_lens}")
+            ins = _build_case_inputs(case, scale_case)
+            keepalive.append(ins)
+            for backend in args.backends:
+                # Reuse the PURE-LAUNCH closure (all device-arg construction +
+                # `.item()` syncs happen here, before any timed/captured window).
+                cap_fn, out_buf = _bench_capturable_fn(backend, ins)
+                keepalive.append(out_buf)
+                # Prewarm: settle FA4 JIT-compile + Triton autotune OFF the
+                # capture path. Skip a backend that fails (e.g. unsupported arch).
+                try:
+                    for _ in range(args.prewarm_iters):
+                        cap_fn()
+                    torch.cuda.synchronize()
+                except Exception as exc:  # noqa: BLE001 -- graceful per-backend skip
+                    print(f"    [{backend_label[backend]}] {case_key}/{scale_key} "
+                          f"prewarm FAILED -> skipping: "
+                          f"{type(exc).__name__}: {exc}")
+                    continue
+                label = f"{case_key}/{backend}/{scale_key}"
+                plan.append((label, case_key, backend, scale_key, cap_fn))
+                print(f"    [{backend_label[backend]}] prewarmed -> "
+                      f"NVTX label '{label}'")
+
+    if not plan:
+        print("nsys mode: no backend prewarmed successfully; nothing to capture.")
+        return
+
+    # --- Phase 2: the capture window. Lazy-import the profiler/nvtx hooks here.
+    import torch.cuda.profiler as cuda_profiler
+    import torch.cuda.nvtx as nvtx
+
+    print()
+    print("=" * 78)
+    print(f"nsys mode: Phase 2 -- capture window "
+          f"({args.nsys_iters} iters/range, {len(plan)} ranges)")
+    print("=" * 78)
+    torch.cuda.synchronize()
+    cuda_profiler.start()
+    try:
+        for label, _case_key, _backend, _scale_key, cap_fn in plan:
+            with nvtx.range(label):
+                for _ in range(args.nsys_iters):
+                    cap_fn()
+            torch.cuda.synchronize()
+    finally:
+        cuda_profiler.stop()
+    torch.cuda.synchronize()
+
+    # --- Report the NVTX label -> (case, backend, scale) map + stats hint.
+    print()
+    print("=" * 78)
+    print("nsys mode: NVTX label -> (case, backend, scale) map")
+    print("=" * 78)
+    for label, case_key, backend, scale_key, _cap_fn in plan:
+        print(f"  {label:<40} -> case={case_key:<8} "
+              f"backend={backend_label[backend]:<11} scale={scale_key}")
+    print()
+    print("Suggested analysis (point at the .nsys-rep you wrote with -o):")
+    print("  nsys stats --report nvtx_gpu_proj_sum --report cuda_gpu_kern_sum \\")
+    print("    --format table <out>.nsys-rep")
+
+
+def _bench_main(argv=None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Perf benchmark: FA4-dequant vs Triton vs FA4-bf16 on "
+                    "gemma4 decode + prefill (additive to the test file)."
+    )
+
+    def _csv(allowed):
+        def parse(s):
+            vals = [x.strip() for x in s.split(",") if x.strip()]
+            bad = [v for v in vals if v not in allowed]
+            if bad:
+                raise argparse.ArgumentTypeError(
+                    f"invalid value(s) {bad}; allowed: {sorted(allowed)}"
+                )
+            return vals
+        return parse
+
+    parser.add_argument("--cases", type=_csv({"decode", "prefill"}),
+                        default=["decode", "prefill"])
+    parser.add_argument("--scales", type=_csv({"unity", "non_default"}),
+                        default=["unity", "non_default"])
+    parser.add_argument("--backends",
+                        type=_csv({"fa4_dequant", "triton_fp16q", "triton_fp8", "fa4_bf16"}),
+                        default=["fa4_dequant", "triton_fp16q", "fa4_bf16", "triton_fp8"])
+    parser.add_argument("--cudagraph", choices=["auto", "on", "off"], default="auto")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--rep", type=int, default=10)
+    parser.add_argument("--prewarm-iters", type=int, default=3, dest="prewarm_iters")
+    # nsys capture mode (additive): replay pure-launch closures inside a
+    # cudaProfilerApi window under NVTX ranges for a concise kernel-level trace.
+    parser.add_argument("--nsys", action="store_true", default=False,
+                        help="cudaProfilerApi-bounded nsys capture mode "
+                             "(skips the normal do_bench/cudagraph timing run).")
+    parser.add_argument("--nsys-iters", type=int, default=20, dest="nsys_iters",
+                        help="pure-launch replays per NVTX range in --nsys mode.")
+    args = parser.parse_args(argv)
+    if args.nsys:
+        _bench_run_nsys(args)
+        return
+    _bench_run(args)
+
+
+if __name__ == "__main__":
+    import os  # noqa: E402 -- local to the __main__ entry; tests don't need it.
+
+    # When launched as `python tests/cute/<file>.py`, sys.path[0] is this script's
+    # dir (tests/cute), not the repo root, so the cwd-resolved (not pip-installed)
+    # `flash_attn` package is not importable. pytest avoids this by running from the
+    # repo root. Re-add the FA repo root here and re-import the cute interface if the
+    # module-level import was swallowed -- additive, __main__-only, mirrors the
+    # existing module-level vLLM-path guard. Tests are unaffected.
+    _FA_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+    if _FA_REPO_ROOT not in sys.path:
+        sys.path.insert(0, _FA_REPO_ROOT)
+    if _cute_flash_attn_fwd is None:
+        try:
+            from flash_attn.cute.interface import _flash_attn_fwd as _cute_flash_attn_fwd
+            from flash_attn.cute.testing import attention_ref
+        except Exception:  # pragma: no cover
+            _cute_flash_attn_fwd = None
+
+    _bench_main()


### PR DESCRIPTION
Rebased and squashed version of https://github.com/vllm-project/flash-attention/pull/147
Kernel required for Gemma-4 head_dim 512 layer when KV are FP8. 10% more throughput.