### PR TITLE
Fix FP8 rescale threshold

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2029,7 +2029,7 @@ class FlashAttentionForwardSm100:
 
             rescale_threshold = (
                 8.0 if const_expr(self.q_dtype.width == 16) else
-                4.0 if const_expr(self.q_dtype.width == 8) else
+                0.75 if const_expr(self.q_dtype.width == 8) else
                 0.0
             )
             softmax = SoftmaxSm100.create(


### PR DESCRIPTION
Based on open upstream PR https://github.com/Dao-AILab/flash-attention/pull/2578, which fixes https://github.com/Dao-AILab/flash-attention/issues/2577

Rather than setting the threshold to 0.0, we can recover some of the performance loss by using 0.75, which is still under the maximum 0.807 = log2(448) − 8:

| batch × seqlen | 4.0 (ms) | 0.0 (ms) | 0.75 (ms) | 0.0 vs 4.0 | 0.75 vs 4.0 | 0.75 recovers |
|---|---|---|---|---|---|---|
| 32 × 512 | 0.0762 | 0.0782 | 0.0782 | +2.6% | +2.6% | ~0% |
| 16 × 1024 | 0.0946 | 0.1007 | 0.0987 | +6.4% | +4.3% | ~33% |
| 8 × 2048 | 0.1305 | 0.1439 | 0.1397 | +10.3% | +7.0% | ~31% |
| 4 × 4096 | 0.2010 | 0.2318 | 0.2198 | +15.3% | +9.4% | ~39% |
| 2 × 8192 | 0.3342 | 0.3997 | 0.3709 | +19.6% | +11.0% | ~44% |
| 1 × 16384 | 0.6147 | 0.7328 | 0.6641 | +19.2% | +8.0% | ~58% |
