### PR TITLE
Require C++20 to match PyTorch ATen headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,13 @@ if (FA2_ENABLED)
         # FLASHATTENTION_DISABLE_LOCAL
         FLASHATTENTION_DISABLE_PYBIND
     )
+
+    # Pin the C++ standard on the target itself. When flash-attn is built as a
+    # vLLM subproject (FetchContent), the directory-level CMAKE_CXX_STANDARD set
+    # above does not propagate to targets created via define_gpu_extension_target,
+    # so the host .cpp sources would compile as C++17 and fail against PyTorch
+    # nightly's ATen headers, which now require C++20.
+    set_target_properties(_vllm_fa2_C PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
 endif ()
 
 # FA3 requires CUDA 12.0 or later
@@ -306,6 +313,9 @@ if (FA3_ENABLED AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.0)
         CUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED
         CUTLASS_ENABLE_GDC_FOR_SM90
     )
+
+    # See _vllm_fa2_C above: enforce C++20 on the target for the vLLM subproject build.
+    set_target_properties(_vllm_fa3_C PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
 elseif(${CMAKE_CUDA_COMPILER_VERSION} VERSION_LESS 12.0)
     message(STATUS "FA3 is disabled because CUDA version is not 12.0 or later.")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.26)
 
 project(vllm_flash_attn LANGUAGES CXX CUDA)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(FA2_ENABLED ON)


### PR DESCRIPTION
## Summary

Bump `CMAKE_CXX_STANDARD` from **17 → 20** so the flash-attention extensions (`_vllm_fa2_C`, `_vllm_fa3_C`) build against current PyTorch, which now **requires C++20**.

## Why

Recent PyTorch (2.13+, and nightly) moved its C++ standard to C++20 and added a hard guard in `ATen.h`:

```
ATen/ATen.h:5:2: error: #error C++20 or later compatible compiler is required to use ATen.
```

This repo's `CMakeLists.txt` pins `set(CMAKE_CXX_STANDARD 17)`, so every host-C++ TU that includes torch (e.g. `csrc/flash_attn/flash_api.cpp`) fails to compile against torch-nightly. vLLM's own build already uses C++20 (`vllm/vllm CMakeLists.txt`: `set(CMAKE_CXX_STANDARD 20)`), but because this subproject sets its own standard, the `_vllm_fa2_C` target reverts to C++17 and breaks.

Observed in vLLM's `Full CI run torch nightly` (build 78983, `:docker: Build image`):

```
FAILED: vllm-flash-attn/CMakeFiles/_vllm_fa2_C.dir/csrc/flash_attn/flash_api.cpp.o
.../ATen/ATen.h:5:2: error: #error C++20 or later compatible compiler is required to use ATen.
ninja: build stopped: subcommand failed.
```

## Change

```diff
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
```

C++20 is required by torch regardless of variant, backward-compatible for the existing sources, and matches the toolchain vLLM already builds the rest of the tree with (GCC ≥ 11.3).

## Follow-up

vLLM pins this repo at a specific commit (`cmake/external_projects/vllm_flash_attn.cmake`, `GIT_TAG 168920233…`), so a pin bump in vllm-project/vllm is needed to pick this up.

Ref: vllm-project/vllm#49260
