### PR TITLE
[Kernel] Support FP32 rotary tables with low-precision inputs

### DIFF
--- a/tests/test_rotary.py
+++ b/tests/test_rotary.py
@@ -11,6 +11,7 @@ import triton
 from flash_attn.layers.rotary import apply_rotary_emb, apply_rotary_emb_torch
 from flash_attn.layers.rotary import apply_rotary_emb_qkv_, apply_rotary_emb_kv_
 from flash_attn.bert_padding import pad_input, unpad_input
+from vllm_flash_attn.layers.rotary import apply_rotary_emb as apply_vllm_rotary_emb
 
 is_sm8x = torch.cuda.get_device_capability("cuda") >= (8, 0)
 
@@ -92,6 +93,57 @@ def test_rotary_emb_func(inplace, interleaved, rotary_fraction, seqlen_offsets_t
     # Numerical error if we just do any arithmetic
     atol = ((out_pt + 0.3 - 0.3) - out_pt).abs().max().item()
     assert torch.allclose(out, out_pt, rtol=rtol, atol=2 * atol)
+    atol = ((x_pt.grad + 0.3 - 0.3) - x_pt.grad).abs().max().item()
+    assert torch.allclose(x.grad, x_pt.grad, rtol=rtol, atol=2 * atol)
+
+
+@pytest.mark.parametrize(
+    "dtype", ([torch.float16] if not is_sm8x else [torch.float16, torch.bfloat16])
+)
+@pytest.mark.parametrize("interleaved", [False, True])
+@pytest.mark.parametrize("inplace", [False, True])
+def test_vllm_rotary_emb_fp32_cos_sin(inplace, interleaved, dtype):
+    rtol = 1e-3
+    batch_size = 2
+    nheads = 3
+    seqlen = 32
+    headdim = 64
+    rotary_dim = 32
+    device = "cuda"
+    torch.manual_seed(42)
+
+    x = torch.randn(
+        batch_size,
+        seqlen,
+        nheads,
+        headdim,
+        dtype=dtype,
+        device=device,
+        requires_grad=True,
+    )
+    x_pt = x.detach().clone().requires_grad_()
+    x_before = x.detach().clone()
+    cos, sin = generate_cos_sin(seqlen, rotary_dim, device, torch.float32)
+
+    out = apply_vllm_rotary_emb(
+        x, cos, sin, interleaved=interleaved, inplace=inplace
+    )
+    cos_pt, sin_pt = index_cos_sin(cos, sin, 0, seqlen)
+    out_pt = apply_rotary_emb_torch(
+        x_pt.float(), cos_pt, sin_pt, interleaved=interleaved
+    ).to(dtype=dtype)
+
+    assert out.dtype == dtype
+    if not inplace:
+        assert torch.equal(x, x_before)
+    assert torch.equal(out[..., rotary_dim:], x[..., rotary_dim:])
+    atol = ((out_pt + 0.3 - 0.3) - out_pt).abs().max().item()
+    assert torch.allclose(out, out_pt, rtol=rtol, atol=2 * atol)
+
+    grad = torch.randn_like(out)
+    grad_pt = grad.clone()
+    out.backward(grad)
+    out_pt.backward(grad_pt)
     atol = ((x_pt.grad + 0.3 - 0.3) - x_pt.grad).abs().max().item()
     assert torch.allclose(x.grad, x_pt.grad, rtol=rtol, atol=2 * atol)
 

--- a/vllm_flash_attn/layers/rotary.py
+++ b/vllm_flash_attn/layers/rotary.py
@@ -107,7 +107,8 @@ def apply_rotary_emb(
     Arguments:
         x: (batch_size, seqlen, nheads, headdim) if cu_seqlens is None
             else (total_seqlen, nheads, headdim)
-        cos, sin: (seqlen_rotary, rotary_dim / 2)
+        cos, sin: (seqlen_rotary, rotary_dim / 2). These tensors must have the
+            same dtype, which may differ from x.
         interleaved: if True, rotate pairs of even and odd dimensions (GPT-J style) instead
             of 1st half and 2nd half (GPT-NeoX style).
         inplace: if True, apply rotary embedding in-place.
@@ -117,7 +118,7 @@ def apply_rotary_emb(
         max_seqlen: int
     Return:
         out: (batch_size, seqlen, nheads, headdim) if cu_seqlens is None
-            else (total_seqlen, nheads, headdim)
+            else (total_seqlen, nheads, headdim). The dtype matches x.
     rotary_dim must be <= headdim
     Apply rotary embedding to the first rotary_dim of x.
     """

--- a/vllm_flash_attn/ops/triton/rotary.py
+++ b/vllm_flash_attn/ops/triton/rotary.py
@@ -146,13 +146,14 @@ def apply_rotary(
     Arguments:
         x: (batch, seqlen, nheads, headdim) if cu_seqlens is None
             else (total_seqlen, nheads, headdim).
-        cos: (seqlen_ro, rotary_dim / 2)
-        sin: (seqlen_ro, rotary_dim / 2)
+        cos: (seqlen_ro, rotary_dim / 2). May have a different floating-point
+            dtype than x.
+        sin: (seqlen_ro, rotary_dim / 2). Must have the same dtype as cos.
         seqlen_offsets: integer or integer tensor of size (batch,)
         cu_seqlens: (batch + 1,) or None
         max_seqlen: int
     Returns:
-        y: (batch, seqlen, nheads, headdim)
+        y: (batch, seqlen, nheads, headdim), with the same dtype as x.
     """
     is_varlen = cu_seqlens is not None
     if not is_varlen:
@@ -173,9 +174,6 @@ def apply_rotary(
     assert (
         cos.dtype == sin.dtype
     ), f"cos and sin must have the same dtype, got {cos.dtype} and {sin.dtype}"
-    assert (
-        x.dtype == cos.dtype
-    ), f"Input and cos/sin must have the same dtype, got {x.dtype} and {cos.dtype}"
 
     cos, sin = cos.contiguous(), sin.contiguous()
     if isinstance(seqlen_offsets, torch.Tensor):


### PR DESCRIPTION
## Purpose

Allow FP16/BF16 rotary inputs to use FP32 cosine and sine tables in the
`vllm_flash_attn` Triton implementation.

The kernel already converts every loaded `x`, `cos`, and `sin` tile to FP32
before arithmetic, then writes to an output allocated with `torch.empty_like(x)`.
The same-dtype assertion therefore did not protect the computation; it forced
callers that require FP32 rotary tables to materialize the full input and output
in FP32.

This change removes only the `x.dtype == cos.dtype` assertion. The cos/sin
same-dtype check, kernel launch configuration, and autograd facade remain
unchanged. The public docstring now records that output dtype follows `x`.

The regression test covers FP16 and BF16 inputs, NeoX and GPT-J layouts,
partial rotary dimensions, in-place and out-of-place execution, and backward.

## Duplicate check

Searched open PRs for `rotary`, `rotary dtype fp32`, and `mixed dtype rotary`;
no overlapping PR was found as of 2026-07-19.

## Validation

Completed:

- `py_compile` on all three changed Python files
- Ruff 0.11.13 on the changed files (excluding repository-existing F401/F811)
- typos 1.43.5
- `git diff --check`
- pytest collection: all 8 new parameter combinations collected

Pending before marking ready:

- CUDA execution of the 8 mixed-dtype tests on RTX 5090
- downstream vLLM MiniMax-M3 initialization/profile validation

## AI assistance

OpenAI Codex assisted with diagnosis, implementation, and test design. The
human submitter will review every changed line and GPU result before marking
this PR ready.
