### PR TITLE
[WIP/RFC][SM120] Add bounded BF16 D256 paged-decode specialization

### DIFF
--- a/flash_attn/__init__.py
+++ b/flash_attn/__init__.py
@@ -1,16 +1,53 @@
 from pkgutil import extend_path
+from importlib import import_module
 
 # look for every subdir with flash_attn base name such that fa2 and fa4 can be co-installed
 __path__ = extend_path(__path__, __name__)
 
 __version__ = "2.8.4"
 
-from flash_attn.flash_attn_interface import (
-    flash_attn_func,
-    flash_attn_kvpacked_func,
-    flash_attn_qkvpacked_func,
-    flash_attn_varlen_func,
-    flash_attn_varlen_kvpacked_func,
-    flash_attn_varlen_qkvpacked_func,
-    flash_attn_with_kvcache,
+_LEGACY_FA2_EXPORTS = (
+    "flash_attn_func",
+    "flash_attn_kvpacked_func",
+    "flash_attn_qkvpacked_func",
+    "flash_attn_varlen_func",
+    "flash_attn_varlen_kvpacked_func",
+    "flash_attn_varlen_qkvpacked_func",
+    "flash_attn_with_kvcache",
 )
+
+__all__ = ["__version__", *_LEGACY_FA2_EXPORTS]
+
+
+def _load_legacy_fa2_interface():
+    """Import the FA2 compatibility API only when a legacy symbol is used.
+
+    FA4 is distributed as a child package of the co-installable ``flash_attn``
+    namespace.  It must not require the separately-built FA2 extension merely
+    to import ``flash_attn.cute``.  Keep the legacy API lazy, while retaining
+    its import-time error when a caller actually requests a legacy symbol.
+    """
+    try:
+        return import_module(".flash_attn_interface", __name__)
+    except ModuleNotFoundError as error:
+        if error.name != "flash_attn_2_cuda":
+            raise
+        raise ModuleNotFoundError(
+            "The legacy flash_attn top-level API requires the FA2 extension "
+            "'flash_attn_2_cuda'. Install a package that provides it, or use "
+            "flash_attn.cute for FA4."
+        ) from error
+
+
+def __getattr__(name):
+    if name not in _LEGACY_FA2_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    legacy_interface = _load_legacy_fa2_interface()
+    exported = getattr(legacy_interface, name)
+    globals()[name] = exported
+    return exported
+
+
+def __dir__():
+    return sorted({*globals(), *_LEGACY_FA2_EXPORTS})

--- a/flash_attn/cute/__init__.py
+++ b/flash_attn/cute/__init__.py
@@ -8,11 +8,35 @@ except PackageNotFoundError:
     __version__ = "0.0.0"
 
 from .interface import (
+    compile_sm120_paged_decode_d256_plan,
+    compile_sm120_paged_decode_d256_from_specs,
+    compile_sm120_paged_decode_d256_warmup_plan,
     flash_attn_func,
     flash_attn_varlen_func,
+    try_launch_sm120_paged_decode_d256,
+)
+from .sm120_paged_decode import (
+    Sm120PagedDecodeCompileUnit,
+    Sm120PagedDecodeD256Metadata,
+    build_sm120_paged_decode_d256_compile_plan,
+    build_sm120_paged_decode_d256_warmup_plan,
+    select_sm120_paged_decode_d256_num_splits,
+    sm120_paged_decode_d256_available,
+    sm120_paged_decode_d256_enabled,
 )
 
 __all__ = [
+    "Sm120PagedDecodeCompileUnit",
+    "Sm120PagedDecodeD256Metadata",
+    "build_sm120_paged_decode_d256_compile_plan",
+    "build_sm120_paged_decode_d256_warmup_plan",
+    "compile_sm120_paged_decode_d256_plan",
+    "compile_sm120_paged_decode_d256_from_specs",
+    "compile_sm120_paged_decode_d256_warmup_plan",
     "flash_attn_func",
     "flash_attn_varlen_func",
+    "select_sm120_paged_decode_d256_num_splits",
+    "sm120_paged_decode_d256_available",
+    "sm120_paged_decode_d256_enabled",
+    "try_launch_sm120_paged_decode_d256",
 ]

--- a/flash_attn/cute/flash_fwd_decode_sm120.py
+++ b/flash_attn/cute/flash_fwd_decode_sm120.py
@@ -1,0 +1,475 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# SM120 (consumer Blackwell, RTX PRO 6000) decode-specialized forward pass.
+#
+# Decode = seqlen_q == 1 with a large KV cache.  The general SM80-base forward
+# kernel (flash_fwd.py) runs the m16n8k16 tensor-core MMA over a tile_m of
+# mostly-empty query rows, making decode COMPUTE-bound on wasted MMA instead of
+# MEMORY-bound on the KV stream; and with pack_gqa disabled on the SplitKV path
+# it launches one CTA per *query* head, streaming the shared KV cache of a GQA
+# group `qhead_per_kvhead` times.
+#
+# This kernel is a from-scratch GEMV-style decode path:
+#   * One CTA == one (batch, kv_head, split).  All R = qhead_per_kvhead query
+#     rows that share a KV head are processed together, so each K/V tile is read
+#     from DRAM exactly once (no GQA redundancy).
+#   * Scores Q.K^T and the P.V contraction are FMA + warp-shuffle reductions
+#     (a GEMV), NOT the m16n8k16 MMA -> no tensor-core lanes wasted on empty
+#     query rows.
+#   * K/V tiles are streamed with cp.async (128-bit coalesced) by all threads,
+#     double buffered -> the inner loop is DRAM bound.
+#   * Online softmax (running max/sum per query row) within the split; the
+#     existing FlashAttentionForwardCombine merges splits.  Writes fp32 partial
+#     O (num_splits, b, s, h, d) and partial LSE (num_splits, b, h, s).
+#
+# Thread layout: tpr = head_dim / (128/dtype.width) threads cooperate on one
+# K/V row's head-dim chunk for loads.  For the math, every thread owns its
+# head-dim chunk (`vec` elements) for all R rows.  Each thread group of `tpr`
+# lanes computes a full score via a width-`tpr` butterfly reduction.  Every
+# thread iterates over ALL keys of the split (the redundant on-chip FMA is cheap
+# vs. DRAM; correctness needs no cross-group reduction).
+
+import math
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Float32, const_expr
+from cutlass.cute.nvgpu import cpasync
+
+from flash_attn.cute import utils
+
+
+LOG2_E = Float32(math.log2(math.e))
+LN2 = Float32(math.log(2.0))
+
+
+class FlashAttentionDecodeSm120:
+    def __init__(
+        self,
+        dtype,
+        head_dim: int,
+        head_dim_v: int,
+        qhead_per_kvhead: int,
+        num_splits: int,
+        tile_n: int = 64,
+        num_threads: int = 128,
+        num_stages: int = 2,
+        page_size: int = 0,
+    ):
+        self.dtype = dtype
+        self.kv_dtype = cutlass.BFloat16
+        self.head_dim = head_dim
+        self.head_dim_v = head_dim_v
+        assert head_dim == head_dim_v, "decode kernel assumes head_dim == head_dim_v"
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.num_splits = num_splits
+        self.tile_n = tile_n
+        self.num_threads = num_threads
+        self.num_stages = num_stages
+        self.page_size = page_size
+        assert self.can_implement(
+            dtype, head_dim, head_dim_v, qhead_per_kvhead, num_threads, tile_n
+        )
+        assert page_size in (16, 784)
+        self.R = qhead_per_kvhead
+        self.vec = 128 // self.kv_dtype.width  # elems per 16B load
+        self.threads_per_row = head_dim // self.vec  # tpr
+        assert num_threads % self.threads_per_row == 0
+        self.rows_per_iter = num_threads // self.threads_per_row
+        assert tile_n % self.rows_per_iter == 0
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        head_dim_v,
+        qhead_per_kvhead,
+        num_threads,
+        tile_n,
+        num_stages=2,
+        kv_dtype=None,
+    ):
+        if dtype != cutlass.BFloat16:
+            return False
+        if kv_dtype not in (None, cutlass.BFloat16):
+            return False
+        if head_dim != 256 or head_dim_v != 256 or qhead_per_kvhead != 6:
+            return False
+        if num_threads != 256 or tile_n != 32 or num_stages != 2:
+            return False
+        vec = 128 // cutlass.BFloat16.width
+        if head_dim % vec != 0:
+            return False
+        tpr = head_dim // vec
+        if num_threads % tpr != 0:
+            return False
+        rpi = num_threads // tpr
+        if tile_n % rpi != 0:
+            return False
+        if num_threads % 32 != 0 or qhead_per_kvhead > 32:
+            return False
+        R = qhead_per_kvhead
+        kv_elem_bytes = cutlass.BFloat16.width // 8
+        kv_tile = num_stages * tile_n * head_dim * kv_elem_bytes
+        # Two-level reduction: warp-shuffle merge within each warp, then an smem
+        # fan-out across only `nwarps` warps (not the rpi row-groups), so the fp32
+        # reduction scratch is sized by nwarps.
+        nwarps = num_threads // 32
+        red_acc = nwarps * R * tpr * vec * 4
+        red_ms = 2 * nwarps * R * tpr * 4
+        sK_smem = max(kv_tile, red_acc)
+        sV_smem = max(kv_tile, red_ms)
+        if sK_smem + sV_smem > 99 * 1024:
+            return False
+        return True
+
+    def _smem_bytes(self):
+        kv_elem_bytes = self.kv_dtype.width // 8
+        kv_tile = self.num_stages * self.tile_n * self.head_dim * kv_elem_bytes
+        R, tpr, vec = self.R, self.threads_per_row, self.vec
+        nwarps = self.num_threads // 32
+        red_acc = nwarps * R * tpr * vec * 4
+        red_ms = 2 * nwarps * R * tpr * 4
+        sK_bytes = max(kv_tile, red_acc)
+        sV_bytes = max(kv_tile, red_ms)
+        return sK_bytes + sV_bytes
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,  # (batch, hq, d)
+        mK: cute.Tensor,  # (page, token, hkv, d)
+        mV: cute.Tensor,  # (page, token, hkv, d)
+        mO: cute.Tensor,  # (num_splits, batch, hq, d) fp32
+        mLSE: cute.Tensor,  # (num_splits, hq, batch) fp32
+        softmax_scale: Float32,
+        mPageTable: cute.Tensor,  # (b, max_pages)
+        mSeqUsedK: cute.Tensor,  # (b,)
+        stream=None,
+    ):
+        from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+
+        mQ, mK, mV = [assume_tensor_aligned(t) for t in (mQ, mK, mV)]
+        b = mPageTable.shape[0]
+        hkv = mK.shape[2]
+        grid = (self.num_splits, hkv, b)
+        self.kernel(
+            mQ,
+            mK,
+            mV,
+            mO,
+            mLSE,
+            softmax_scale,
+            mPageTable,
+            mSeqUsedK,
+        ).launch(
+            grid=grid,
+            block=[self.num_threads, 1, 1],
+            smem=self._smem_bytes(),
+            stream=stream,
+        )
+
+    @cute.jit
+    def load_tile(
+        self,
+        gKc,
+        gVc,
+        sKc,
+        sVc,
+        copy_atom,
+        n_block,
+        stage,
+        lane_d,
+        row_grp,
+        seqlen_k,
+        mPageTable,
+        batch,
+        kv_head,
+    ):
+        # gKc/gVc: (sk, tpr, vec) chunked view of K/V.
+        # sKc/sVc: (NS, TN, tpr, vec) chunked smem.
+        TN = const_expr(self.tile_n)
+        vec = const_expr(self.vec)
+        rpi = const_expr(self.rows_per_iter)
+        n_waves = const_expr(TN // rpi)
+        base_row = n_block * TN
+        for w in cutlass.range_constexpr(n_waves):
+            krow = w * rpi + row_grp
+            gk = base_row + krow
+            page = Int32(0)
+            page_offset = Int32(0)
+            if gk < seqlen_k:
+                # The page-16 specialization keeps its divisor constant.  Page
+                # 784 uses this direct bounded generic-address path.  Each lane
+                # loads its own page-table entry; no cached or broadcast table
+                # state is used by this specialization.
+                if const_expr(self.page_size == 16):
+                    page_idx = gk // 16
+                    page_offset = gk % 16
+                else:
+                    page_idx = gk // self.page_size
+                    page_offset = gk % self.page_size
+                page = mPageTable[batch, page_idx]
+                cute.copy(
+                    copy_atom,
+                    gKc[page, page_offset, kv_head, lane_d, None],
+                    sKc[stage, krow, lane_d, None],
+                )
+                cute.copy(
+                    copy_atom,
+                    gVc[page, page_offset, kv_head, lane_d, None],
+                    sVc[stage, krow, lane_d, None],
+                )
+            else:
+                for e in cutlass.range_constexpr(vec):
+                    sKc[stage, krow, lane_d, e] = self.kv_dtype(0.0)
+                    sVc[stage, krow, lane_d, e] = self.kv_dtype(0.0)
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        softmax_scale: Float32,
+        mPageTable: cute.Tensor,
+        mSeqUsedK: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        split_idx, kv_head, batch = cute.arch.block_idx()
+
+        d = const_expr(self.head_dim)
+        R = const_expr(self.R)
+        TN = const_expr(self.tile_n)
+        vec = const_expr(self.vec)
+        tpr = const_expr(self.threads_per_row)
+        rpi = const_expr(self.rows_per_iter)
+        NS = const_expr(self.num_stages)
+        seqlen_k = mSeqUsedK[batch]
+
+        n_block_total = cute.ceil_div(seqlen_k, TN)
+        nblk_per_split = cute.ceil_div(n_block_total, self.num_splits)
+        n_block_min = cutlass.min(split_idx * nblk_per_split, n_block_total)
+        n_block_max = cutlass.min(n_block_min + nblk_per_split, n_block_total)
+        n_iters = cutlass.max(n_block_max - n_block_min, Int32(0))
+
+        # ---- shared memory: NS-buffered K and V tiles, chunked as (NS,TN,tpr,vec) ----
+        # Allocate K/V tiles and reuse their bytes as reduction scratch after the
+        # streaming mainloop completes.
+        kv_elem_bytes = const_expr(self.kv_dtype.width // 8)
+        kv_tile_bytes = const_expr(NS * TN * d * kv_elem_bytes)
+        nwarps = const_expr(self.num_threads // 32)
+        red_acc_bytes = const_expr(nwarps * R * tpr * vec * 4)
+        red_ms_bytes = const_expr(2 * nwarps * R * tpr * 4)
+        sK_bytes = const_expr(max(kv_tile_bytes, red_acc_bytes))
+        sV_bytes = const_expr(max(kv_tile_bytes, red_ms_bytes))
+        smem = cutlass.utils.SmemAllocator()
+        smem_layout = cute.make_layout((NS, TN, tpr, vec), stride=(TN * d, d, vec, 1))
+        sK_ptr = smem.allocate(sK_bytes, byte_alignment=1024)
+        sV_ptr = smem.allocate(sV_bytes, byte_alignment=1024)
+        sKc = cute.make_tensor(cute.recast_ptr(sK_ptr, dtype=self.kv_dtype), smem_layout)
+        sVc = cute.make_tensor(cute.recast_ptr(sV_ptr, dtype=self.kv_dtype), smem_layout)
+
+        lane_d = tidx % tpr  # which 16B chunk of head dim
+        row_grp = tidx // tpr  # which K/V row within a cp.async wave
+
+        copy_atom = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self.kv_dtype,
+            num_bits_per_copy=128,
+        )
+
+        # chunked gmem views: (sk, tpr, vec).  Each thread's innermost load is
+        # vec contiguous elements = one 16B chunk; the row base and lane_d*vec
+        # offset are both 16B aligned.
+        gK_chunk_layout = cute.make_layout(
+            (mK.shape[0], mK.shape[1], mK.shape[2], tpr, vec),
+            stride=(mK.stride[0], mK.stride[1], mK.stride[2], vec, 1),
+        )
+        gKc = cute.make_tensor(mK.iterator, gK_chunk_layout)
+        gVc = cute.make_tensor(mV.iterator, gK_chunk_layout)
+
+        # ---- load Q rows (R rows, this thread's vec chunk) into registers ----
+        rQ = cute.make_rmem_tensor((R, vec), Float32)
+        for r in cutlass.range_constexpr(R):
+            q_head = kv_head * R + r
+            for e in cutlass.range_constexpr(vec):
+                rQ[r, e] = Float32(mQ[batch, q_head, lane_d * vec + e])
+
+        # ---- online softmax state (per row; this thread's acc chunk) ----
+        acc_o = cute.make_rmem_tensor((R, vec), Float32)
+        row_max = cute.make_rmem_tensor((R,), Float32)
+        row_sum = cute.make_rmem_tensor((R,), Float32)
+        for r in cutlass.range_constexpr(R):
+            row_max[r] = Float32(-1e30)
+            row_sum[r] = Float32(0.0)
+            for e in cutlass.range_constexpr(vec):
+                acc_o[r, e] = Float32(0.0)
+
+        # prologue: prefetch first tile (bounds-checked; empty split -> zero-fill)
+        self.load_tile(
+            gKc,
+            gVc,
+            sKc,
+            sVc,
+            copy_atom,
+            n_block_min,
+            Int32(0),
+            lane_d,
+            row_grp,
+            seqlen_k,
+            mPageTable,
+            batch,
+            kv_head,
+        )
+        cute.arch.cp_async_commit_group()
+
+        for it in cutlass.range(n_iters, unroll=1):
+            n_block = n_block_min + it
+            stage = it % NS
+            nxt = (it + 1) % NS
+            if it + 1 < n_iters:
+                self.load_tile(
+                    gKc,
+                    gVc,
+                    sKc,
+                    sVc,
+                    copy_atom,
+                    n_block_min + it + 1,
+                    nxt,
+                    lane_d,
+                    row_grp,
+                    seqlen_k,
+                    mPageTable,
+                    batch,
+                    kv_head,
+                )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(1)
+            else:
+                cute.arch.cp_async_wait_group(0)
+            cute.arch.barrier()
+
+            base_row = n_block * TN
+            # Partition keys across the rpi row-groups: row_grp `g` handles keys
+            # j = g, g+rpi, g+2*rpi, ...  (1/rpi of the tile).  A final smem
+            # reduction across the rpi groups merges the per-row stats.
+            for jw in cutlass.range_constexpr(TN // rpi):
+                j = jw * rpi + row_grp
+                gj = base_row + j
+                valid = gj < seqlen_k
+                for r in cutlass.range_constexpr(R):
+                    p = Float32(0.0)
+                    for e in cutlass.range_constexpr(vec):
+                        p += rQ[r, e] * Float32(sKc[stage, j, lane_d, e])
+                    # reduce partial dot across the tpr lanes (butterfly, width tpr)
+                    p = utils.warp_reduce(p, lambda a, bb: a + bb, width=tpr)
+                    s = p * softmax_scale
+                    s = s if valid else Float32(-1e30)
+                    old_max = row_max[r]
+                    new_max = cutlass.max(old_max, s)
+                    corr = cute.math.exp2((old_max - new_max) * LOG2_E, fastmath=True)
+                    corr = corr if old_max > Float32(-1e29) else Float32(0.0)
+                    pexp = cute.math.exp2((s - new_max) * LOG2_E, fastmath=True)
+                    pexp = pexp if valid else Float32(0.0)
+                    row_max[r] = new_max
+                    row_sum[r] = row_sum[r] * corr + pexp
+                    for e in cutlass.range_constexpr(vec):
+                        acc_o[r, e] = acc_o[r, e] * corr + pexp * Float32(sVc[stage, j, lane_d, e])
+            cute.arch.barrier()
+
+        # ---- cross-row-group reduction of (max, sum, acc) over the rpi groups ----
+        # Each row_grp owns a disjoint key subset; their online-softmax states are
+        # merged in two levels to keep the smem fan-out (and hence occupancy) low:
+        #   1) WARP level: the `groups_per_warp` row-groups that live in the same
+        #      warp (and share a lane_d) are merged with shuffle-butterfly XORs over
+        #      the row-group bits of the lane index (offsets tpr, 2*tpr, ...).  After
+        #      this every lane holds its warp's merged state for its lane_d.
+        #   2) SMEM level: one representative lane per (warp, lane_d) writes the
+        #      warp-merged state to scratch indexed by warp_id; warp 0 then merges
+        #      across the `nwarps` warps.
+        # This shrinks the smem fan-out from rpi -> nwarps.  For bf16 the K/V tile
+        nwarps = const_expr(self.num_threads // 32)
+        gpw = const_expr(32 // tpr)  # row-groups per warp sharing a lane_d
+        warp_id = tidx // 32
+        lane = tidx % 32
+
+        # 1) warp-level butterfly merge of (max, sum, acc) across the gpw groups.
+        for r in cutlass.range_constexpr(R):
+            wm = row_max[r]
+            ws = row_sum[r]
+            for off in cutlass.range_constexpr(int(math.log2(gpw))):
+                step = const_expr(tpr << off)
+                om = cute.arch.shuffle_sync_bfly(wm, offset=step)
+                os_ = cute.arch.shuffle_sync_bfly(ws, offset=step)
+                nm = cutlass.max(wm, om)
+                cself = cute.math.exp2((wm - nm) * LOG2_E, fastmath=True)
+                cself = cself if wm > Float32(-1e29) else Float32(0.0)
+                cother = cute.math.exp2((om - nm) * LOG2_E, fastmath=True)
+                cother = cother if om > Float32(-1e29) else Float32(0.0)
+                for e in cutlass.range_constexpr(vec):
+                    oa = cute.arch.shuffle_sync_bfly(acc_o[r, e], offset=step)
+                    acc_o[r, e] = acc_o[r, e] * cself + oa * cother
+                ws = ws * cself + os_ * cother
+                wm = nm
+            row_max[r] = wm
+            row_sum[r] = ws
+
+        # 2) smem fan-out across the nwarps warps.  Scratch ALIASED onto the
+        # now-finished K/V smem (recast -> fp32): sKc holds acc, sVc holds
+        # [max | sum], indexed by warp_id.  can_implement guarantees these fit.
+        sRedAcc = cute.make_tensor(
+            cute.recast_ptr(sKc.iterator, dtype=Float32),
+            cute.make_layout((nwarps, R, tpr, vec), stride=(R * tpr * vec, tpr * vec, vec, 1)),
+        )
+        sRedMS = cute.make_tensor(
+            cute.recast_ptr(sVc.iterator, dtype=Float32),
+            cute.make_layout((2, nwarps, R, tpr), stride=(nwarps * R * tpr, R * tpr, tpr, 1)),
+        )
+        cute.arch.barrier()
+        # Lanes in local group 0 of each warp (lane < tpr) own a distinct lane_d
+        # and hold the warp-merged state; they publish it keyed by warp_id.
+        if lane < tpr:
+            for r in cutlass.range_constexpr(R):
+                sRedMS[0, warp_id, r, lane_d] = row_max[r]
+                sRedMS[1, warp_id, r, lane_d] = row_sum[r]
+                for e in cutlass.range_constexpr(vec):
+                    sRedAcc[warp_id, r, lane_d, e] = acc_o[r, e]
+        cute.arch.barrier()
+
+        # row_grp 0 (which is lane_d == lane, warp 0) merges across all nwarps.
+        if row_grp == 0:
+            for r in cutlass.range_constexpr(R):
+                gmax = Float32(-1e30)
+                for g in cutlass.range_constexpr(nwarps):
+                    gmax = cutlass.max(gmax, sRedMS[0, g, r, lane_d])
+                gsum = Float32(0.0)
+                for e in cutlass.range_constexpr(vec):
+                    acc_o[r, e] = Float32(0.0)
+                for g in cutlass.range_constexpr(nwarps):
+                    gm = sRedMS[0, g, r, lane_d]
+                    corr = cute.math.exp2((gm - gmax) * LOG2_E, fastmath=True)
+                    corr = corr if gm > Float32(-1e29) else Float32(0.0)
+                    gsum += sRedMS[1, g, r, lane_d] * corr
+                    for e in cutlass.range_constexpr(vec):
+                        acc_o[r, e] += sRedAcc[g, r, lane_d, e] * corr
+                row_max[r] = gmax
+                row_sum[r] = gsum
+
+        # ---- write normalized partial O + natural-log LSE (row_grp 0 only) ----
+        if row_grp == 0:
+            for r in cutlass.range_constexpr(R):
+                s = row_sum[r]
+                zero_or_nan = (s == Float32(0.0)) or (s != s)
+                inv = cute.arch.rcp_approx(s if not zero_or_nan else Float32(1.0))
+                q_head = kv_head * R + r
+                for e in cutlass.range_constexpr(vec):
+                    mO[split_idx, batch, q_head, lane_d * vec + e] = acc_o[r, e] * inv
+                if lane_d == 0:
+                    lse = (
+                        (row_max[r] * LOG2_E + cute.math.log2(s, fastmath=True)) * LN2
+                        if not zero_or_nan
+                        else Float32(-1e30)
+                    )
+                    mLSE[split_idx, q_head, batch] = lse

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -38,6 +38,15 @@ from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
 from flash_attn.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
 from flash_attn.cute.flash_fwd_sm100 import FlashAttentionForwardSm100, DescaleTensors
 from flash_attn.cute.flash_fwd_sm120 import FlashAttentionForwardSm120
+from flash_attn.cute.flash_fwd_decode_sm120 import FlashAttentionDecodeSm120
+from flash_attn.cute.sm120_paged_decode import (
+    Sm120PagedDecodeD256Metadata,
+    build_sm120_paged_decode_d256_compile_plan,
+    build_sm120_paged_decode_d256_warmup_plan,
+    select_sm120_paged_decode_d256_num_splits,
+    sm120_paged_decode_d256_available,
+    sm120_paged_decode_d256_enabled,
+)
 from flash_attn.cute.flash_bwd_preprocess import FlashAttentionBackwardPreprocess
 from flash_attn.cute.flash_bwd import FlashAttentionBackwardSm80
 from flash_attn.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
@@ -338,6 +347,174 @@ def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
     # NOTE: We should revisit this heuristic after persistence is supported for split KV.
     # Sometimes, it's ideal to over-schedule splits for better efficiency.
     return min(num_SMs // total_mblocks, max_splits, num_n_blocks)
+
+
+def _try_flash_attn_sm120_paged_decode_d256(
+    *,
+    q,
+    k,
+    v,
+    out,
+    lse,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_q,
+    seqused_k,
+    page_table,
+    batch_size,
+    total_q,
+    num_head,
+    num_head_kv,
+    head_dim,
+    head_dim_v,
+    q_dtype,
+    page_size,
+    max_seqlen_q,
+    max_seqlen_k,
+    softmax_scale,
+    causal,
+    local,
+    qv,
+    score_mod,
+    mask_mod,
+    softcap,
+    learnable_sink,
+    block_sparse_tensors,
+    q_descale,
+    k_descale,
+    v_descale,
+    requires_grad,
+    arch,
+    num_splits,
+    current_stream,
+    compile_only,
+):
+    """Launch the bounded SM120 BF16 D256 B1 paged-decode specialization.
+
+    Returning ``None`` means fail closed: the caller resumes the existing FA4
+    path.  This function owns no long-lived tensor/workspace cache; that is the
+    safe alternative to a hot-plan until a lifecycle proof is available.
+    """
+    if not sm120_paged_decode_d256_enabled():
+        return None
+    metadata = Sm120PagedDecodeD256Metadata(
+        capability=arch,
+        dtype=q_dtype,
+        batch_size=batch_size,
+        query_tokens=max_seqlen_q,
+        query_heads=num_head,
+        kv_heads=num_head_kv,
+        head_dim=head_dim,
+        page_size=page_size or 0,
+        kv_tokens=max_seqlen_k,
+        paged_kv=page_table is not None,
+        has_cu_seqlens_q=cu_seqlens_q is not None,
+        has_seqused_k=seqused_k is not None,
+        causal_or_full_decode=not local,
+        has_unsupported_feature=(
+            requires_grad
+            or total_q != 1
+            or head_dim_v != 256
+            or cu_seqlens_k is not None
+            or seqused_q is not None
+            or qv is not None
+            or score_mod is not None
+            or mask_mod is not None
+            or softcap is not None
+            or learnable_sink is not None
+            or block_sparse_tensors is not None
+            or q_descale is not None
+            or k_descale is not None
+            or v_descale is not None
+        ),
+    )
+    if not sm120_paged_decode_d256_available(metadata):
+        return None
+
+    selected_splits = select_sm120_paged_decode_d256_num_splits(metadata.kv_tokens)
+    if num_splits not in (0, 1, selected_splits):
+        return None
+
+    if isinstance(q, _CompileOnlyTensorSpec):
+        out_partial = _make_compile_only_tensor_spec(
+            (selected_splits, total_q, num_head, head_dim_v), torch.float32
+        )
+        lse_partial = _make_compile_only_tensor_spec(
+            (selected_splits, num_head, total_q), torch.float32, assumed_align=4
+        )
+    else:
+        out_partial = torch.empty(
+            selected_splits, total_q, num_head, head_dim_v,
+            dtype=torch.float32, device=v.device,
+        )
+        lse_partial = torch.empty(
+            selected_splits, num_head, total_q, dtype=torch.float32, device=v.device
+        )
+
+    decode_key = (cutlass.BFloat16, selected_splits, metadata.page_size)
+    if decode_key not in _flash_attn_fwd.sm120_paged_decode_cache:
+        decode = FlashAttentionDecodeSm120(
+            cutlass.BFloat16,
+            256,
+            256,
+            6,
+            selected_splits,
+            tile_n=32,
+            num_threads=256,
+            page_size=metadata.page_size,
+        )
+        _flash_attn_fwd.sm120_paged_decode_cache[decode_key] = cute.compile(
+            decode,
+            to_cute_tensor(q),
+            to_cute_tensor(k),
+            to_cute_tensor(v),
+            to_cute_tensor(out_partial, assumed_align=4),
+            to_cute_tensor(lse_partial, assumed_align=4),
+            Float32(softmax_scale),
+            to_cute_tensor(page_table),
+            to_cute_tensor(seqused_k),
+            current_stream,
+            options="--enable-tvm-ffi",
+        )
+
+    combine_key = (
+        cutlass.BFloat16,
+        Float32,
+        256,
+        8,
+        128,
+        max(math.ceil(math.log2(selected_splits)), 5),
+        True,
+        False,
+        lse is not None,
+        False,
+        None,
+    )
+    if combine_key not in _flash_attn_fwd_combine.compile_cache:
+        _flash_attn_fwd_combine.compile_cache[combine_key] = _compile_fwd_combine(
+            *combine_key
+        )
+    if compile_only:
+        return out, lse, None, None
+    if not is_fake_mode():
+        _flash_attn_fwd.sm120_paged_decode_cache[decode_key](
+            q.detach(),
+            k.detach(),
+            v.detach(),
+            out_partial,
+            lse_partial,
+            Float32(softmax_scale),
+            page_table,
+            seqused_k,
+        )
+        _flash_attn_fwd_combine(
+            out_partial,
+            lse_partial.transpose(-1, -2),
+            out,
+            lse.transpose(-1, -2) if lse is not None else None,
+            cu_seqlens_q,
+        )
+    return out, lse, None, None
 
 
 def _resolve_causal_local_window(causal, window_size_left, window_size_right, mask_mod=None):
@@ -659,6 +836,49 @@ def _flash_attn_fwd(
         seqlen_k_loaded = max(0, min(max_seqlen_k, win_right + win_left + 1 + tile_m))
     else:
         seqlen_k_loaded = max_seqlen_k
+
+    specialized_result = _try_flash_attn_sm120_paged_decode_d256(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        lse=lse,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        page_table=page_table,
+        batch_size=batch_size,
+        total_q=total_q,
+        num_head=num_head,
+        num_head_kv=num_head_kv,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        q_dtype=q_dtype,
+        page_size=page_size,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        local=local,
+        qv=qv,
+        score_mod=score_mod,
+        mask_mod=mask_mod,
+        softcap=softcap,
+        learnable_sink=learnable_sink,
+        block_sparse_tensors=block_sparse_tensors,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        requires_grad=requires_grad,
+        arch=arch,
+        num_splits=num_splits,
+        current_stream=current_stream,
+        compile_only=compile_only,
+    )
+    if specialized_result is not None:
+        return specialized_result
+
     num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
     total_mblocks = batch_size * num_head_kv * num_m_blocks
     num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
@@ -1268,6 +1488,7 @@ def _flash_attn_fwd(
 
 
 _flash_attn_fwd.compile_cache = get_jit_cache("fwd")
+_flash_attn_fwd.sm120_paged_decode_cache = get_jit_cache("sm120_paged_decode")
 
 
 def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k, nheads_major=False):
@@ -3028,6 +3249,102 @@ def flash_attn_varlen_func(
         out,
         output_scale,
     )
+
+
+def compile_sm120_paged_decode_d256_from_specs(
+    *,
+    kv_tokens: int,
+    page_size: int,
+    softmax_scale: Optional[float] = None,
+):
+    """Compile the bounded SM120 D256 paged-decode forward and combine pair.
+
+    This is deliberately a narrow public compile-only contract.  It is the
+    same selector used by runtime routing and it does not enumerate a shape
+    Cartesian product.
+    """
+    if not sm120_paged_decode_d256_enabled():
+        raise ValueError("FLASH_ATTENTION_SM120_DECODE_KERNEL is not enabled")
+    metadata = Sm120PagedDecodeD256Metadata(
+        capability=120,
+        dtype=torch.bfloat16,
+        batch_size=1,
+        query_tokens=1,
+        query_heads=24,
+        kv_heads=4,
+        head_dim=256,
+        page_size=page_size,
+        kv_tokens=kv_tokens,
+        paged_kv=True,
+        has_cu_seqlens_q=True,
+        has_seqused_k=True,
+    )
+    plan = build_sm120_paged_decode_d256_compile_plan(metadata)
+    num_splits = plan[0].num_splits
+    num_pages = (kv_tokens + page_size - 1) // page_size
+    q = _make_compile_only_tensor_spec((1, 24, 256), torch.bfloat16)
+    k = _make_compile_only_tensor_spec((num_pages, page_size, 4, 256), torch.bfloat16)
+    v = _make_compile_only_tensor_spec((num_pages, page_size, 4, 256), torch.bfloat16)
+    out = _make_compile_only_tensor_spec((1, 24, 256), torch.bfloat16)
+    return _flash_attn_fwd(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=_make_compile_only_tensor_spec((2,), torch.int32, 4),
+        seqused_k=_make_compile_only_tensor_spec((1,), torch.int32, 4),
+        page_table=_make_compile_only_tensor_spec((1, num_pages), torch.int32, 4),
+        max_seqlen_q=1,
+        max_seqlen_k=kv_tokens,
+        softmax_scale=softmax_scale,
+        num_splits=num_splits,
+        out=out,
+        _arch=120,
+        compile_only=True,
+    )
+
+
+def compile_sm120_paged_decode_d256_plan(metadata: Sm120PagedDecodeD256Metadata):
+    """Compile one vendor-owned plan; its single request includes forward+combine."""
+    if not sm120_paged_decode_d256_enabled():
+        raise ValueError("FLASH_ATTENTION_SM120_DECODE_KERNEL is not enabled")
+    plan = build_sm120_paged_decode_d256_compile_plan(metadata)
+    compile_sm120_paged_decode_d256_from_specs(
+        kv_tokens=plan[0].kv_tokens_witness,
+        page_size=plan[0].page_size,
+    )
+    return plan
+
+
+def compile_sm120_paged_decode_d256_warmup_plan(
+    metadata: Sm120PagedDecodeD256Metadata, max_kv_tokens: int
+):
+    """Compile the vendor-owned bounded witness set, including all combines."""
+    if not sm120_paged_decode_d256_enabled():
+        raise ValueError("FLASH_ATTENTION_SM120_DECODE_KERNEL is not enabled")
+    plan = build_sm120_paged_decode_d256_warmup_plan(metadata, max_kv_tokens)
+    for unit in plan:
+        if unit.kernel != "sm120_paged_decode_d256_forward":
+            continue
+        compile_sm120_paged_decode_d256_from_specs(
+            kv_tokens=unit.kv_tokens_witness,
+            page_size=unit.page_size,
+        )
+    return plan
+
+
+def try_launch_sm120_paged_decode_d256(
+    metadata: Sm120PagedDecodeD256Metadata, **flash_attn_varlen_kwargs
+) -> bool:
+    """Launch through the public varlen wrapper only when the vendor contract matches.
+
+    ``False`` is a no-side-effect fail-closed result; callers must use their
+    existing fallback.  On ``True`` the supplied output buffer has been written.
+    The wrapper rechecks the same metadata-derived contract before dispatch.
+    """
+    if not sm120_paged_decode_d256_enabled() or not sm120_paged_decode_d256_available(metadata):
+        return False
+    flash_attn_varlen_func(**flash_attn_varlen_kwargs)
+    return True
 
 
 def compile_flash_attn_varlen_func_from_specs(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -47,6 +47,11 @@ from flash_attn.cute.sm120_paged_decode import (
     sm120_paged_decode_d256_available,
     sm120_paged_decode_d256_enabled,
 )
+from flash_attn.cute.sm120_paged_decode_cache import (
+    Sm120PagedDecodeRuntimeCache,
+    current_stream_key,
+    is_current_stream_capturing,
+)
 from flash_attn.cute.flash_bwd_preprocess import FlashAttentionBackwardPreprocess
 from flash_attn.cute.flash_bwd import FlashAttentionBackwardSm80
 from flash_attn.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
@@ -443,12 +448,40 @@ def _try_flash_attn_sm120_paged_decode_d256(
             (selected_splits, num_head, total_q), torch.float32, assumed_align=4
         )
     else:
-        out_partial = torch.empty(
-            selected_splits, total_q, num_head, head_dim_v,
-            dtype=torch.float32, device=v.device,
+        runtime_stream_key = current_stream_key(q)
+        allow_runtime_cache = not is_current_stream_capturing()
+        workspace_key = (
+            selected_splits,
+            total_q,
+            num_head,
+            head_dim_v,
+            v.device,
         )
-        lse_partial = torch.empty(
-            selected_splits, num_head, total_q, dtype=torch.float32, device=v.device
+
+        def make_workspace():
+            return (
+                torch.empty(
+                    selected_splits,
+                    total_q,
+                    num_head,
+                    head_dim_v,
+                    dtype=torch.float32,
+                    device=v.device,
+                ),
+                torch.empty(
+                    selected_splits,
+                    num_head,
+                    total_q,
+                    dtype=torch.float32,
+                    device=v.device,
+                ),
+            )
+
+        out_partial, lse_partial = _flash_attn_fwd.sm120_paged_decode_runtime_cache.get_workspace(
+            workspace_key,
+            runtime_stream_key,
+            make_workspace,
+            allow_cache=allow_runtime_cache,
         )
 
     decode_key = (cutlass.BFloat16, selected_splits, metadata.page_size)
@@ -494,6 +527,32 @@ def _try_flash_attn_sm120_paged_decode_d256(
         _flash_attn_fwd_combine.compile_cache[combine_key] = _compile_fwd_combine(
             *combine_key
         )
+    if not isinstance(q, _CompileOnlyTensorSpec) and allow_runtime_cache:
+        hot_tensors = (q, k, v, out, cu_seqlens_q, seqused_k, page_table)
+        launcher_identity = (
+            id(_flash_attn_fwd.sm120_paged_decode_cache[decode_key]),
+            id(_flash_attn_fwd_combine.compile_cache[combine_key]),
+        )
+        plan_key = (decode_key, combine_key)
+        if _flash_attn_fwd.sm120_paged_decode_runtime_cache.get_hot_plan(
+            plan_key,
+            hot_tensors,
+            runtime_stream_key,
+            launcher_identity,
+            metadata.page_size,
+            selected_splits,
+        ) is None:
+            # A hot-plan hit is valid only when all caller-owned objects still
+            # match by weak identity and storage metadata. A miss intentionally
+            # takes this checked path and records no strong input references.
+            _flash_attn_fwd.sm120_paged_decode_runtime_cache.record_hot_plan(
+                plan_key,
+                hot_tensors,
+                runtime_stream_key,
+                launcher_identity,
+                metadata.page_size,
+                selected_splits,
+            )
     if compile_only:
         return out, lse, None, None
     if not is_fake_mode():
@@ -1489,6 +1548,7 @@ def _flash_attn_fwd(
 
 _flash_attn_fwd.compile_cache = get_jit_cache("fwd")
 _flash_attn_fwd.sm120_paged_decode_cache = get_jit_cache("sm120_paged_decode")
+_flash_attn_fwd.sm120_paged_decode_runtime_cache = Sm120PagedDecodeRuntimeCache()
 
 
 def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k, nheads_major=False):

--- a/flash_attn/cute/sm120_paged_decode.py
+++ b/flash_attn/cute/sm120_paged_decode.py
@@ -1,0 +1,143 @@
+"""Public contract for the bounded SM120 paged-decode specialization."""
+
+from dataclasses import dataclass
+import os
+
+import torch
+
+
+_PAGE_SIZES = (16, 784)
+_SPLITS = (16, 32, 48)
+
+
+@dataclass(frozen=True)
+class Sm120PagedDecodeD256Metadata:
+    """Runtime facts used to decide whether the specialization is available."""
+
+    capability: int
+    dtype: torch.dtype
+    batch_size: int
+    query_tokens: int
+    query_heads: int
+    kv_heads: int
+    head_dim: int
+    page_size: int
+    kv_tokens: int
+    paged_kv: bool
+    has_cu_seqlens_q: bool
+    has_seqused_k: bool
+    causal_or_full_decode: bool = True
+    has_unsupported_feature: bool = False
+
+
+@dataclass(frozen=True)
+class Sm120PagedDecodeCompileUnit:
+    """One exact, bounded compile request with its runtime witness."""
+
+    kernel: str
+    page_size: int
+    num_splits: int
+    kv_tokens_witness: int
+
+
+def select_sm120_paged_decode_d256_num_splits(kv_tokens: int) -> int:
+    """Select from the only supported SplitKV variants: 1/16/32/48."""
+    if kv_tokens < 0:
+        raise ValueError("kv_tokens must be non-negative")
+    if kv_tokens <= 256:
+        return 1
+    if kv_tokens <= 512:
+        return 16
+    if kv_tokens <= 1024:
+        return 32
+    return 48
+
+
+def sm120_paged_decode_d256_enabled() -> bool:
+    """Return whether the experimental vendor specialization is explicitly enabled."""
+    return os.environ.get("FLASH_ATTENTION_SM120_DECODE_KERNEL", "0").lower() in (
+        "1",
+        "true",
+        "on",
+        "yes",
+    )
+
+
+def sm120_paged_decode_d256_available(metadata: Sm120PagedDecodeD256Metadata) -> bool:
+    """Fail closed unless every supported geometry and feature condition holds."""
+    return (
+        metadata.capability == 120
+        and metadata.dtype == torch.bfloat16
+        and metadata.batch_size == 1
+        and metadata.query_tokens == 1
+        and metadata.query_heads == 24
+        and metadata.kv_heads == 4
+        and metadata.head_dim == 256
+        and metadata.page_size in _PAGE_SIZES
+        and metadata.kv_tokens > 256
+        and metadata.paged_kv
+        and metadata.has_cu_seqlens_q
+        and metadata.has_seqused_k
+        and metadata.causal_or_full_decode
+        and not metadata.has_unsupported_feature
+    )
+
+
+def build_sm120_paged_decode_d256_compile_plan(
+    metadata: Sm120PagedDecodeD256Metadata,
+) -> tuple[Sm120PagedDecodeCompileUnit, ...]:
+    """Return the forward/combine pair for one selector-derived witness."""
+    if not sm120_paged_decode_d256_available(metadata):
+        raise ValueError("metadata is outside the SM120 BF16 D256 paged-decode contract")
+    num_splits = select_sm120_paged_decode_d256_num_splits(metadata.kv_tokens)
+    if num_splits not in _SPLITS:
+        raise ValueError("metadata does not select a compiled SplitKV specialization")
+    return (
+        Sm120PagedDecodeCompileUnit(
+            kernel="sm120_paged_decode_d256_forward",
+            page_size=metadata.page_size,
+            num_splits=num_splits,
+            kv_tokens_witness=metadata.kv_tokens,
+        ),
+        Sm120PagedDecodeCompileUnit(
+            kernel="sm120_splitkv_combine",
+            page_size=metadata.page_size,
+            num_splits=num_splits,
+            kv_tokens_witness=metadata.kv_tokens,
+        ),
+    )
+
+
+def build_sm120_paged_decode_d256_warmup_plan(
+    metadata: Sm120PagedDecodeD256Metadata, max_kv_tokens: int
+) -> tuple[Sm120PagedDecodeCompileUnit, ...]:
+    """Enumerate at most three selector witnesses up to an engine's K bound.
+
+    The witnesses are selector boundary representatives, not a length/page/batch
+    Cartesian expansion.  Every returned forward unit is paired with its exact
+    SplitKV combine unit.
+    """
+    if max_kv_tokens < 0:
+        raise ValueError("max_kv_tokens must be non-negative")
+    units = []
+    for witness in (257, 513, 1025):
+        if witness > max_kv_tokens:
+            continue
+        witness_metadata = Sm120PagedDecodeD256Metadata(
+            capability=metadata.capability,
+            dtype=metadata.dtype,
+            batch_size=metadata.batch_size,
+            query_tokens=metadata.query_tokens,
+            query_heads=metadata.query_heads,
+            kv_heads=metadata.kv_heads,
+            head_dim=metadata.head_dim,
+            page_size=metadata.page_size,
+            kv_tokens=witness,
+            paged_kv=metadata.paged_kv,
+            has_cu_seqlens_q=metadata.has_cu_seqlens_q,
+            has_seqused_k=metadata.has_seqused_k,
+            causal_or_full_decode=metadata.causal_or_full_decode,
+            has_unsupported_feature=metadata.has_unsupported_feature,
+        )
+        units.extend(build_sm120_paged_decode_d256_compile_plan(witness_metadata))
+    return tuple(units)

--- a/flash_attn/cute/sm120_paged_decode_cache.py
+++ b/flash_attn/cute/sm120_paged_decode_cache.py
@@ -1,0 +1,168 @@
+"""Bounded, lifecycle-safe runtime state for the SM120 decode specialization."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+import weakref
+
+import torch
+
+
+_MAX_ITEMS_PER_STREAM = 8
+_T = TypeVar("_T")
+
+
+def current_stream_key(tensor: torch.Tensor) -> tuple[str, int | None, int]:
+    """Return a stream key without retaining the stream or input tensor."""
+    device = tensor.device
+    if device.type != "cuda":
+        return (device.type, device.index, 0)
+    stream = torch.cuda.current_stream(device)
+    return (device.type, device.index, int(stream.cuda_stream))
+
+
+def is_current_stream_capturing() -> bool:
+    """Keep mutable caches outside graph capture; captured calls use fallback state."""
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
+def _tensor_signature(tensor: torch.Tensor) -> tuple[object, ...]:
+    return (
+        tensor.data_ptr(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.device,
+    )
+
+
+@dataclass(frozen=True)
+class Sm120PagedDecodeHotPlan:
+    """A weak-reference-only witness for a safe hot-edge cache hit."""
+
+    tensor_refs: tuple[weakref.ReferenceType[torch.Tensor], ...]
+    tensor_signatures: tuple[tuple[object, ...], ...]
+    stream_key: tuple[str, int | None, int]
+    launcher_identity: tuple[int, int]
+    page_size: int
+    num_splits: int
+
+    def matches(
+        self,
+        tensors: tuple[torch.Tensor, ...],
+        stream_key: tuple[str, int | None, int],
+        launcher_identity: tuple[int, int],
+        page_size: int,
+        num_splits: int,
+    ) -> bool:
+        if (
+            self.stream_key != stream_key
+            or self.launcher_identity != launcher_identity
+            or self.page_size != page_size
+            or self.num_splits != num_splits
+            or len(tensors) != len(self.tensor_refs)
+        ):
+            return False
+        return all(
+            ref() is tensor and signature == _tensor_signature(tensor)
+            for ref, signature, tensor in zip(
+                self.tensor_refs, self.tensor_signatures, tensors, strict=True
+            )
+        )
+
+
+class Sm120PagedDecodeRuntimeCache(Generic[_T]):
+    """Per-stream LRU cache with no strong reference to caller-owned tensors.
+
+    Workspace tensors are owned by this cache deliberately and are bounded to
+    eight entries per stream. Input, output, page-table, and sequence-length
+    tensors are represented only by weak references in the hot plan.
+    """
+
+    def __init__(self, max_items_per_stream: int = _MAX_ITEMS_PER_STREAM) -> None:
+        self.max_items_per_stream = max_items_per_stream
+        self._hot_plans: dict[
+            tuple[str, int | None, int],
+            OrderedDict[tuple[object, ...], Sm120PagedDecodeHotPlan],
+        ] = {}
+        self._workspaces: dict[
+            tuple[str, int | None, int], OrderedDict[tuple[object, ...], _T]
+        ] = {}
+
+    def _bounded_put(self, ordered: OrderedDict[tuple[object, ...], _T], key, value) -> None:
+        ordered[key] = value
+        ordered.move_to_end(key)
+        while len(ordered) > self.max_items_per_stream:
+            ordered.popitem(last=False)
+
+    def get_hot_plan(
+        self,
+        plan_key: tuple[object, ...],
+        tensors: tuple[torch.Tensor, ...],
+        stream_key: tuple[str, int | None, int],
+        launcher_identity: tuple[int, int],
+        page_size: int,
+        num_splits: int,
+    ) -> Sm120PagedDecodeHotPlan | None:
+        plan = self._hot_plans.get(stream_key, {}).get(plan_key)
+        if plan is None or not plan.matches(
+            tensors, stream_key, launcher_identity, page_size, num_splits
+        ):
+            return None
+        self._hot_plans[stream_key].move_to_end(plan_key)
+        return plan
+
+    def record_hot_plan(
+        self,
+        plan_key: tuple[object, ...],
+        tensors: tuple[torch.Tensor, ...],
+        stream_key: tuple[str, int | None, int],
+        launcher_identity: tuple[int, int],
+        page_size: int,
+        num_splits: int,
+    ) -> Sm120PagedDecodeHotPlan | None:
+        try:
+            plan = Sm120PagedDecodeHotPlan(
+                tuple(weakref.ref(tensor) for tensor in tensors),
+                tuple(_tensor_signature(tensor) for tensor in tensors),
+                stream_key,
+                launcher_identity,
+                page_size,
+                num_splits,
+            )
+        except (RuntimeError, TypeError):
+            return None
+        plans = self._hot_plans.setdefault(stream_key, OrderedDict())
+        self._bounded_put(plans, plan_key, plan)
+        return plan
+
+    def get_workspace(
+        self,
+        workspace_key: tuple[object, ...],
+        stream_key: tuple[str, int | None, int],
+        factory: Callable[[], _T],
+        *,
+        allow_cache: bool,
+    ) -> _T:
+        if not allow_cache:
+            return factory()
+        workspaces = self._workspaces.setdefault(stream_key, OrderedDict())
+        value = workspaces.get(workspace_key)
+        if value is None:
+            value = factory()
+            self._bounded_put(workspaces, workspace_key, value)
+        else:
+            workspaces.move_to_end(workspace_key)
+        return value
+
+    def workspace_count(self, stream_key: tuple[str, int | None, int]) -> int:
+        return len(self._workspaces.get(stream_key, ()))
+
+    def hot_plan_count(self, stream_key: tuple[str, int | None, int]) -> int:
+        return len(self._hot_plans.get(stream_key, ()))
+
+    def clear(self) -> None:
+        self._hot_plans.clear()
+        self._workspaces.clear()

--- a/tests/cute/test_sm120_paged_decode_d256.py
+++ b/tests/cute/test_sm120_paged_decode_d256.py
@@ -1,0 +1,137 @@
+"""Focused tests for the bounded SM120 BF16 D256 paged-decode path."""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flash_attn.cute import flash_attn_varlen_func
+from flash_attn.cute.sm120_paged_decode import (
+    Sm120PagedDecodeD256Metadata,
+    build_sm120_paged_decode_d256_compile_plan,
+    build_sm120_paged_decode_d256_warmup_plan,
+    select_sm120_paged_decode_d256_num_splits,
+    sm120_paged_decode_d256_available,
+)
+
+
+def _metadata(**overrides):
+    values = dict(
+        capability=120,
+        dtype=torch.bfloat16,
+        batch_size=1,
+        query_tokens=1,
+        query_heads=24,
+        kv_heads=4,
+        head_dim=256,
+        page_size=784,
+        kv_tokens=4096,
+        paged_kv=True,
+        has_cu_seqlens_q=True,
+        has_seqused_k=True,
+    )
+    values.update(overrides)
+    return Sm120PagedDecodeD256Metadata(**values)
+
+
+@pytest.mark.parametrize(
+    ("kv_tokens", "expected"),
+    [(256, 1), (257, 16), (512, 16), (513, 32), (1024, 32), (1025, 48)],
+)
+def test_split_selector_boundaries(kv_tokens, expected):
+    assert select_sm120_paged_decode_d256_num_splits(kv_tokens) == expected
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"dtype": torch.float16},
+        {"head_dim": 128},
+        {"query_heads": 32},
+        {"kv_heads": 8},
+        {"page_size": 128},
+        {"has_unsupported_feature": True},
+    ],
+)
+def test_eligibility_fails_closed(override):
+    assert not sm120_paged_decode_d256_available(_metadata(**override))
+
+
+def test_compile_plan_contains_exact_forward_and_combine_witness():
+    plan = build_sm120_paged_decode_d256_compile_plan(_metadata(kv_tokens=513))
+    assert [(unit.kernel, unit.num_splits) for unit in plan] == [
+        ("sm120_paged_decode_d256_forward", 32),
+        ("sm120_splitkv_combine", 32),
+    ]
+
+
+def test_warmup_plan_is_bounded_and_deduplicated_by_selector_witness():
+    plan = build_sm120_paged_decode_d256_warmup_plan(_metadata(), 16_384)
+    forward = [unit for unit in plan if unit.kernel.endswith("forward")]
+    combine = [unit for unit in plan if unit.kernel.endswith("combine")]
+    assert [unit.num_splits for unit in forward] == [16, 32, 48]
+    assert [unit.num_splits for unit in combine] == [16, 32, 48]
+    assert [unit.kv_tokens_witness for unit in forward] == [257, 513, 1025]
+
+
+def _require_sm120():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("SM120-only specialization")
+
+
+@pytest.mark.parametrize("page_size,kv_tokens", [(16, 513), (784, 1025)])
+def test_paged_decode_matches_sdpa_and_cuda_graph_replay(
+    monkeypatch, page_size, kv_tokens
+):
+    _require_sm120()
+    monkeypatch.setenv("FLASH_ATTENTION_SM120_DECODE_KERNEL", "1")
+    torch.manual_seed(17)
+    device = torch.device("cuda")
+    pages = math.ceil(kv_tokens / page_size)
+    q = torch.randn(1, 24, 256, dtype=torch.bfloat16, device=device)
+    k = torch.randn(pages, page_size, 4, 256, dtype=torch.bfloat16, device=device)
+    v = torch.randn_like(k)
+    page_table = torch.arange(pages, dtype=torch.int32, device=device)[None]
+    cu_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_k = torch.tensor([kv_tokens], dtype=torch.int32, device=device)
+    out = torch.empty_like(q)
+    kwargs = dict(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        cu_seqlens_q=cu_q,
+        seqused_k=seqused_k,
+        max_seqlen_q=1,
+        max_seqlen_k=kv_tokens,
+        page_table=page_table,
+        causal=True,
+        num_splits=0,
+    )
+    flash_attn_varlen_func(**kwargs)
+    logical_k = k[page_table[0]].flatten(0, 1)[:kv_tokens]
+    logical_v = v[page_table[0]].flatten(0, 1)[:kv_tokens]
+    reference = (
+        F.scaled_dot_product_attention(
+            q.transpose(0, 1)[None].float(),
+            logical_k.transpose(0, 1)[None].repeat_interleave(6, dim=1).float(),
+            logical_v.transpose(0, 1)[None].repeat_interleave(6, dim=1).float(),
+            is_causal=False,
+        )
+        .squeeze(0)
+        .transpose(0, 1)
+        .to(torch.bfloat16)
+    )
+    torch.testing.assert_close(out, reference, atol=2e-2, rtol=2e-2)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        flash_attn_varlen_func(**kwargs)
+    page_table.copy_(torch.flip(page_table, dims=(1,)))
+    seqused_k.fill_(max(257, kv_tokens - 1))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.isfinite(out).all()

--- a/tests/cute/test_sm120_paged_decode_d256.py
+++ b/tests/cute/test_sm120_paged_decode_d256.py
@@ -1,18 +1,24 @@
 """Focused tests for the bounded SM120 BF16 D256 paged-decode path."""
 
 import math
+import gc
+from unittest.mock import MagicMock
+import weakref
 
 import pytest
 import torch
 import torch.nn.functional as F
 
 from flash_attn.cute import flash_attn_varlen_func
+from flash_attn.cute import interface as cute_interface
+from flash_attn.cute.sm120_paged_decode_cache import Sm120PagedDecodeRuntimeCache
 from flash_attn.cute.sm120_paged_decode import (
     Sm120PagedDecodeD256Metadata,
     build_sm120_paged_decode_d256_compile_plan,
     build_sm120_paged_decode_d256_warmup_plan,
     select_sm120_paged_decode_d256_num_splits,
     sm120_paged_decode_d256_available,
+    sm120_paged_decode_d256_enabled,
 )
 
 
@@ -56,6 +62,132 @@ def test_split_selector_boundaries(kv_tokens, expected):
 )
 def test_eligibility_fails_closed(override):
     assert not sm120_paged_decode_d256_available(_metadata(**override))
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "off", "no", "invalid", "2"])
+def test_opt_in_invalid_or_disabled_values_fail_closed(monkeypatch, value):
+    monkeypatch.setenv("FLASH_ATTENTION_SM120_DECODE_KERNEL", value)
+    assert not sm120_paged_decode_d256_enabled()
+
+
+def test_public_launcher_does_not_call_varlen_for_unsupported_metadata(monkeypatch):
+    monkeypatch.setenv("FLASH_ATTENTION_SM120_DECODE_KERNEL", "1")
+    varlen = MagicMock()
+    monkeypatch.setattr(cute_interface, "flash_attn_varlen_func", varlen)
+
+    launched = cute_interface.try_launch_sm120_paged_decode_d256(
+        _metadata(dtype=torch.float16),
+        q=object(),
+        k=object(),
+        v=object(),
+    )
+
+    assert not launched
+    varlen.assert_not_called()
+
+
+def _hot_plan_tensors():
+    return tuple(torch.empty((2, 2)) for _ in range(7))
+
+
+def test_hot_plan_requires_object_storage_stream_launcher_and_configuration_match():
+    cache = Sm120PagedDecodeRuntimeCache()
+    tensors = _hot_plan_tensors()
+    stream = ("cuda", 0, 11)
+    launcher = (101, 102)
+    key = ("decode", "combine")
+    cache.record_hot_plan(key, tensors, stream, launcher, 16, 16)
+
+    assert cache.get_hot_plan(key, tensors, stream, launcher, 16, 16) is not None
+    tensors[0].set_(torch.empty_like(tensors[0]))
+    assert cache.get_hot_plan(key, tensors, stream, launcher, 16, 16) is None
+
+    tensors = _hot_plan_tensors()
+    cache.record_hot_plan(key, tensors, stream, launcher, 16, 16)
+    replaced_output = (*tensors[:3], torch.empty_like(tensors[3]), *tensors[4:])
+    assert cache.get_hot_plan(key, replaced_output, stream, launcher, 16, 16) is None
+    assert cache.get_hot_plan(key, tensors, ("cuda", 0, 12), launcher, 16, 16) is None
+    assert cache.get_hot_plan(key, tensors, stream, (103, 102), 16, 16) is None
+    assert cache.get_hot_plan(key, tensors, stream, launcher, 784, 16) is None
+    assert cache.get_hot_plan(key, tensors, stream, launcher, 16, 32) is None
+
+
+def test_hot_plan_rejects_shape_stride_and_dtype_mutation():
+    cache = Sm120PagedDecodeRuntimeCache()
+    stream = ("cuda", 0, 11)
+    launcher = (101, 102)
+    key = ("decode", "combine")
+
+    tensors = _hot_plan_tensors()
+    cache.record_hot_plan(key, tensors, stream, launcher, 16, 16)
+    tensors[0].resize_(4, 1)
+    assert cache.get_hot_plan(key, tensors, stream, launcher, 16, 16) is None
+
+    tensors = _hot_plan_tensors()
+    cache.record_hot_plan(key, tensors, stream, launcher, 16, 16)
+    tensors[0].as_strided_((2, 2), (1, 2))
+    assert cache.get_hot_plan(key, tensors, stream, launcher, 16, 16) is None
+
+    tensors = _hot_plan_tensors()
+    cache.record_hot_plan(key, tensors, stream, launcher, 16, 16)
+    tensors[0].data = tensors[0].to(torch.bfloat16)
+    assert cache.get_hot_plan(key, tensors, stream, launcher, 16, 16) is None
+
+
+def test_hot_plan_uses_weak_input_references_and_allows_page_content_updates():
+    cache = Sm120PagedDecodeRuntimeCache()
+    tensors = list(_hot_plan_tensors())
+    stream = ("cuda", 0, 11)
+    launcher = (101, 102)
+    cache.record_hot_plan(
+        ("decode", "combine"), tuple(tensors), stream, launcher, 16, 16
+    )
+    tensors[5].fill_(1)
+    tensors[6].fill_(2)
+    assert (
+        cache.get_hot_plan(
+            ("decode", "combine"), tuple(tensors), stream, launcher, 16, 16
+        )
+        is not None
+    )
+
+    input_ref = weakref.ref(tensors[0])
+    tensors[0] = torch.empty_like(tensors[0])
+    gc.collect()
+    assert input_ref() is None
+
+
+def test_workspace_cache_is_bounded_per_stream_and_capture_falls_back():
+    cache = Sm120PagedDecodeRuntimeCache()
+    stream = ("cuda", 0, 11)
+    created = []
+
+    def make_workspace():
+        workspace = object()
+        created.append(workspace)
+        return workspace
+
+    first = cache.get_workspace((0,), stream, make_workspace, allow_cache=True)
+    for index in range(1, 9):
+        cache.get_workspace((index,), stream, make_workspace, allow_cache=True)
+    assert cache.workspace_count(stream) == 8
+    assert (
+        cache.get_workspace((0,), stream, make_workspace, allow_cache=True) is not first
+    )
+
+    capture_stream = ("cuda", 0, 12)
+    first_capture = cache.get_workspace(
+        (0,), capture_stream, make_workspace, allow_cache=False
+    )
+    second_capture = cache.get_workspace(
+        (0,), capture_stream, make_workspace, allow_cache=False
+    )
+    assert first_capture is not second_capture
+    assert cache.workspace_count(capture_stream) == 0
+
+    cache.clear()
+    assert cache.workspace_count(stream) == 0
+    assert cache.hot_plan_count(stream) == 0
 
 
 def test_compile_plan_contains_exact_forward_and_combine_witness():

--- a/tests/test_flash_attn_package_init.py
+++ b/tests/test_flash_attn_package_init.py
@@ -1,0 +1,61 @@
+"""Package-boundary tests for co-installed FA2 and FA4 distributions."""
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+import flash_attn
+
+
+def test_fa4_child_package_does_not_eagerly_import_legacy_fa2(monkeypatch):
+    def fail_legacy_import(*args, **kwargs):
+        raise AssertionError("FA2 interface must stay lazy while importing FA4")
+
+    monkeypatch.setattr(flash_attn, "import_module", fail_legacy_import)
+
+    cute = importlib.import_module("flash_attn.cute")
+
+    assert cute.__name__ == "flash_attn.cute"
+
+
+def test_legacy_top_level_api_loads_and_caches_when_present(monkeypatch):
+    name = "flash_attn_func"
+    expected = object()
+    legacy_interface = SimpleNamespace(**{name: expected})
+
+    monkeypatch.delitem(flash_attn.__dict__, name, raising=False)
+    monkeypatch.setattr(flash_attn, "import_module", lambda *args: legacy_interface)
+
+    assert getattr(flash_attn, name) is expected
+    assert getattr(flash_attn, name) is expected
+
+
+def test_missing_legacy_extension_has_an_explicit_error(monkeypatch):
+    def missing_legacy_extension(*args, **kwargs):
+        raise ModuleNotFoundError(
+            "No module named 'flash_attn_2_cuda'", name="flash_attn_2_cuda"
+        )
+
+    monkeypatch.delitem(flash_attn.__dict__, "flash_attn_func", raising=False)
+    monkeypatch.setattr(flash_attn, "import_module", missing_legacy_extension)
+
+    with pytest.raises(ModuleNotFoundError, match="requires the FA2 extension"):
+        flash_attn.flash_attn_func
+
+
+def test_non_legacy_import_error_is_not_rewritten(monkeypatch):
+    expected = ModuleNotFoundError(
+        "No module named 'another_dependency'", name="another_dependency"
+    )
+
+    def missing_other_dependency(*args, **kwargs):
+        raise expected
+
+    monkeypatch.delitem(flash_attn.__dict__, "flash_attn_func", raising=False)
+    monkeypatch.setattr(flash_attn, "import_module", missing_other_dependency)
+
+    with pytest.raises(ModuleNotFoundError) as raised:
+        flash_attn.flash_attn_func
+
+    assert raised.value is expected


### PR DESCRIPTION
> **WIP/RFC — default-off, known Long-K regression, and not merge-ready.**
> This Draft does not request merge or claim that the performance gates pass.
> Its purpose is to request maintainer design feedback before any further
> implementation work.

## Scope

This opt-in specialization is limited to SM120, BF16, B1/Q1,
`24Q/4KV/D256`, paged KV, page sizes 16/784, and bounded SplitKV `{16,32,48}`.
It includes fail-closed metadata routing, compile-only forward/combine
witnesses, and a bounded weak-reference hot-plan/per-stream workspace cache.

It does not claim generic D256, arbitrary page sizes, FP8, D128 acceleration,
GDN/MLP/scheduler work, split96, a generic SM12x rewrite, or a full-model
performance gain. Unsupported shapes and features follow the existing path.

## Known performance result — this is why this is WIP/RFC

The default-off specialization was measured with an attention-backend replay
using `B1/Q1/24Q/4KV/D256`, page784, public wrapper, SplitKV combine, CUDA
Graph, and five fresh processes:

| KV length | FA2/FA4 median | P10 |
| --- | ---: | ---: |
| 4K | `1.336331x` | `1.336123x` |
| 8K | `1.019905x` | `1.019669x` |
| 16K | `0.791393x` | `0.791236x` |

Thus this does **not** pass its Long-K floor and is not merge-ready. The
aggregate geomean median/P10 is `1.025557x`/`1.025509x`, versus required
`>=1.03x`/`>=1.01x`. This WIP/RFC neither claims a performance gate pass nor
asks reviewers to accept the current 16K behavior.

## Long-K investigation already performed

An actual cubin/Driver-API diagnosis shows the forward launcher at 250
registers/thread and 81,920 B dynamic shared memory, with one CTA/SM and eight
warps/SM. Fixed split48 raises maximum serial K-tile loops from 3 at 4K to 6
at 8K and 11 at 16K. The diagnosis supports a residency constraint and
Long-K serial-work growth; it does not claim hardware-counter attribution for
cp.async stalls.

Three mutually isolated Long-K candidates were evaluated and rejected during
this investigation:

| Candidate | Result at 16K | Reason not retained |
| --- | ---: | --- |
| Q heads/CTA `6 -> 3` | `+13.25%` latency | resources fell but shared memory still limited residency to one CTA/SM; K/V reads doubled |
| bounded `split48 -> split64` | `+37.65%` latency | shorter loop did not cross the residency limit and extra partial work dominated |
| direct 128-bit global-to-register K/V loads | `-2.1839%` latency | real cp.async removal and resource reduction, but below the required 10% threshold |

No candidate was incorporated into this branch. No candidate five-process run
was performed after the promotion rule rejected it.

## Specific feedback requested

1. For a long-K decode-only path on SM120, would maintainers prefer a distinct
   parallel decomposition / query-head grouping design, or a runtime `K > 8K`
   fallback to the existing FA2 path?
2. If a distinct long-K kernel is preferable, which dataflow boundary is most
   appropriate to upstream first: reducing per-CTA live state, changing CTA
   decomposition, or a new load/reduction decomposition?
3. Is an explicit, tested `K > 8K` FA2 fallback the preferred safety boundary
   while a long-K specialization is developed?

## Build, tests, and reproduction boundary

The Vendor branch in this Draft is clean, signed-off, and based on current
main.
Fresh C++20 FA4/root wheels installed outside the checkout; `flash_attn.cute`,
`_vllm_fa2_C`, and `_vllm_fa3_C` loaded from site-packages, and focused vendor
plus SM120 page16/page784 CUDA Graph tests passed. The ordinary-SM120
`mDynamicCausal` failure reproduces unchanged at base and head and is tracked
as `BASELINE_XFAIL / NON_BLOCKING`.

The specialization is opt-in and fail-closed. Removing these commits or
leaving the opt-in disabled restores the existing behavior. No upstream pin,
companion vLLM PR, CI result, or merge request is implied by this RFC.
