### PR TITLE
FA4 Hopper optimizations

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -33,8 +33,19 @@ class BlockInfo:
             m_idx_max = (m_block + 1) * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
                 m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
-            n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            seqlen_k_for_mask = (
+                seqlen_info.tot_seqlen_k
+                if const_expr(seqlen_info.cp_world_size > 1)
+                else seqlen_info.seqlen_k
+            )
+            n_idx = m_idx_max + seqlen_k_for_mask - seqlen_info.seqlen_q
             n_idx_right = n_idx if const_expr(self.is_causal) else n_idx + self.window_size_right
+            if const_expr(seqlen_info.cp_world_size > 1):
+                n_idx_right = cute.ceil_div(
+                    n_idx_right - seqlen_info.cp_rank,
+                    seqlen_info.cp_world_size,
+                )
+                n_idx_right = cutlass.max(n_idx_right, 0)
             n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
         n_block_min = 0
         if const_expr(self.is_local and self.window_size_left is not None):
@@ -109,6 +120,10 @@ class BlockInfo:
         n_block_min: Int32,
     ) -> Int32:
         """If we have separate iterations with causal or local masking at the start, where do we stop"""
+        if const_expr(seqlen_info.cp_world_size > 1):
+            # Context-parallel key coordinates are strided in global sequence
+            # space, so conservatively mask every local tile.
+            return n_block_min
         m_idx_min = m_block * self.tile_m
         if const_expr(self.qhead_per_kvhead_packgqa > 1):
             m_idx_min = m_idx_min // self.qhead_per_kvhead_packgqa
@@ -149,8 +164,19 @@ class BlockInfo:
             m_idx_max = (m_block + 1) * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
                 m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
-            n_idx_right = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            seqlen_k_for_mask = (
+                seqlen_info.tot_seqlen_k
+                if const_expr(seqlen_info.cp_world_size > 1)
+                else seqlen_info.seqlen_k
+            )
+            n_idx_right = m_idx_max + seqlen_k_for_mask - seqlen_info.seqlen_q
             if const_expr(self.window_size_right is not None):
                 n_idx_right += self.window_size_right
+            if const_expr(seqlen_info.cp_world_size > 1):
+                n_idx_right = cute.ceil_div(
+                    n_idx_right - seqlen_info.cp_rank,
+                    seqlen_info.cp_world_size,
+                )
+                n_idx_right = cutlass.max(n_idx_right, 0)
             n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
         return n_block_max

--- a/flash_attn/cute/flash_fwd_combine.py
+++ b/flash_attn/cute/flash_fwd_combine.py
@@ -209,6 +209,7 @@ class FlashAttentionForwardCombine:
         varlen_batch_idx: Optional[cute.Tensor] = None,
         semaphore_to_reset: Optional[cute.Tensor] = None,
         output_scale: Optional[cute.Tensor] = None,
+        max_seqlen_q: Optional[Int32] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -297,8 +298,13 @@ class FlashAttentionForwardCombine:
         seqlen_divmod = FastDivmodDivisor(seqlen)
         head_divmod = FastDivmodDivisor(num_head)
 
+        grid_seqlen = (
+            max_seqlen_q
+            if const_expr(cu_seqlens is not None and max_seqlen_q is not None)
+            else seqlen
+        )
         grid_dim = (
-            cute.ceil_div(seqlen * num_head, self.tile_m),
+            cute.ceil_div(grid_seqlen * num_head, self.tile_m),
             cute.ceil_div(self.head_dim, self.k_block_size),
             batch_size,
         )

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -38,15 +38,22 @@ from flash_attn.cute.paged_kv import PagedKVManager
 from flash_attn.cute.named_barrier import NamedBarrierFwd
 from quack.cute_dsl_utils import ParamsBase
 from flash_attn.cute.tile_scheduler import (
-    TileSchedulerArguments,
+    HopperTileSchedulerArguments,
+    WorkTileInfo,
     SingleTileScheduler,
     SingleTileLPTScheduler,
     SingleTileVarlenScheduler,
+    StaticPersistentVarlenTileScheduler,
+    DynamicPersistentVarlenTileScheduler,
 )
 from cutlass.cute import FastDivmodDivisor
 
 from flash_attn.cute.flash_fwd import FlashAttentionForwardBase
 from flash_attn.cute.utils import AuxData
+
+
+def _use_paged_kv_overlap_sm90(intra_wg_overlap, paged_kv_non_tma, tile_n):
+    return intra_wg_overlap and paged_kv_non_tma and tile_n == 128
 
 
 class FlashAttentionForwardSm90(FlashAttentionForwardBase):
@@ -57,6 +64,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mma_pv_is_rs: bool = True,
         paged_kv_non_tma: bool = False,
         is_split_kv: bool = False,
+        use_persistent_varlen: bool = False,
+        use_dynamic_varlen: bool = False,
+        persistent_scheduler_sm_count: Optional[int] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -64,10 +74,23 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             f"Fused quant output not implemented for {type(self).__name__}"
         )
         self.intra_wg_overlap = intra_wg_overlap
+        self.use_paged_kv_overlap = _use_paged_kv_overlap_sm90(
+            self.intra_wg_overlap,
+            paged_kv_non_tma,
+            self.tile_n,
+        )
         self.mma_pv_is_rs = mma_pv_is_rs
         self.buffer_align_bytes = 1024
         self.use_tma_KV = not paged_kv_non_tma
         self.is_split_kv = is_split_kv
+        self.use_persistent_varlen = use_persistent_varlen
+        self.use_dynamic_varlen = use_dynamic_varlen
+        assert not (self.use_persistent_varlen and self.use_dynamic_varlen)
+        self.persistent_scheduler_sm_count = persistent_scheduler_sm_count
+        assert (
+            not (self.use_persistent_varlen or self.use_dynamic_varlen)
+            or self.persistent_scheduler_sm_count is not None
+        )
         assert self.use_tma_KV or not (self.check_hdim_oob or self.check_hdim_v_oob), (
             "Paged KV does not support irregular head dim"
         )
@@ -142,12 +165,16 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mbar_ptr_Q_struct = cute.struct.MemRange[cutlass.Int64, 1 * 2]
         mbar_ptr_K_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
         mbar_ptr_V_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
+        work_info_struct = cute.struct.MemRange[
+            cutlass.Int32, 2 * 5 if const_expr(self.use_dynamic_varlen) else 0
+        ]
 
         @cute.struct
         class SharedStorageQKV:
             mbar_ptr_Q: mbar_ptr_Q_struct
             mbar_ptr_K: mbar_ptr_K_struct
             mbar_ptr_V: mbar_ptr_V_struct
+            work_info: work_info_struct
             sV: sV_struct
             sQ: sQ_struct
             sK: sK_struct
@@ -158,6 +185,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mbar_ptr_Q: mbar_ptr_Q_struct
             mbar_ptr_K: mbar_ptr_K_struct
             mbar_ptr_V: mbar_ptr_V_struct
+            work_info: work_info_struct
             sQ: sQV_struct
             sK: sK_struct
             sP: sP_struct
@@ -185,6 +213,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
         output_scale: Optional[cute.Tensor] = None,
+        mSchedulerWorkspace: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -336,14 +365,22 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 (self.tile_m, self.tile_hdimv),  # No mcast
             )
         if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
-            TileScheduler = SingleTileVarlenScheduler
+            TileScheduler = (
+                DynamicPersistentVarlenTileScheduler
+                if const_expr(self.use_dynamic_varlen)
+                else (
+                    StaticPersistentVarlenTileScheduler
+                    if const_expr(self.use_persistent_varlen)
+                    else SingleTileVarlenScheduler
+                )
+            )
         else:
             TileScheduler = (
                 SingleTileScheduler
                 if const_expr(not self.is_causal or self.is_local)
                 else SingleTileLPTScheduler
             )
-        tile_sched_args = TileSchedulerArguments(
+        tile_sched_args = HopperTileSchedulerArguments(
             cute.ceil_div(cute.size(mQ.shape[0]), self.tile_m),
             cute.size(mQ.shape[2]),
             cute.size(mQ.shape[3])
@@ -366,9 +403,21 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             is_persistent=False,
             lpt=self.is_causal or self.is_local,
             is_split_kv=self.is_split_kv,
+            use_dynamic_gqa_l2_budget=self.use_dynamic_varlen
+            and self.pack_gqa
+            and self.tile_hdim == 128,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
-        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+        grid_dim = (
+            TileScheduler.get_grid_shape(
+                tile_sched_params,
+                sm_count=self.persistent_scheduler_sm_count,
+            )
+            if const_expr(
+                self.use_persistent_varlen or self.use_dynamic_varlen
+            )
+            else TileScheduler.get_grid_shape(tile_sched_params)
+        )
         softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(
             softmax_scale, self.score_mod
         )
@@ -418,6 +467,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             aux_data,
             fastdiv_mods,
             output_scale,
+            mSchedulerWorkspace,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -467,6 +517,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
         output_scale: Optional[cute.Tensor] = None,
+        mSchedulerWorkspace: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # Prefetch tma descriptor
@@ -563,6 +614,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             sP = storage.sP.get_tensor(sP_layout.outer, swizzle=sP_layout.inner)
         # reuse sQ's data iterator
         sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
+        sWorkInfo = (
+            storage.work_info.get_tensor(
+                cute.make_layout((5, 2), stride=(1, 5))
+            )
+            if const_expr(self.use_dynamic_varlen)
+            else None
+        )
 
         block_info = BlockInfo(
             self.tile_m,
@@ -629,6 +687,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 block_info,
                 SeqlenInfoCls,
                 TileSchedulerCls,
+                sWorkInfo,
+                mSchedulerWorkspace,
                 num_splits,
             )
 
@@ -662,11 +722,33 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 SeqlenInfoCls,
                 AttentionMaskCls,
                 TileSchedulerCls,
+                sWorkInfo,
                 blocksparse_tensors,
                 aux_data,
                 fastdiv_mods,
                 num_splits,
             )
+
+        if const_expr(self.use_dynamic_varlen):
+            cute.arch.sync_threads()
+            tidx, _, _ = cute.arch.thread_idx()
+            if tidx == 0:
+                # Workspace layout is [work counter, completion counter]. The
+                # last finishing CTA resets both for the next exclusive launch.
+                done_ptr = (mSchedulerWorkspace.iterator + 1).llvm_ptr
+                done = cute.arch.atomic_add(
+                    done_ptr, Int32(1), sem="release", scope="gpu"
+                )
+                if done == cute.arch.grid_dim()[0] - 1:
+                    cute.arch.store(
+                        mSchedulerWorkspace.iterator.llvm_ptr,
+                        Int32(0),
+                        sem="release",
+                        scope="gpu",
+                    )
+                    cute.arch.store(
+                        done_ptr, Int32(0), sem="release", scope="gpu"
+                    )
 
     @cute.jit
     def load(
@@ -689,6 +771,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
+        sWorkInfo: Optional[cute.Tensor],
+        mSchedulerWorkspace: Optional[cute.Tensor],
         num_splits: Int32 = Int32(1),
     ):
         warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
@@ -700,13 +784,26 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         # KV loading restricted to warp 0 for TMA, all warps for non-TMA KV
         is_kv_load_warp = warp_idx_in_wg == 0 or const_expr(not self.use_tma_KV)
 
-        if is_load_warp:
+        if is_load_warp or const_expr(self.use_dynamic_varlen):
             q_producer_phase = Int32(1)
             kv_producer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer, self.num_stages
             )
             tile_scheduler = TileSchedulerCls()
-            work_tile = tile_scheduler.initial_work_tile_info()
+            work_info_phase = Int32(0)
+            work_tile = (
+                self.publish_dynamic_work(
+                    tile_scheduler,
+                    mSchedulerWorkspace,
+                    sWorkInfo,
+                    work_info_phase,
+                    warp_idx_in_wg,
+                )
+                if const_expr(self.use_dynamic_varlen)
+                else tile_scheduler.initial_work_tile_info()
+            )
+            if const_expr(self.use_dynamic_varlen):
+                work_info_phase ^= 1
             while work_tile.is_valid_tile:
                 # if work_tile.is_valid_tile:
                 m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
@@ -771,6 +868,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         self.num_threads_per_warp_group,
                         mK.element_type,
                         arch=self.arch.major * 10 + self.arch.minor,
+                        cache_v_ptr=self.use_paged_kv_overlap,
                     )
 
                 load_K = partial(
@@ -835,7 +933,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     if is_kv_load_warp:
                         pipeline_k.producer_acquire(kv_producer_state)
                         if const_expr(not self.use_tma_KV):
-                            paged_kv_manager.load_page_table(n_block)
+                            paged_kv_manager.load_page_table(n_block, mask_seqlen=True)
+                            if const_expr(self.use_paged_kv_overlap):
+                                paged_kv_manager.update_V_ptr()
                         load_K(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)
                     if const_expr(self.use_tma_Q):
                         if warp_idx_in_wg == 0:
@@ -852,7 +952,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         q_producer_phase ^= 1
 
                     if is_kv_load_warp:
-                        if const_expr(not self.intra_wg_overlap or not self.use_tma_KV):
+                        if const_expr(
+                            not self.intra_wg_overlap
+                            or (not self.use_tma_KV and not self.use_paged_kv_overlap)
+                        ):
                             pipeline_v.producer_acquire(kv_producer_state)
                             load_V(
                                 block=n_block, producer_state=kv_producer_state, page_idx=page_idx
@@ -866,18 +969,22 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                                     else None
                                 )
                                 if const_expr(not self.use_tma_KV):
-                                    paged_kv_manager.load_page_table(n_block)
+                                    paged_kv_manager.load_page_table(
+                                        n_block, mask_seqlen=False
+                                    )
                                 pipeline_k.producer_acquire(kv_producer_state)
                                 load_K(
                                     block=n_block,
                                     producer_state=kv_producer_state,
                                     page_idx=page_idx,
+                                    mask_seqlen=False,
                                 )
                                 pipeline_v.producer_acquire(kv_producer_state)
                                 load_V(
                                     block=n_block,
                                     producer_state=kv_producer_state,
                                     page_idx=page_idx,
+                                    mask_seqlen=False,
                                 )
                                 kv_producer_state.advance()
                         else:
@@ -886,38 +993,64 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                                 n_block = n_block_prev - 1
                                 page_idx = (
                                     mPageTable[batch_idx, n_block]
-                                    if const_expr(mPageTable is not None)
+                                    if const_expr(mPageTable is not None and self.use_tma_KV)
                                     else None
                                 )
                                 page_idx_prev = (
                                     mPageTable[batch_idx, n_block_prev]
-                                    if const_expr(mPageTable is not None)
+                                    if const_expr(mPageTable is not None and self.use_tma_KV)
                                     else None
                                 )
                                 kv_producer_state_prev = kv_producer_state.clone()
                                 kv_producer_state.advance()
+                                if const_expr(not self.use_tma_KV):
+                                    paged_kv_manager.load_page_table(
+                                        n_block, mask_seqlen=False
+                                    )
                                 pipeline_k.producer_acquire(kv_producer_state)
                                 load_K(
                                     block=n_block,
                                     producer_state=kv_producer_state,
                                     page_idx=page_idx,
+                                    mask_seqlen=False,
                                 )
                                 pipeline_v.producer_acquire(kv_producer_state_prev)
-                                load_V(
-                                    block=n_block_prev,
-                                    producer_state=kv_producer_state_prev,
-                                    page_idx=page_idx_prev,
-                                )
+                                if const_expr(self.use_tma_KV):
+                                    load_V(
+                                        block=n_block_prev,
+                                        producer_state=kv_producer_state_prev,
+                                        page_idx=page_idx_prev,
+                                    )
+                                else:
+                                    self.load_paged_V_cached(
+                                        paged_kv_manager,
+                                        sV,
+                                        n_block_prev,
+                                        pipeline_v,
+                                        kv_producer_state_prev,
+                                    )
                             n_block = n_block_min
                             page_idx = (
                                 mPageTable[batch_idx, n_block]
-                                if const_expr(mPageTable is not None)
+                                if const_expr(mPageTable is not None and self.use_tma_KV)
                                 else None
                             )
                             pipeline_v.producer_acquire(kv_producer_state)
-                            load_V(
-                                block=n_block, producer_state=kv_producer_state, page_idx=page_idx
-                            )
+                            if const_expr(self.use_tma_KV):
+                                load_V(
+                                    block=n_block,
+                                    producer_state=kv_producer_state,
+                                    page_idx=page_idx,
+                                )
+                            else:
+                                self.load_paged_V_cached(
+                                    paged_kv_manager,
+                                    sV,
+                                    n_block,
+                                    pipeline_v,
+                                    kv_producer_state,
+                                    update_cache=False,
+                                )
                             kv_producer_state.advance()
                 else:
                     # Block sparsity: use TMA closures directly (not paged)
@@ -952,9 +1085,18 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                             self.q_subtile_factor,
                         )
 
-                tile_scheduler.prefetch_next_work()
-                tile_scheduler.advance_to_next_work()
-                work_tile = tile_scheduler.get_current_work()
+                if const_expr(self.use_dynamic_varlen):
+                    work_tile = self.publish_dynamic_work(
+                        tile_scheduler,
+                        mSchedulerWorkspace,
+                        sWorkInfo,
+                        work_info_phase,
+                        warp_idx_in_wg,
+                    )
+                    work_info_phase ^= 1
+                else:
+                    tile_scheduler.prefetch_next_work()
+                    work_tile = tile_scheduler.advance_to_next_work()
                 # End of persistent scheduler loop
 
             # Producer tail is only useful for cluster to avoid early exit of blocks.
@@ -962,6 +1104,56 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             # need it for Q (no cluster) and K.
             if is_kv_load_warp:
                 pipeline_v.producer_tail(kv_producer_state)
+
+    @cute.jit
+    def read_dynamic_work(
+        self, sWorkInfo: cute.Tensor, work_info_phase: Int32
+    ) -> WorkTileInfo:
+        return WorkTileInfo(
+            (
+                Int32(sWorkInfo[0, work_info_phase]),
+                Int32(sWorkInfo[1, work_info_phase]),
+                Int32(sWorkInfo[2, work_info_phase]),
+                Int32(sWorkInfo[3, work_info_phase]),
+            ),
+            sWorkInfo[4, work_info_phase] != 0,
+        )
+
+    @cute.jit
+    def publish_dynamic_work(
+        self,
+        tile_scheduler: DynamicPersistentVarlenTileScheduler,
+        mSchedulerWorkspace: cute.Tensor,
+        sWorkInfo: Optional[cute.Tensor],
+        work_info_phase: Int32,
+        warp_idx_in_wg: Int32,
+    ) -> WorkTileInfo:
+        if warp_idx_in_wg == 0:
+            claimed_work = tile_scheduler.claim_next_work(mSchedulerWorkspace)
+            if cute.arch.lane_idx() == 0:
+                m_block, head_idx, batch_idx, split_idx = claimed_work.tile_idx
+                sWorkInfo[0, work_info_phase] = m_block
+                sWorkInfo[1, work_info_phase] = head_idx
+                sWorkInfo[2, work_info_phase] = batch_idx
+                sWorkInfo[3, work_info_phase] = split_idx
+                sWorkInfo[4, work_info_phase] = (
+                    Int32(1) if claimed_work.is_valid_tile else Int32(0)
+                )
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.PFull),
+            number_of_threads=self.num_threads,
+        )
+        return self.read_dynamic_work(sWorkInfo, work_info_phase)
+
+    @cute.jit
+    def wait_dynamic_work(
+        self, sWorkInfo: cute.Tensor, work_info_phase: Int32
+    ) -> WorkTileInfo:
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.PFull),
+            number_of_threads=self.num_threads,
+        )
+        return self.read_dynamic_work(sWorkInfo, work_info_phase)
 
     @cute.jit
     def load_KV(
@@ -974,14 +1166,38 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         producer_state: pipeline.PipelineState,
         K_or_V: Literal["K", "V"],
         page_idx: Optional[Int32] = None,
+        mask_seqlen: cutlass.Constexpr[bool] = True,
     ):
         if const_expr(self.use_tma_KV):
             src_idx = block if const_expr(page_idx is None) else page_idx
             tma_load_fn(src_idx=src_idx, producer_state=producer_state)
         else:
-            paged_kv_manager.load_KV(block, sX[None, None, producer_state.index], K_or_V)
+            paged_kv_manager.load_KV(
+                block,
+                sX[None, None, producer_state.index],
+                K_or_V,
+                mask_seqlen=mask_seqlen,
+            )
             cute.arch.cp_async_commit_group()
         pipeline_kv.producer_commit(producer_state)
+
+    @cute.jit
+    def load_paged_V_cached(
+        self,
+        paged_kv_manager: PagedKVManager,
+        sV: cute.Tensor,
+        block: Int32,
+        pipeline_v: pipeline.PipelineAsync,
+        producer_state: pipeline.PipelineState,
+        update_cache: cutlass.Constexpr[bool] = True,
+    ):
+        paged_kv_manager.load_V_cached(
+            block,
+            sV[None, None, producer_state.index],
+            update_cache=update_cache,
+        )
+        cute.arch.cp_async_commit_group()
+        pipeline_v.producer_commit(producer_state)
 
     @cute.jit
     def mma(
@@ -1008,6 +1224,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         SeqlenInfoCls: Callable,
         AttentionMaskCls: Callable,
         TileSchedulerCls: Callable,
+        sWorkInfo: cute.Tensor,
         blocksparse_tensors: Optional[BlockSparseTensors],
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
@@ -1050,7 +1267,14 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         )
 
         tile_scheduler = TileSchedulerCls()
-        work_tile = tile_scheduler.initial_work_tile_info()
+        work_info_phase = Int32(0)
+        work_tile = (
+            self.wait_dynamic_work(sWorkInfo, work_info_phase)
+            if const_expr(self.use_dynamic_varlen)
+            else tile_scheduler.initial_work_tile_info()
+        )
+        if const_expr(self.use_dynamic_varlen):
+            work_info_phase ^= 1
         softmax = Softmax.create(
             softmax_scale_log2,
             num_rows=acc_O.shape[0][0] * acc_O.shape[1],
@@ -1242,6 +1466,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 n_block_min_before_local_mask = block_info.get_n_block_min_before_local_mask(
                     seqlen, m_block, n_block_min
                 )
+                interior_mask_fn = (
+                    partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False)
+                    if const_expr(self.mask_mod is not None)
+                    else None
+                )
                 # if cute.arch.thread_idx()[0] == 128: cute.printf("n_block_min_before_local_mask = {}, n_block_min = {}", n_block_min_before_local_mask, n_block_min)
                 for n_tile in cutlass.range(n_block_max - n_block_min_before_local_mask, unroll=1):
                     kv_consumer_state = mma_one_n_block(
@@ -1249,7 +1478,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         n_block=n_block_max - 1 - n_tile,
                         seqlen=seqlen,
                         mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
+                        mask_fn=interior_mask_fn,
                     )
                     O_should_accumulate = True
                 # Separate iterations with local masking on the left
@@ -1264,8 +1493,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                             mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
                         )
                         O_should_accumulate = True
-                # Release Q pipeline so the producer can load the next tile's Q
-                pipeline_q.consumer_release_w_index(0)
                 # Last "half" iteration
                 if const_expr(self.intra_wg_overlap):
                     kv_consumer_state = process_last_half_block(
@@ -1302,16 +1529,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor,
                 )
-
-                # Release Q pipeline so the producer can load the next tile's Q
-                pipeline_q.consumer_release_w_index(0)
-
                 # Handle empty case (when no blocks to process)
                 if not processed_any:
                     softmax.reset()
                     acc_O.fill(0.0)
-
-            q_consumer_phase ^= 1
 
             sink_val = None
             if const_expr(learnable_sink is not None):
@@ -1362,8 +1583,18 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 split_idx,
             )
 
-            tile_scheduler.advance_to_next_work()
-            work_tile = tile_scheduler.get_current_work()
+            # sO aliases sQ. Each consumer warp releases Q only after its epilogue
+            # work, so the pipeline cannot become empty until all consumers finish.
+            pipeline_q.consumer_release_w_index(0)
+            q_consumer_phase ^= 1
+
+            work_tile = (
+                self.wait_dynamic_work(sWorkInfo, work_info_phase)
+                if const_expr(self.use_dynamic_varlen)
+                else tile_scheduler.advance_to_next_work()
+            )
+            if const_expr(self.use_dynamic_varlen):
+                work_info_phase ^= 1
 
     @cute.jit
     def first_half_block_overlap(

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -213,7 +213,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
         output_scale: Optional[cute.Tensor] = None,
-        mSchedulerWorkspace: Optional[cute.Tensor] = None,
+        mWorkCounter: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -467,7 +467,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             aux_data,
             fastdiv_mods,
             output_scale,
-            mSchedulerWorkspace,
+            mWorkCounter,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -517,7 +517,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
         output_scale: Optional[cute.Tensor] = None,
-        mSchedulerWorkspace: Optional[cute.Tensor] = None,
+        mWorkCounter: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # Prefetch tma descriptor
@@ -688,7 +688,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 SeqlenInfoCls,
                 TileSchedulerCls,
                 sWorkInfo,
-                mSchedulerWorkspace,
+                mWorkCounter,
                 num_splits,
             )
 
@@ -729,27 +729,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 num_splits,
             )
 
-        if const_expr(self.use_dynamic_varlen):
-            cute.arch.sync_threads()
-            tidx, _, _ = cute.arch.thread_idx()
-            if tidx == 0:
-                # Workspace layout is [work counter, completion counter]. The
-                # last finishing CTA resets both for the next exclusive launch.
-                done_ptr = (mSchedulerWorkspace.iterator + 1).llvm_ptr
-                done = cute.arch.atomic_add(
-                    done_ptr, Int32(1), sem="release", scope="gpu"
-                )
-                if done == cute.arch.grid_dim()[0] - 1:
-                    cute.arch.store(
-                        mSchedulerWorkspace.iterator.llvm_ptr,
-                        Int32(0),
-                        sem="release",
-                        scope="gpu",
-                    )
-                    cute.arch.store(
-                        done_ptr, Int32(0), sem="release", scope="gpu"
-                    )
-
     @cute.jit
     def load(
         self,
@@ -772,7 +751,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
         sWorkInfo: Optional[cute.Tensor],
-        mSchedulerWorkspace: Optional[cute.Tensor],
+        mWorkCounter: Optional[cute.Tensor],
         num_splits: Int32 = Int32(1),
     ):
         warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
@@ -794,7 +773,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             work_tile = (
                 self.publish_dynamic_work(
                     tile_scheduler,
-                    mSchedulerWorkspace,
+                    mWorkCounter,
                     sWorkInfo,
                     work_info_phase,
                     warp_idx_in_wg,
@@ -1088,7 +1067,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 if const_expr(self.use_dynamic_varlen):
                     work_tile = self.publish_dynamic_work(
                         tile_scheduler,
-                        mSchedulerWorkspace,
+                        mWorkCounter,
                         sWorkInfo,
                         work_info_phase,
                         warp_idx_in_wg,
@@ -1123,13 +1102,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
     def publish_dynamic_work(
         self,
         tile_scheduler: DynamicPersistentVarlenTileScheduler,
-        mSchedulerWorkspace: cute.Tensor,
+        mWorkCounter: cute.Tensor,
         sWorkInfo: Optional[cute.Tensor],
         work_info_phase: Int32,
         warp_idx_in_wg: Int32,
     ) -> WorkTileInfo:
         if warp_idx_in_wg == 0:
-            claimed_work = tile_scheduler.claim_next_work(mSchedulerWorkspace)
+            claimed_work = tile_scheduler.claim_next_work(mWorkCounter)
             if cute.arch.lane_idx() == 0:
                 m_block, head_idx, batch_idx, split_idx = claimed_work.tile_idx
                 sWorkInfo[0, work_info_phase] = m_block

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -275,7 +275,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             assert mCpTotSeqUsedK is not None
         if const_expr(self.has_qv):
             assert mQv.element_type == self.dtype, "Qv must have the same dtype as Q"
-            assert not self.pack_gqa, "SM90 Qv does not yet support PackGQA"
 
         self.varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
 
@@ -332,7 +331,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self.use_tma_Q = self.arch >= Arch.sm_90 and not (
             self.pack_gqa and self.tile_m % self.qhead_per_kvhead != 0
         )
-        assert not self.has_qv or self.use_tma_Q, "SM90 Qv requires TMA query loads"
         self.use_tma_O = self.use_tma_Q and not self.is_split_kv
         # Producer needs more registers when doing cp.async Q or KV loads
         if const_expr(self.num_wg_mma == 2 and (not self.use_tma_Q or not self.use_tma_KV)):
@@ -363,6 +361,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         if const_expr(self.pack_gqa):
             nheads_kv = mK.shape[2]
             mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(self.has_qv):
+                mQv = pack_gqa_layout(mQv, self.qhead_per_kvhead, nheads_kv, head_idx=2)
             mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
             if const_expr(mLSE is not None):
                 mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
@@ -398,9 +398,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 (self.tile_m, self.tile_hdim),  # No mcast
             )
             if const_expr(self.has_qv):
-                tma_atom_Qv, tma_tensor_Qv = cpasync.make_tiled_tma_atom(
+                tma_atom_Qv, tma_tensor_Qv = make_tiled_tma_atom_fn(
                     gmem_tiled_copy_Q,
-                    mQv_og,
+                    mQv_og if const_expr(self.pack_gqa) else mQv,
                     self.sQv_layout,
                     (self.tile_m, self.tile_hdimv),  # No mcast
                 )
@@ -499,7 +499,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
 
         self.kernel(
             tma_tensor_Q if const_expr(self.use_tma_Q) else mQ,
-            tma_tensor_Qv if const_expr(self.has_qv) else None,
+            (
+                tma_tensor_Qv if const_expr(self.use_tma_Q) else mQv
+            )
+            if const_expr(self.has_qv)
+            else None,
             tma_tensor_K if const_expr(self.use_tma_KV) else mK,
             tma_tensor_V if const_expr(self.use_tma_KV) else mV,
             tma_tensor_O if const_expr(self.use_tma_O) else mO,
@@ -987,10 +991,18 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 )
 
                 pack_gqa = None
+                pack_gqa_qv = None
                 if const_expr(not self.use_tma_Q):
                     pack_gqa = PackGQA(
                         self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
                     )
+                    if const_expr(self.has_qv):
+                        pack_gqa_qv = PackGQA(
+                            self.tile_m,
+                            self.tile_hdimv,
+                            self.check_hdim_v_oob,
+                            self.qhead_per_kvhead,
+                        )
 
                 if const_expr(not self.use_block_sparsity):
                     n_block_min, n_block_max = block_info.get_n_block_min_max(
@@ -1047,6 +1059,15 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         pack_gqa.load_Q(
                             mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q
                         )
+                        if const_expr(self.has_qv):
+                            pack_gqa_qv.load_Q(
+                                mQv_cur,
+                                sQv,
+                                gmem_tiled_copy_Q,
+                                tidx,
+                                m_block,
+                                seqlen.seqlen_q,
+                            )
                         cute.arch.cp_async_commit_group()
                         pipeline_q.producer_commit_w_index(0)
                         q_producer_phase ^= 1
@@ -1168,6 +1189,15 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         pack_gqa.load_Q(
                             mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q
                         )
+                        if const_expr(self.has_qv):
+                            pack_gqa_qv.load_Q(
+                                mQv_cur,
+                                sQv,
+                                gmem_tiled_copy_Q,
+                                tidx,
+                                m_block,
+                                seqlen.seqlen_q,
+                            )
                         cute.arch.cp_async_commit_group()
                         pipeline_q.producer_commit_w_index(0)
                         q_producer_phase ^= 1

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -68,6 +68,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         use_dynamic_varlen: bool = False,
         persistent_scheduler_sm_count: Optional[int] = None,
         has_qv: bool = False,
+        cp_world_size: int = 1,
+        cp_rank: int = 0,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -75,6 +77,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             f"Fused quant output not implemented for {type(self).__name__}"
         )
         self.has_qv = has_qv
+        assert cp_world_size >= 1
+        assert 0 <= cp_rank < cp_world_size
+        assert cp_world_size == 1 or self.has_qv
+        self.cp_world_size = cp_world_size
+        self.cp_rank = cp_rank
         # The correctness-oriented MLA path computes QK and QvV serially into
         # the same score accumulator. The overlapped mainloop has different V
         # pipeline ownership and is intentionally left for a later pass.
@@ -226,6 +233,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mCpTotSeqUsedK: Optional[cute.Tensor] = None,
         mDynamicCausal: Optional[cute.Tensor] = None,
         mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
         window_size_left: Int32 | int | None = None,
@@ -247,10 +255,24 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self._check_type(
             *(
                 t.element_type if t is not None else None
-                for t in (mQ, mK, mV, mO, mLSE, mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)
+                for t in (
+                    mQ,
+                    mK,
+                    mV,
+                    mO,
+                    mLSE,
+                    mCuSeqlensQ,
+                    mCuSeqlensK,
+                    mSeqUsedQ,
+                    mSeqUsedK,
+                )
             ),
             is_split_kv=self.is_split_kv,
         )
+        if const_expr(mCpTotSeqUsedK is not None):
+            assert mCpTotSeqUsedK.element_type == Int32
+        if const_expr(self.cp_world_size > 1):
+            assert mCpTotSeqUsedK is not None
         if const_expr(self.has_qv):
             assert mQv.element_type == self.dtype, "Qv must have the same dtype as Q"
             assert not self.pack_gqa, "SM90 Qv does not yet support PackGQA"
@@ -486,6 +508,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
+            mCpTotSeqUsedK,
             mDynamicCausal,
             mPageTable,
             tma_atom_Q,
@@ -540,6 +563,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
         mSeqUsedK: Optional[cute.Tensor],
+        mCpTotSeqUsedK: Optional[cute.Tensor],
         mDynamicCausal: Optional[cute.Tensor],
         mPageTable: Optional[cute.Tensor],
         tma_atom_Q: Optional[cute.CopyAtom],
@@ -707,6 +731,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
+            mCpTotSeqUsedK=mCpTotSeqUsedK,
+            cp_world_size=self.cp_world_size,
+            cp_rank=self.cp_rank,
             mCuTotalMBlocks=(
                 blocksparse_tensors.cu_total_m_blocks if blocksparse_tensors is not None else None
             ),
@@ -985,17 +1012,16 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                             else:
                                 n_block_min = Int32(0)
                                 n_block_max = n_block_max_full
-                    # Clamp n_block to 0 when n_block_max == 0 (can happen with causal
-                    # + pack_gqa when seqlen_k < tile_n). TMA handles n_block=-1
-                    # gracefully (fills zeros), but cp.async would crash on
-                    # out-of-bounds page table access.
+                    # Keep the dummy pipeline transaction when the range is empty.
+                    # TMA handles block=-1 for dense KV, while paged TMA needs a
+                    # valid page-table lookup; the consumer fully masks page 0.
                     n_block = (
                         n_block_max - 1
                         if const_expr(self.use_tma_KV)
                         else cutlass.max(n_block_max - 1, 0)
                     )
                     page_idx = (
-                        mPageTable[batch_idx, n_block]
+                        mPageTable[batch_idx, cutlass.max(n_block, 0)]
                         if const_expr(mPageTable is not None and self.use_tma_KV)
                         else None
                     )

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -67,13 +67,18 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         use_persistent_varlen: bool = False,
         use_dynamic_varlen: bool = False,
         persistent_scheduler_sm_count: Optional[int] = None,
+        has_qv: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         assert self.output_quant_key is None, (
             f"Fused quant output not implemented for {type(self).__name__}"
         )
-        self.intra_wg_overlap = intra_wg_overlap
+        self.has_qv = has_qv
+        # The correctness-oriented MLA path computes QK and QvV serially into
+        # the same score accumulator. The overlapped mainloop has different V
+        # pipeline ownership and is intentionally left for a later pass.
+        self.intra_wg_overlap = intra_wg_overlap and not self.has_qv
         self.use_paged_kv_overlap = _use_paged_kv_overlap_sm90(
             self.intra_wg_overlap,
             paged_kv_non_tma,
@@ -148,7 +153,16 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             if self.mma_pv_is_rs
             else warpgroup.OperandSource.SMEM,
         )
-        return tiled_mma_qk, tiled_mma_pv
+        tiled_mma_qv = sm90_utils_basic.make_trivial_tiled_mma(
+            self.dtype,
+            self.dtype,
+            warpgroup.OperandMajorMode.K,
+            warpgroup.OperandMajorMode.K,
+            Float32,
+            atom_layout_mnk=(self.tile_m // 64, atom_layout_n, 1),
+            tiler_mn=(64, self.tile_n),
+        )
+        return tiled_mma_qk, tiled_mma_pv, tiled_mma_qv
 
     def _get_shared_storage_cls(self):
         sQ_struct, sK_struct, sV_struct = [
@@ -156,6 +170,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 cute.struct.MemRange[self.dtype, cute.cosize(layout)], self.buffer_align_bytes
             ]
             for layout in (self.sQ_layout, self.sK_layout, self.sV_layout)
+        ]
+        cosize_sQv = cute.cosize(self.sQv_layout) if const_expr(self.has_qv) else 0
+        sQv_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, cosize_sQv], self.buffer_align_bytes
         ]
         cosize_sQV = max(cute.cosize(self.sQ_layout), cute.cosize(self.sV_layout))
         sQV_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sQV], 1024]
@@ -178,6 +196,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             sV: sV_struct
             sQ: sQ_struct
             sK: sK_struct
+            sQv: sQv_struct
             sP: sP_struct
 
         @cute.struct
@@ -188,6 +207,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             work_info: work_info_struct
             sQ: sQV_struct
             sK: sK_struct
+            sQv: sQv_struct
             sP: sP_struct
 
         return SharedStorageQKV if const_expr(not self.Q_in_regs) else SharedStorageSharedQV
@@ -196,6 +216,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
     def __call__(
         self,
         mQ: cute.Tensor,  # (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
+        mQv: Optional[cute.Tensor],  # (b, s_q, h, dv) or (total_q, h, dv)
         mK: cute.Tensor,  # (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size, h_k, d) if there is page_table
         mV: cute.Tensor,  # (b_k, s_k, h_k, dv) or (total_k, h_k, dv) if there is cu_seqlens_k or (num_pages, page_size, h_k, dv) if there is page_table
         mO: cute.Tensor,  # (b, s_q, h, dv) or (total_q, h, dv) if there is cu_seqlens_q
@@ -219,9 +240,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
     ):
         """Configures and launches the flash attention kernel.
 
-        mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
+        mQ/mQv/mK/mV/mO have the same data type (fp16 or bf16) and layout:
         (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
         """
+        assert (mQv is not None) == self.has_qv
         self._check_type(
             *(
                 t.element_type if t is not None else None
@@ -229,12 +251,18 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             ),
             is_split_kv=self.is_split_kv,
         )
+        if const_expr(self.has_qv):
+            assert mQv.element_type == self.dtype, "Qv must have the same dtype as Q"
+            assert not self.pack_gqa, "SM90 Qv does not yet support PackGQA"
 
         self.varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
 
         mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
+        mQv = assume_tensor_aligned(mQv) if const_expr(self.has_qv) else None
         Q_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
         mQ = layout_utils.select(mQ, Q_layout_transpose)
+        if const_expr(self.has_qv):
+            mQv = layout_utils.select(mQv, Q_layout_transpose)
         num_splits = Int32(1)
         if const_expr(not self.is_split_kv):
             O_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
@@ -254,7 +282,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             else None
         )
 
-        tiled_mma_qk, tiled_mma_pv = self._get_tiled_mma()
+        tiled_mma_qk, tiled_mma_pv, tiled_mma_qv = self._get_tiled_mma()
         self.num_mma_threads = tiled_mma_qk.size
         self.num_threads_per_warp_group = 128
         self.num_wg_mma = self.num_mma_threads // self.num_threads_per_warp_group
@@ -273,9 +301,16 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             if const_expr(self.intra_wg_overlap)
             else (self.num_wg_mma == 2)
         )
+        if const_expr(self.has_qv):
+            # Both warp groups consume the same completed QK + QvV scores
+            # before issuing PV. The standard round-robin scheduler barrier is
+            # for alternating QK/PV work and deadlocks the 64x64, Dv=512 MLA
+            # specialization, whose warp groups are partitioned across Dv.
+            self.use_scheduler_barrier = False
         self.use_tma_Q = self.arch >= Arch.sm_90 and not (
             self.pack_gqa and self.tile_m % self.qhead_per_kvhead != 0
         )
+        assert not self.has_qv or self.use_tma_Q, "SM90 Qv requires TMA query loads"
         self.use_tma_O = self.use_tma_Q and not self.is_split_kv
         # Producer needs more registers when doing cp.async Q or KV loads
         if const_expr(self.num_wg_mma == 2 and (not self.use_tma_Q or not self.use_tma_KV)):
@@ -283,12 +318,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self.rescale_O_before_gemm = self.tile_hdimv > 128 and self.intra_wg_overlap
         self._setup_attributes()
         # TODO: we prob don't need most of what's in _setup_attributes
-        self.sQ_layout, self.sK_layout, self.sV_layout, self.sO_layout = [
+        self.sQ_layout, self.sK_layout, self.sV_layout, self.sQv_layout, self.sO_layout = [
             sm90_utils.make_smem_layout(mX.element_type, LayoutEnum.ROW_MAJOR, shape, stage)
             for mX, shape, stage in [
                 (mQ, (self.tile_m, self.tile_hdim), None),
                 (mK, (self.tile_n, self.tile_hdim), self.num_stages),
                 (mV, (self.tile_n, self.tile_hdimv), self.num_stages),
+                (mQv if const_expr(self.has_qv) else mQ, (self.tile_m, self.tile_hdimv), None),
                 # sO layout dtype possibly different from mO dtype when using splitkv (fp32)
                 (mQ, (self.tile_m, self.tile_hdimv), None),
             ]
@@ -301,7 +337,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
 
         SharedStorage = self._get_shared_storage_cls()
 
-        mQ_og, mO_og = mQ, mO
+        mQ_og, mQv_og, mO_og = mQ, mQv, mO
         if const_expr(self.pack_gqa):
             nheads_kv = mK.shape[2]
             mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
@@ -321,12 +357,17 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 ("V", mV, self.sV_layout),
             ]
         }
+        if const_expr(self.has_qv):
+            self.tma_copy_bytes["Qv"] = cute.size_in_bytes(
+                mQv.element_type, cute.select(self.sQv_layout, mode=[0, 1])
+            )
         make_tiled_tma_atom_fn = (
             partial(make_packgqa_tiled_tma_atom, qhead_per_kvhead=self.qhead_per_kvhead, head_idx=2)
             if const_expr(self.pack_gqa)
             else cpasync.make_tiled_tma_atom
         )
         tma_atom_Q, tma_tensor_Q = None, None
+        tma_atom_Qv, tma_tensor_Qv = None, None
         if const_expr(self.use_tma_Q):
             tma_atom_Q, tma_tensor_Q = make_tiled_tma_atom_fn(
                 gmem_tiled_copy_Q,
@@ -334,6 +375,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 self.sQ_layout,
                 (self.tile_m, self.tile_hdim),  # No mcast
             )
+            if const_expr(self.has_qv):
+                tma_atom_Qv, tma_tensor_Qv = cpasync.make_tiled_tma_atom(
+                    gmem_tiled_copy_Q,
+                    mQv_og,
+                    self.sQv_layout,
+                    (self.tile_m, self.tile_hdimv),  # No mcast
+                )
         tma_atom_K, tma_tensor_K = None, None
         tma_atom_V, tma_tensor_V = None, None
         if const_expr(self.use_tma_KV):
@@ -429,6 +477,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
 
         self.kernel(
             tma_tensor_Q if const_expr(self.use_tma_Q) else mQ,
+            tma_tensor_Qv if const_expr(self.has_qv) else None,
             tma_tensor_K if const_expr(self.use_tma_KV) else mK,
             tma_tensor_V if const_expr(self.use_tma_KV) else mV,
             tma_tensor_O if const_expr(self.use_tma_O) else mO,
@@ -440,6 +489,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mDynamicCausal,
             mPageTable,
             tma_atom_Q,
+            tma_atom_Qv,
             tma_atom_K,
             tma_atom_V,
             tma_atom_O,
@@ -452,6 +502,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             self.sQ_layout,
             self.sK_layout,
             self.sV_layout,
+            self.sQv_layout,
             self.sO_layout,
             self.sP_layout,
             self.gmem_tiled_copy_Q,
@@ -460,6 +511,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             self.gmem_tiled_copy_O,
             tiled_mma_qk,
             tiled_mma_pv,
+            tiled_mma_qv,
             tile_sched_params,
             TileScheduler,
             SharedStorage,
@@ -479,6 +531,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
     def kernel(
         self,
         mQ: cute.Tensor,
+        mQv: Optional[cute.Tensor],
         mK: cute.Tensor,
         mV: cute.Tensor,
         mO: cute.Tensor,
@@ -490,6 +543,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mDynamicCausal: Optional[cute.Tensor],
         mPageTable: Optional[cute.Tensor],
         tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_Qv: Optional[cute.CopyAtom],
         tma_atom_K: Optional[cute.CopyAtom],
         tma_atom_V: Optional[cute.CopyAtom],
         tma_atom_O: Optional[cute.CopyAtom],
@@ -502,6 +556,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         sQ_layout: cute.ComposedLayout,
         sK_layout: cute.ComposedLayout,
         sV_layout: cute.ComposedLayout,
+        sQv_layout: cute.ComposedLayout,
         sO_layout: cute.ComposedLayout,
         sP_layout: cute.ComposedLayout | None,
         gmem_tiled_copy_Q: cute.TiledCopy,
@@ -510,6 +565,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         gmem_tiled_copy_O: cute.TiledCopy,
         tiled_mma_qk: cute.TiledMma,
         tiled_mma_pv: cute.TiledMma,
+        tiled_mma_qv: cute.TiledMma,
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         SharedStorage: cutlass.Constexpr[Callable],
@@ -522,7 +578,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # Prefetch tma descriptor
         if warp_idx == 0:
-            for tma_atom in (tma_atom_Q, tma_atom_K, tma_atom_V, tma_atom_O):
+            for tma_atom in (tma_atom_Q, tma_atom_Qv, tma_atom_K, tma_atom_V, tma_atom_O):
                 if const_expr(tma_atom is not None):
                     cpasync.prefetch_descriptor(tma_atom)
 
@@ -542,7 +598,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 num_stages=1,
                 producer_group=tma_warp,
                 consumer_group=mma_warps,
-                tx_count=self.tma_copy_bytes["Q"],
+                tx_count=self.tma_copy_bytes["Q"]
+                + (self.tma_copy_bytes["Qv"] if const_expr(self.has_qv) else 0),
                 defer_sync=True,
             )
         else:
@@ -600,6 +657,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        sQv = (
+            storage.sQv.get_tensor(sQv_layout.outer, swizzle=sQv_layout.inner)
+            if const_expr(self.has_qv)
+            else sQ
+        )
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
         if const_expr(not self.Q_in_regs):
             sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
@@ -612,8 +674,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         sP = None
         if const_expr(sP_layout is not None):
             sP = storage.sP.get_tensor(sP_layout.outer, swizzle=sP_layout.inner)
-        # reuse sQ's data iterator
-        sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
+        # With MLA, Qv is dead after the score mainloop, so the epilogue can
+        # safely reuse its equally-shaped tile. The Q pipeline is released only
+        # after the epilogue, preventing the producer from overwriting sO.
+        sO_storage = storage.sQv if const_expr(self.has_qv) else storage.sQ
+        sO = sO_storage.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
         sWorkInfo = (
             storage.work_info.get_tensor(
                 cute.make_layout((5, 2), stride=(1, 5))
@@ -670,12 +735,15 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             cute.arch.setmaxregister_decrease(self.num_producer_regs)
             self.load(
                 mQ,
+                mQv,
                 mK,
                 mV,
                 sQ,
+                sQv,
                 sK,
                 sV,
                 tma_atom_Q,
+                tma_atom_Qv,
                 tma_atom_K,
                 tma_atom_V,
                 pipeline_k,
@@ -702,10 +770,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             self.mma(
                 tiled_mma_qk,
                 tiled_mma_pv,
+                tiled_mma_qv,
                 mO,
                 mLSE,
                 sQ,
+                sQv,
                 sK,
+                sV,
                 sVt,
                 sP,
                 sO,
@@ -733,12 +804,15 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
     def load(
         self,
         mQ: cute.Tensor,
+        mQv: Optional[cute.Tensor],
         mK: cute.Tensor,
         mV: cute.Tensor,
         sQ: cute.Tensor,
+        sQv: cute.Tensor,
         sK: cute.Tensor,
         sV: cute.Tensor,
         tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_Qv: Optional[cute.CopyAtom],
         tma_atom_K: Optional[cute.CopyAtom],
         tma_atom_V: Optional[cute.CopyAtom],
         pipeline_k: pipeline.PipelineAsync,
@@ -788,16 +862,34 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
                 seqlen = SeqlenInfoCls(batch_idx)
                 mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+                mQv_cur = (
+                    seqlen.offset_batch_Q(mQv, batch_idx, dim=3)[None, None, head_idx]
+                    if const_expr(self.has_qv)
+                    else None
+                )
                 head_idx_kv = (
                     head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
                 )
 
                 load_Q = None
+                load_Qv = None
                 if const_expr(self.use_tma_Q):
                     gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
                     load_Q, _, _ = copy_utils.tma_get_copy_fn(
                         tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True
                     )
+                    if const_expr(self.has_qv):
+                        gQv = cute.local_tile(
+                            mQv_cur, (self.tile_m, self.tile_hdimv), (m_block, 0)
+                        )
+                        load_Qv, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_Qv,
+                            0,
+                            cute.make_layout(1),
+                            gQv,
+                            sQv,
+                            single_stage=True,
+                        )
 
                 paged_kv_manager = None
                 tma_load_K_fn = None
@@ -919,7 +1011,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     if const_expr(self.use_tma_Q):
                         if warp_idx_in_wg == 0:
                             pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
-                            load_Q(tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(0))
+                            q_barrier = pipeline_q.sync_object_full.get_barrier(0)
+                            load_Q(tma_bar_ptr=q_barrier)
+                            if const_expr(self.has_qv):
+                                load_Qv(tma_bar_ptr=q_barrier)
                             q_producer_phase ^= 1
                     else:
                         pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
@@ -1037,7 +1132,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     if const_expr(self.use_tma_Q):
                         if warp_idx_in_wg == 0:
                             pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
-                            load_Q(tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(0))
+                            q_barrier = pipeline_q.sync_object_full.get_barrier(0)
+                            load_Q(tma_bar_ptr=q_barrier)
+                            if const_expr(self.has_qv):
+                                load_Qv(tma_bar_ptr=q_barrier)
                             q_producer_phase ^= 1
                     else:
                         pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
@@ -1183,10 +1281,13 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self,
         tiled_mma_qk: cute.TiledMma,
         tiled_mma_pv: cute.TiledMma,
+        tiled_mma_qv: cute.TiledMma,
         mO: cute.Tensor,
         mLSE: Optional[cute.Tensor],
         sQ: cute.Tensor,
+        sQv: cute.Tensor,
         sK: cute.Tensor,
+        sV: cute.Tensor,
         sVt: cute.Tensor,
         sP: Optional[cute.Tensor],
         sO: cute.Tensor,
@@ -1223,6 +1324,12 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mma_qk_fn = partial(
             sm90_utils.gemm_zero_init, tiled_mma_qk, (self.tile_m, self.tile_n), tSrQ, tSrK
         )
+        tSrQv, tSrV = None, None
+        if const_expr(self.has_qv):
+            wg_mma_qv = tiled_mma_qv.get_slice(warp_group_thread_layout(warp_group_idx))
+            _, tSrQv, tSrV = sm90_utils.partition_fragment_ABC(
+                wg_mma_qv, (self.tile_m, self.tile_n, self.tile_hdimv), sQv, sV
+            )
         acc_O, tOrP, tOrVt = sm90_utils.partition_fragment_ABC(
             wg_mma_pv, (self.tile_m, self.tile_hdimv, self.tile_n), sP, sVt
         )
@@ -1270,6 +1377,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             if const_expr(self.intra_wg_overlap)
             else self.mma_one_n_block,
             mma_qk_fn=mma_qk_fn,
+            tiled_mma_qv=tiled_mma_qv,
+            tSrQv=tSrQv,
+            tSrV=tSrV,
             pipeline_k=pipeline_k,
             pipeline_v=pipeline_v,
             acc_O=acc_O,
@@ -1562,8 +1672,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 split_idx,
             )
 
-            # sO aliases sQ. Each consumer warp releases Q only after its epilogue
-            # work, so the pipeline cannot become empty until all consumers finish.
+            # sO aliases the query tile (Qv for MLA, Q otherwise). Each consumer
+            # warp releases it only after the epilogue, so the pipeline cannot
+            # become empty until all consumers finish.
             pipeline_q.consumer_release_w_index(0)
             q_consumer_phase ^= 1
 
@@ -1660,6 +1771,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         smem_pipe_read: pipeline.PipelineState | pipeline_custom.PipelineStateSimple,
         n_block: Int32,
         mma_qk_fn: Callable,
+        tiled_mma_qv: cute.TiledMma,
+        tSrQv: Optional[cute.Tensor],
+        tSrV: Optional[cute.Tensor],
         mma_pv_fn: Callable,
         pipeline_k: pipeline.PipelineAsync,
         pipeline_v: pipeline.PipelineAsync,
@@ -1677,9 +1791,29 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         pipeline_k.consumer_wait(smem_pipe_read, pipeline_k.consumer_try_wait(smem_pipe_read))
         # S = Q @ K.T
         acc_S = mma_qk_fn(B_idx=smem_pipe_read.index, wg_wait=-1)
+        if const_expr(self.has_qv):
+            # V participates in both score formation and the later PV GEMM.
+            # Keep its pipeline stage owned until both operations complete.
+            pipeline_v.consumer_wait(
+                smem_pipe_read, pipeline_v.consumer_try_wait(smem_pipe_read)
+            )
+            sm90_utils.gemm(
+                tiled_mma_qv,
+                acc_S,
+                tSrQv,
+                tSrV[None, None, None, smem_pipe_read.index],
+                zero_init=False,
+                wg_wait=-1,
+            )
         self.warp_scheduler_barrier_arrive()
-        warpgroup.wait_group(0)
+        if const_expr(self.has_qv):
+            # QK is the older of the two committed WGMMA groups.
+            warpgroup.wait_group(1)
+        else:
+            warpgroup.wait_group(0)
         pipeline_k.consumer_release(smem_pipe_read)
+        if const_expr(self.has_qv):
+            warpgroup.wait_group(0)
 
         # handle score mods and masking
         if const_expr(score_mod_fn is not None):
@@ -1708,7 +1842,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             # Fence and barrier to make sure smem store is visible to WGMMA
             cute.arch.fence_view_async_shared()
             cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
-        pipeline_v.consumer_wait(smem_pipe_read, pipeline_v.consumer_try_wait(smem_pipe_read))
+        if const_expr(not self.has_qv):
+            pipeline_v.consumer_wait(
+                smem_pipe_read, pipeline_v.consumer_try_wait(smem_pipe_read)
+            )
         self.warp_scheduler_barrier_sync()
         # O += P @ V
         mma_pv_fn(B_idx=smem_pipe_read.index, wg_wait=0)
@@ -1722,6 +1859,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         smem_pipe_read: pipeline.PipelineState | pipeline_custom.PipelineStateSimple,
         n_block: Int32,
         mma_qk_fn: Callable,
+        tiled_mma_qv: cute.TiledMma,
+        tSrQv: Optional[cute.Tensor],
+        tSrV: Optional[cute.Tensor],
         mma_pv_fn: Callable,
         pipeline_k: pipeline.PipelineAsync,
         pipeline_v: pipeline.PipelineAsync,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -337,7 +337,105 @@ def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
 
     # NOTE: We should revisit this heuristic after persistence is supported for split KV.
     # Sometimes, it's ideal to over-schedule splits for better efficiency.
-    return min(num_SMs // total_mblocks, max_splits, num_n_blocks)
+    return max(1, min(num_SMs // total_mblocks, max_splits, num_n_blocks))
+
+
+def _num_splits_sm90(
+    total_mblocks,
+    num_SMs,
+    num_n_blocks,
+    max_splits,
+    batch_size,
+    qhead_per_kvhead,
+    paged_kv,
+    head_dim,
+    head_dim_v,
+):
+    """Hopper split-K policy derived from measured workload boundaries."""
+    if total_mblocks == 0:
+        return 1
+
+    # Four K blocks can benefit severely underfilled multi-request GQA/MQA.
+    # Require more available CTA waves than K blocks: once four-way splitting
+    # nearly fills the GPU, combine overhead outweighs the extra parallelism.
+    allow_four_n_blocks = (
+        batch_size > 1
+        and qhead_per_kvhead > 1
+        and num_n_blocks == 4
+        and num_SMs // total_mblocks > num_n_blocks
+    )
+    if num_n_blocks <= 4 and not allow_four_n_blocks:
+        return 1
+
+    # Leave enough K work in each split to amortize the partial-output combine.
+    blocks_per_split = (
+        8 if num_n_blocks >= 192 and total_mblocks > 1 else 4
+    )
+    max_splits_for_work = (
+        max(1, num_n_blocks // blocks_per_split)
+        if num_n_blocks >= 64
+        else num_n_blocks
+    )
+    num_splits = min(
+        num_SMs // total_mblocks,
+        max_splits,
+        num_n_blocks,
+        max_splits_for_work,
+    )
+
+    # A single underfilled wave leaves Hopper d64 paged prefill idle, while
+    # two splits provide enough parallel work to amortize the combine.
+    if (
+        paged_kv
+        and batch_size == 1
+        and head_dim == head_dim_v == 64
+        and num_splits == 1
+        and num_n_blocks > 4
+        and num_SMs // 2 < total_mblocks < num_SMs
+    ):
+        num_splits = 2
+    return max(1, num_splits)
+
+
+def _combine_max_seqlen_q_sm90(arch, max_seqlen_q, is_packed_varlen):
+    return max_seqlen_q if arch // 10 == 9 and is_packed_varlen else None
+
+
+def _use_dynamic_varlen_scheduler_sm90(
+    *,
+    arch,
+    batch_size,
+    num_head,
+    num_head_kv,
+    head_dim,
+    max_seqlen_q,
+    max_seqlen_k,
+    no_explicit_window,
+    local,
+    mask_mod,
+    aux_tensors,
+):
+    """Select the measured Hopper regimes that benefit from dynamic work."""
+    if arch // 10 != 9:
+        return False
+    if batch_size > 1 or num_head == num_head_kv:
+        return True
+    return (
+        batch_size == 1
+        and head_dim == 128
+        and (
+            max_seqlen_k >= 16 * 1024
+            or (
+                max_seqlen_q >= 64 * 128
+                and max_seqlen_k >= 64 * 128
+                and num_head >= 64
+            )
+        )
+        and no_explicit_window
+        and not local
+        and mask_mod is None
+        and aux_tensors is None
+    )
 
 
 def _resolve_causal_local_window(causal, window_size_left, window_size_right, mask_mod=None):
@@ -402,6 +500,7 @@ def _flash_attn_fwd(
     v_descale: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
     output_scale: Optional[torch.Tensor] = None,
+    dynamic_scheduler_workspace: Optional[torch.Tensor] = None,
     compile_only: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """Forward pass for FlashAttention.
@@ -421,6 +520,12 @@ def _flash_attn_fwd(
         output_scale: 0-d FP32 GPU tensor. Presence opts into the static per-tensor
             FP8 (e4m3fn) fused-quant output: the kernel writes FP8 with
             dequant = out_fp8 * output_scale. SM100/SM110 only.
+        dynamic_scheduler_workspace: Optional contiguous CUDA int32 tensor with
+            shape (2,). The entries are respectively the work and completion
+            counters. The caller must zero-initialize the workspace and keep it
+            exclusive to one non-overlapping launch. Violating either contract
+            silently produces incorrect output. The last finishing CTA resets
+            both entries.
         compile_only: If True, compile the selected kernel and return without
             launching it.
     """
@@ -604,6 +709,9 @@ def _flash_attn_fwd(
         assert arch // 10 == 10, "FP8 is only supported on SM100 (compute capability 10.x) for FA4 CuTe."
     use_block_sparsity = block_sparse_tensors is not None
 
+    no_explicit_window = (
+        window_size_left is None and window_size_right is None
+    )
     causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
         causal, window_size_left, window_size_right, mask_mod
     )
@@ -647,6 +755,17 @@ def _flash_attn_fwd(
     if cu_seqlens_k is None and seqused_k is None:
         min_seqlen_k = seqlen_k 
     seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead
+    if (
+        arch // 10 == 9
+        and tile_mn is None
+        and head_dim == head_dim_v
+        and head_dim in (64, 128)
+        and not local
+        and not use_block_sparsity
+        and seqlen_q_packgqa <= 64
+    ):
+        tile_m = 64
+        tile_n = 128
     if arch // 10 in [10, 11]:
         q_stage = 2 if seqlen_q_packgqa > tile_m else 1
     else:
@@ -666,7 +785,23 @@ def _flash_attn_fwd(
     if arch // 10 == 12:
         assert num_splits == 1, "SM120 forward only supports num_splits=1"
     elif num_splits < 1:
-        num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
+        num_splits = (
+            _num_splits_sm90(
+                total_mblocks,
+                num_SMs,
+                num_n_blocks,
+                128,
+                batch_size,
+                qhead_per_kvhead,
+                page_table is not None,
+                head_dim,
+                head_dim_v,
+            )
+            if arch // 10 == 9
+            else num_splits_heuristic(
+                total_mblocks, num_SMs, num_n_blocks, 128
+            )
+        )
 
     # SplitKV uses float32 partial output, which doubles the O buffer size
     # in shared memory, causing OOM for diff-headdim (192, 128)
@@ -679,6 +814,49 @@ def _flash_attn_fwd(
             num_splits = 1
 
     is_split_kv = num_splits > 1
+    persistent_varlen_capable = (
+        arch // 10 == 9
+        and (cu_seqlens_q is not None or seqused_q is not None)
+        and batch_size == 1
+        and not is_split_kv
+    )
+    if dynamic_scheduler_workspace is not None:
+        assert arch // 10 == 9, "dynamic varlen scheduler is only supported on SM90"
+        assert cu_seqlens_q is not None or seqused_q is not None
+        assert dynamic_scheduler_workspace.dtype == torch.int32
+        assert dynamic_scheduler_workspace.is_cuda
+        assert dynamic_scheduler_workspace.device == device
+        assert dynamic_scheduler_workspace.shape == (2,)
+        assert dynamic_scheduler_workspace.stride(0) == 1
+    dynamic_varlen_capable = (
+        dynamic_scheduler_workspace is not None
+        and arch // 10 == 9
+        and (cu_seqlens_q is not None or seqused_q is not None)
+    )
+    use_dynamic_varlen = (
+        dynamic_varlen_capable
+        and not is_split_kv
+        and _use_dynamic_varlen_scheduler_sm90(
+            arch=arch,
+            batch_size=batch_size,
+            num_head=num_head,
+            num_head_kv=num_head_kv,
+            head_dim=head_dim,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            no_explicit_window=no_explicit_window,
+            local=local,
+            mask_mod=mask_mod,
+            aux_tensors=aux_tensors,
+        )
+    )
+    dynamic_scheduler_workspace_effective = (
+        dynamic_scheduler_workspace if use_dynamic_varlen else None
+    )
+    use_persistent_varlen = persistent_varlen_capable and not use_dynamic_varlen
+    persistent_scheduler_sm_count = (
+        num_SMs if use_persistent_varlen or use_dynamic_varlen else None
+    )
     if is_split_kv:
         if isinstance(q, _CompileOnlyTensorSpec):
             out_partial = _make_compile_only_tensor_spec(
@@ -865,6 +1043,10 @@ def _flash_attn_fwd(
         q_subtile_factor,
         mma_pv_is_rs,
         intra_wg_overlap,
+        use_persistent_varlen,
+        use_dynamic_varlen,
+        # The persistent grid shape bakes this trace-time value into the cubin.
+        persistent_scheduler_sm_count,
         use_clc_scheduler,
         q is not None,
         qv is not None,
@@ -884,11 +1066,20 @@ def _flash_attn_fwd(
             seqused_k_tensor,
             learnable_sink_tensor,
             output_scale_tensor, # 1d scalar tensor
+            dynamic_scheduler_workspace_tensor,
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
             else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, output_scale)
+            for t in (
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                learnable_sink,
+                output_scale,
+                dynamic_scheduler_workspace_effective,
+            )
         ]
         dynamic_causal_tensor = (
             to_cute_tensor(dynamic_causal, assumed_align=4, leading_dim=0)
@@ -981,6 +1172,9 @@ def _flash_attn_fwd(
                 has_aux_tensors=aux_tensors is not None,
                 q_subtile_factor=q_subtile_factor,
                 paged_kv_non_tma=page_size not in [None, tile_n],
+                use_persistent_varlen=use_persistent_varlen,
+                use_dynamic_varlen=use_dynamic_varlen,
+                persistent_scheduler_sm_count=persistent_scheduler_sm_count,
                 # SplitKV: forward writes FP32 partials, combine does the fold.
                 output_quant_key=output_quant_key if not is_split_kv else None,
             )
@@ -1167,6 +1361,8 @@ def _flash_attn_fwd(
             # too, then drop this special-casing and the qv/hd256 fp8-output guards above.
             if not use_dedicated_hd256_kernel:
                 compile_args.append(output_scale_tensor)
+            if arch // 10 == 9:
+                compile_args.append(dynamic_scheduler_workspace_tensor)
             compile_args.append(current_stream)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
                 *compile_args, options="--enable-tvm-ffi"
@@ -1253,6 +1449,8 @@ def _flash_attn_fwd(
             # See the TODO above: hd256/MLA kernels don't take output_scale yet.
             if not use_dedicated_hd256_kernel:
                 call_args.append(output_scale)
+            if arch // 10 == 9:
+                call_args.append(dynamic_scheduler_workspace_effective)
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
     if is_split_kv:
         _flash_attn_fwd_combine(
@@ -1262,6 +1460,9 @@ def _flash_attn_fwd(
             lse.transpose(-1, -2) if lse is not None else None,
             cu_seqlens_q,
             seqused_q,
+            max_seqlen_q=_combine_max_seqlen_q_sm90(
+                arch, max_seqlen_q, cu_seqlens_q is not None
+            ),
             output_scale=output_scale,
         )
     return out, lse, p, row_max
@@ -3097,6 +3298,7 @@ def compile_flash_attn_varlen_func_from_specs(
 def _compile_fwd_combine(
     dtype, dtype_partial, head_dim, tile_m, k_block_size, log_max_splits,
     has_cu_seqlens, has_seqused, has_lse, has_varlen_batch_idx, output_quant_key,
+    use_max_seqlen_q,
 ):
     """Compile fwd combine kernel using cute fake tensors (no real GPU tensors needed)."""
     sym = cute.sym_int
@@ -3144,12 +3346,18 @@ def _compile_fwd_combine(
     mSemaphore = None  # Not parametrized in compile_key
     output_scale = fake_tensor(Float32, (1,), divisibility=1) if output_quant_key is not None else None
 
-    return cute.compile(
-        fa_combine,
+    compile_args = [
         mO_partial, mLSE_partial, mO, mLSE,
         mCuSeqlens, mSeqused, mNumSplitsDynamic, mVarlenBatchIdx, mSemaphore,
         output_scale,
-        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+    ]
+    compile_args.append(Int32(1) if use_max_seqlen_q else None)
+    compile_args.append(
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    )
+    return cute.compile(
+        fa_combine,
+        *compile_args,
         options="--enable-tvm-ffi",
     )
 
@@ -3165,6 +3373,7 @@ def _flash_attn_fwd_combine(
     varlen_batch_idx: Optional[torch.Tensor] = None,
     semaphore_to_reset: Optional[torch.Tensor] = None,
     output_scale: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
 ) -> None:
     """Forward combine kernel for split attention computation.
 
@@ -3182,6 +3391,10 @@ def _flash_attn_fwd_combine(
         seqused: Used sequence lengths for each batch
         num_splits_dynamic_ptr: Dynamic number of splits per batch
         semaphore_to_reset: Semaphore for synchronization
+        max_seqlen_q: Maximum query sequence length for packed variable-length
+            input. It must be at least the true maximum; a smaller value leaves
+            output rows unwritten. Defaults to total_q, preserving the previous
+            launch shape when omitted.
         k_block_size: Block size for head dimension
 
     Returns:
@@ -3214,6 +3427,8 @@ def _flash_attn_fwd_combine(
     head_dim = out_partial.shape[-1]
     num_splits = out_partial.shape[0]
     assert num_splits <= 256
+    if max_seqlen_q is not None:
+        assert max_seqlen_q > 0
     # If hdim is 96 or 192, it's faster to round them to 128 or 256 respectively
     # so that kBlockM is smaller and we have more parallelism.
     k_block_size = 64 if head_dim <= 64 else 128
@@ -3241,18 +3456,22 @@ def _flash_attn_fwd_combine(
         lse is not None,
         varlen_batch_idx is not None,
         output_quant_key,
+        max_seqlen_q is not None,
     )
     if compile_key not in _flash_attn_fwd_combine.compile_cache:
         _flash_attn_fwd_combine.compile_cache[compile_key] = _compile_fwd_combine(
             *compile_key
         )
     if not is_fake_mode():
-        _flash_attn_fwd_combine.compile_cache[compile_key](
+        call_args = [
             out_partial, lse_partial, out, lse,
             cu_seqlens, seqused, num_splits_dynamic_ptr, varlen_batch_idx,
             semaphore_to_reset,
             output_scale,
-        )
+        ]
+        if max_seqlen_q is not None:
+            call_args.append(max_seqlen_q)
+        _flash_attn_fwd_combine.compile_cache[compile_key](*call_args)
 
 
 _flash_attn_fwd_combine.compile_cache = get_jit_cache("fwd_combine")

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -416,7 +416,7 @@ def _use_dynamic_varlen_scheduler_sm90(
     aux_tensors,
 ):
     """Select the measured Hopper regimes that benefit from dynamic work."""
-    if arch // 10 != 9:
+    if arch // 10 != 9 or mask_mod is not None or aux_tensors is not None:
         return False
     if batch_size > 1 or num_head == num_head_kv:
         return True
@@ -433,8 +433,6 @@ def _use_dynamic_varlen_scheduler_sm90(
         )
         and no_explicit_window
         and not local
-        and mask_mod is None
-        and aux_tensors is None
     )
 
 
@@ -500,7 +498,6 @@ def _flash_attn_fwd(
     v_descale: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
     output_scale: Optional[torch.Tensor] = None,
-    dynamic_scheduler_workspace: Optional[torch.Tensor] = None,
     compile_only: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """Forward pass for FlashAttention.
@@ -520,12 +517,6 @@ def _flash_attn_fwd(
         output_scale: 0-d FP32 GPU tensor. Presence opts into the static per-tensor
             FP8 (e4m3fn) fused-quant output: the kernel writes FP8 with
             dequant = out_fp8 * output_scale. SM100/SM110 only.
-        dynamic_scheduler_workspace: Optional contiguous CUDA int32 tensor with
-            shape (2,). The entries are respectively the work and completion
-            counters. The caller must zero-initialize the workspace and keep it
-            exclusive to one non-overlapping launch. Violating either contract
-            silently produces incorrect output. The last finishing CTA resets
-            both entries.
         compile_only: If True, compile the selected kernel and return without
             launching it.
     """
@@ -593,6 +584,7 @@ def _flash_attn_fwd(
             assert present[a].dtype == present[b].dtype, f"{a}.dtype {present[a].dtype} != {b}.dtype {present[b].dtype}"
 
     q_dtype = q.dtype if q is not None else qv.dtype
+    device = v.device
 
     for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
         if t is not None:
@@ -630,6 +622,14 @@ def _flash_attn_fwd(
     assert arch // 10 in [8, 9, 10, 11, 12], "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
     if dynamic_causal is not None:
         assert arch // 10 == 9, "dynamic_causal is only supported on SM90 (Hopper)."
+        _validate_tensor(
+            dynamic_causal,
+            "dynamic_causal",
+            (batch_size,),
+            torch.int32,
+            device,
+        )
+        assert dynamic_causal.stride(0) == 1, "dynamic_causal must be contiguous"
     assert num_head % num_head_kv == 0, "num_head must be divisible by num_head_kv"
     alignment = 16 // v.element_size()
     if arch // 10 not in [8, 12]:
@@ -664,7 +664,6 @@ def _flash_attn_fwd(
     else:
         out_torch_dtype = torch.bfloat16 if is_fp8 else q_dtype
         output_quant_key = None
-    device = v.device
     q_batch_seqlen_shape = (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
 
     if qv is None:
@@ -820,17 +819,8 @@ def _flash_attn_fwd(
         and batch_size == 1
         and not is_split_kv
     )
-    if dynamic_scheduler_workspace is not None:
-        assert arch // 10 == 9, "dynamic varlen scheduler is only supported on SM90"
-        assert cu_seqlens_q is not None or seqused_q is not None
-        assert dynamic_scheduler_workspace.dtype == torch.int32
-        assert dynamic_scheduler_workspace.is_cuda
-        assert dynamic_scheduler_workspace.device == device
-        assert dynamic_scheduler_workspace.shape == (2,)
-        assert dynamic_scheduler_workspace.stride(0) == 1
     dynamic_varlen_capable = (
-        dynamic_scheduler_workspace is not None
-        and arch // 10 == 9
+        arch // 10 == 9
         and (cu_seqlens_q is not None or seqused_q is not None)
     )
     use_dynamic_varlen = (
@@ -850,8 +840,14 @@ def _flash_attn_fwd(
             aux_tensors=aux_tensors,
         )
     )
-    dynamic_scheduler_workspace_effective = (
-        dynamic_scheduler_workspace if use_dynamic_varlen else None
+    dynamic_scheduler_counter = (
+        _make_compile_only_tensor_spec((1,), torch.int32, assumed_align=4)
+        if use_dynamic_varlen and isinstance(v, _CompileOnlyTensorSpec)
+        else (
+            torch.zeros((1,), dtype=torch.int32, device=device)
+            if use_dynamic_varlen
+            else None
+        )
     )
     use_persistent_varlen = persistent_varlen_capable and not use_dynamic_varlen
     persistent_scheduler_sm_count = (
@@ -1011,6 +1007,7 @@ def _flash_attn_fwd(
         head_dim_v,
         qhead_per_kvhead,
         causal,
+        dynamic_causal is not None,
         score_mod_hash,
         mask_mod_hash,
         use_block_sparsity,
@@ -1066,7 +1063,7 @@ def _flash_attn_fwd(
             seqused_k_tensor,
             learnable_sink_tensor,
             output_scale_tensor, # 1d scalar tensor
-            dynamic_scheduler_workspace_tensor,
+            dynamic_scheduler_counter_tensor,
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
@@ -1078,7 +1075,7 @@ def _flash_attn_fwd(
                 seqused_k,
                 learnable_sink,
                 output_scale,
-                dynamic_scheduler_workspace_effective,
+                dynamic_scheduler_counter,
             )
         ]
         dynamic_causal_tensor = (
@@ -1362,7 +1359,7 @@ def _flash_attn_fwd(
             if not use_dedicated_hd256_kernel:
                 compile_args.append(output_scale_tensor)
             if arch // 10 == 9:
-                compile_args.append(dynamic_scheduler_workspace_tensor)
+                compile_args.append(dynamic_scheduler_counter_tensor)
             compile_args.append(current_stream)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
                 *compile_args, options="--enable-tvm-ffi"
@@ -1450,7 +1447,7 @@ def _flash_attn_fwd(
             if not use_dedicated_hd256_kernel:
                 call_args.append(output_scale)
             if arch // 10 == 9:
-                call_args.append(dynamic_scheduler_workspace_effective)
+                call_args.append(dynamic_scheduler_counter)
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
     if is_split_kv:
         _flash_attn_fwd_combine(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -499,6 +499,9 @@ def _flash_attn_fwd(
     gather_kv_indices: Optional[torch.Tensor] = None,
     output_scale: Optional[torch.Tensor] = None,
     compile_only: bool = False,
+    cp_world_size: int = 1,
+    cp_rank: int = 0,
+    cp_tot_seqused_k: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """Forward pass for FlashAttention.
 
@@ -534,6 +537,8 @@ def _flash_attn_fwd(
         batch_size = cu_seqlens_q.shape[0] - 1
         seqlen_q = None
         total_q = q_shape[0]
+    if max_seqlen_q is None:
+        max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
     if page_table is not None:
         assert cu_seqlens_k is None, "page_table is not supported with cu_seqlens_k"
         assert page_table.dtype == torch.int32, "page_table must be int32"
@@ -571,6 +576,20 @@ def _flash_attn_fwd(
     assert seqused_k is None or seqused_k.shape == (batch_size,), (
         "seqused_k must have shape (batch_size,)"
     )
+    assert isinstance(cp_world_size, int) and cp_world_size >= 1, (
+        "cp_world_size must be an integer >= 1"
+    )
+    assert isinstance(cp_rank, int) and 0 <= cp_rank < cp_world_size, (
+        "cp_rank must be in [0, cp_world_size)"
+    )
+    if cp_world_size > 1:
+        assert cp_tot_seqused_k is not None, (
+            "cp_tot_seqused_k is required when cp_world_size > 1"
+        )
+    if cp_tot_seqused_k is not None:
+        assert cp_tot_seqused_k.shape == (batch_size,), (
+            "cp_tot_seqused_k must have shape (batch_size,)"
+        )
     assert v.dtype in [torch.float16, torch.bfloat16, torch.float8_e4m3fn, torch.float8_e5m2], (
         "inputs must be float16, bfloat16, fp8 e4m3fn, or fp8 e5m2"
     )
@@ -586,13 +605,13 @@ def _flash_attn_fwd(
     q_dtype = q.dtype if q is not None else qv.dtype
     device = v.device
 
-    for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
+    for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, cp_tot_seqused_k]:
         if t is not None:
             assert t.dtype == torch.int32, (
-                "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be int32"
+                "sequence length tensors must be int32"
             )
             assert t.stride(0) == 1, (
-                "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be contiguous"
+                "sequence length tensors must be contiguous"
             )
     if learnable_sink is not None:
         assert learnable_sink.shape == (num_head,)
@@ -613,6 +632,7 @@ def _flash_attn_fwd(
                 cu_seqlens_k,
                 seqused_q,
                 seqused_k,
+                cp_tot_seqused_k,
                 page_table,
                 learnable_sink,
                 output_scale,
@@ -620,6 +640,20 @@ def _flash_attn_fwd(
         ), "inputs must be on CUDA device"
     arch = _get_device_arch() if _arch is None else _arch
     assert arch // 10 in [8, 9, 10, 11, 12], "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
+    is_context_parallel = cp_world_size > 1
+    if is_context_parallel:
+        assert arch // 10 == 9, "context parallelism is only supported on SM90"
+        assert qv is not None, "context parallelism is only supported for Hopper MLA"
+        assert dynamic_causal is None, (
+            "dynamic_causal is not supported with context parallelism"
+        )
+        assert window_size_left is None and window_size_right is None, (
+            "local attention is not supported with context parallelism"
+        )
+        assert mask_mod is None, "mask_mod is not supported with context parallelism"
+        assert block_sparse_tensors is None, (
+            "block sparsity is not supported with context parallelism"
+        )
     if dynamic_causal is not None:
         assert arch // 10 == 9, "dynamic_causal is only supported on SM90 (Hopper)."
         _validate_tensor(
@@ -711,6 +745,10 @@ def _flash_attn_fwd(
     no_explicit_window = (
         window_size_left is None and window_size_right is None
     )
+    if is_context_parallel and causal and max_seqlen_q == 1 and no_explicit_window:
+        # Match FA3 decode semantics. With one query token every local key is
+        # visible, independent of how context-parallel ranks interleave keys.
+        causal = False
     causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
         causal, window_size_left, window_size_right, mask_mod
     )
@@ -758,8 +796,6 @@ def _flash_attn_fwd(
             tile_m, tile_n, mma_pv_is_rs = 128, 96, True
         intra_wg_overlap = False
 
-    if max_seqlen_q is None:
-        max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
     if max_seqlen_k is None:
         max_seqlen_k = seqlen_k
     if cu_seqlens_k is None and seqused_k is None:
@@ -1035,6 +1071,9 @@ def _flash_attn_fwd(
         cu_seqlens_k is None,
         seqused_q is None,
         seqused_k is None,
+        cp_world_size,
+        cp_rank,
+        cp_tot_seqused_k is None,
         page_table is not None,
         window_size_left is not None,
         window_size_right is not None,
@@ -1077,6 +1116,7 @@ def _flash_attn_fwd(
             cu_seqlens_k_tensor,
             seqused_q_tensor,
             seqused_k_tensor,
+            cp_tot_seqused_k_tensor,
             learnable_sink_tensor,
             output_scale_tensor, # 1d scalar tensor
             dynamic_scheduler_counter_tensor,
@@ -1089,6 +1129,7 @@ def _flash_attn_fwd(
                 cu_seqlens_k,
                 seqused_q,
                 seqused_k,
+                cp_tot_seqused_k,
                 learnable_sink,
                 output_scale,
                 dynamic_scheduler_counter,
@@ -1189,6 +1230,8 @@ def _flash_attn_fwd(
                 use_dynamic_varlen=use_dynamic_varlen,
                 persistent_scheduler_sm_count=persistent_scheduler_sm_count,
                 has_qv=qv is not None,
+                cp_world_size=cp_world_size,
+                cp_rank=cp_rank,
                 # SplitKV: forward writes FP32 partials, combine does the fold.
                 output_quant_key=output_quant_key if not is_split_kv else None,
             )
@@ -1362,6 +1405,10 @@ def _flash_attn_fwd(
                 cu_seqlens_k_tensor,
                 seqused_q_tensor,
                 seqused_k_tensor,
+            ])
+            if arch // 10 == 9:
+                compile_args.append(cp_tot_seqused_k_tensor)
+            compile_args.extend([
                 dynamic_causal_tensor,
                 page_table_tensor,
                 window_size_left,
@@ -1445,6 +1492,10 @@ def _flash_attn_fwd(
                 cu_seqlens_k,
                 seqused_q,
                 seqused_k,
+            ])
+            if arch // 10 == 9:
+                call_args.append(cp_tot_seqused_k)
+            call_args.extend([
                 dynamic_causal,
                 page_table,
                 window_size_left,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -786,10 +786,10 @@ def _flash_attn_fwd(
         intra_wg_overlap = fwd_cfg.intra_wg_overlap
     if arch // 10 == 9 and qv is not None:
         # Match FA3's Hopper MLA specialization. These tiles leave room for
-        # the additional Qv tile and keep the first correctness-oriented port
-        # on the simpler non-overlapped, direct-head mainloop. PackGQA is an
-        # optimization rather than part of the MLA contract.
-        pack_gqa = False
+        # the additional Qv tile and keep the mainloop non-overlapped.
+        # The DCP mask still uses unpacked query rows.
+        if is_context_parallel:
+            pack_gqa = False
         if head_dim_v == 512:
             tile_m, tile_n, mma_pv_is_rs = 64, 64, False
         else:
@@ -1216,7 +1216,11 @@ def _flash_attn_fwd(
                 pack_gqa=pack_gqa,
                 tile_m=tile_m,
                 tile_n=tile_n,
-                num_stages=1 if any(d > 256 for d in [head_dim, head_dim_v]) else 2,
+                num_stages=(
+                    2
+                    if qv is not None
+                    else 1 if any(d > 256 for d in [head_dim, head_dim_v]) else 2
+                ),
                 num_threads=num_threads,
                 Q_in_regs=False,
                 intra_wg_overlap=intra_wg_overlap,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -666,7 +666,7 @@ def _flash_attn_fwd(
         output_quant_key = None
     q_batch_seqlen_shape = (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
 
-    if qv is None:
+    if qv is None or arch // 10 == 9:
         lse_shape = (batch_size, num_head, seqlen_q) if cu_seqlens_q is None else (num_head, total_q)
     else:
         # num_head contiguous better for MQA in MLA absorbed
@@ -746,6 +746,17 @@ def _flash_attn_fwd(
         mma_pv_is_rs = fwd_cfg.mma_pv_is_rs
     if intra_wg_overlap is None:
         intra_wg_overlap = fwd_cfg.intra_wg_overlap
+    if arch // 10 == 9 and qv is not None:
+        # Match FA3's Hopper MLA specialization. These tiles leave room for
+        # the additional Qv tile and keep the first correctness-oriented port
+        # on the simpler non-overlapped, direct-head mainloop. PackGQA is an
+        # optimization rather than part of the MLA contract.
+        pack_gqa = False
+        if head_dim_v == 512:
+            tile_m, tile_n, mma_pv_is_rs = 64, 64, False
+        else:
+            tile_m, tile_n, mma_pv_is_rs = 128, 96, True
+        intra_wg_overlap = False
 
     if max_seqlen_q is None:
         max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
@@ -948,52 +959,57 @@ def _flash_attn_fwd(
     aux_scalar_metadata = tuple(type(s) for s in aux_scalars) if aux_scalars is not None else None
 
     if qv is not None:
-        assert arch // 10 in [10, 11], "only support Blackwell arch with qv"
         assert q is None or qv.shape[:-1] == q.shape[:-1]
         assert qv.shape[-1] == head_dim_v
-        assert head_dim_v == 512
-        assert q is None or head_dim == 64
         assert not local, "local not yet supported with qv"
         assert q_descale is None and k_descale is None and v_descale is None, (
             "q_descale/k_descale/v_descale are not yet supported with qv"
         )
-        assert tile_n == 128
-
-        assert not is_split_kv, "split kv not supported with qv"
         assert learnable_sink is None
         assert softcap is None
         assert score_mod is None
         assert mask_mod is None
-
-        if page_table is not None:
-            assert gather_kv_indices is None, "paged KV + topk sparsity not yet supported together"
-        
         qv = maybe_contiguous(qv)
 
-        gather_kv_length = 2048  # dummy value
-        sparse_kv = gather_kv_indices is not None
-        # always use kv bitmask by default (handles -1 sentinel)
-        disable_sparse_kv_bitmask = False
-        if sparse_kv:
-            assert gather_kv_indices.shape[:-1] == qv.shape[:-2]
-            gather_kv_length = gather_kv_indices.shape[-1]
-            assert gather_kv_length % 128 == 0
-            # if min_seqlen_k is None or causal:
-            #     disable_sparse_kv_bitmask = False
-            # else:
-            #     # seqlen_k_boundary = min_seqlen_k - max_seqlen_q + 1 if causal else min_seqlen_k
-            #     seqlen_k_boundary = min_seqlen_k
-            #     disable_sparse_kv_bitmask = seqlen_k_boundary >= gather_kv_length
-        
-        if requires_grad and sparse_kv:
-            if cu_seqlens_q is None:
-                p = torch.empty(batch_size, seqlen_q, num_head, gather_kv_length, dtype=q_dtype, device=device)
-                row_max = torch.empty(batch_size, seqlen_q, gather_kv_length//128, num_head, dtype=torch.float32, device=device)
-            else:
-                p = torch.empty(total_q, num_head, gather_kv_length, dtype=q_dtype, device=device)
-                row_max = torch.empty(total_q, gather_kv_length//128, num_head, dtype=torch.float32, device=device)
-        else:
+        if arch // 10 == 9:
+            assert q is not None and k is not None, "Hopper MLA requires both q and k"
+            assert head_dim == 64 and head_dim_v in [256, 512], (
+                "Hopper MLA requires head_dim=64 and head_dim_v in [256, 512]"
+            )
+            assert gather_kv_indices is None, "top-k gather is not supported by Hopper MLA"
+            assert not use_block_sparsity, "block sparsity is not supported by Hopper MLA"
+            gather_kv_length = None
+            sparse_kv = None
+            disable_sparse_kv_bitmask = None
             p = row_max = None
+        else:
+            assert arch // 10 in [10, 11], "qv is only supported on Hopper and Blackwell"
+            assert head_dim_v == 512
+            assert q is None or head_dim == 64
+            assert tile_n == 128
+            assert not is_split_kv, "split kv not supported with qv on Blackwell"
+
+            if page_table is not None:
+                assert gather_kv_indices is None, "paged KV + topk sparsity not yet supported together"
+
+            gather_kv_length = 2048  # dummy value
+            sparse_kv = gather_kv_indices is not None
+            # always use kv bitmask by default (handles -1 sentinel)
+            disable_sparse_kv_bitmask = False
+            if sparse_kv:
+                assert gather_kv_indices.shape[:-1] == qv.shape[:-2]
+                gather_kv_length = gather_kv_indices.shape[-1]
+                assert gather_kv_length % 128 == 0
+
+            if requires_grad and sparse_kv:
+                if cu_seqlens_q is None:
+                    p = torch.empty(batch_size, seqlen_q, num_head, gather_kv_length, dtype=q_dtype, device=device)
+                    row_max = torch.empty(batch_size, seqlen_q, gather_kv_length//128, num_head, dtype=torch.float32, device=device)
+                else:
+                    p = torch.empty(total_q, num_head, gather_kv_length, dtype=q_dtype, device=device)
+                    row_max = torch.empty(total_q, gather_kv_length//128, num_head, dtype=torch.float32, device=device)
+            else:
+                p = row_max = None
     else:
         assert gather_kv_indices is None, "gather_kv_indices is only supported with qv"
         gather_kv_length = None
@@ -1172,6 +1188,7 @@ def _flash_attn_fwd(
                 use_persistent_varlen=use_persistent_varlen,
                 use_dynamic_varlen=use_dynamic_varlen,
                 persistent_scheduler_sm_count=persistent_scheduler_sm_count,
+                has_qv=qv is not None,
                 # SplitKV: forward writes FP32 partials, combine does the fold.
                 output_quant_key=output_quant_key if not is_split_kv else None,
             )
@@ -1304,7 +1321,7 @@ def _flash_attn_fwd(
                 f"Unsupported compute capability: {arch}. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
             )
         # TODO: check @can_implement
-        if qv is not None:
+        if qv is not None and arch // 10 in [10, 11]:
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
                 fa_fwd,
                 q_tensor,
@@ -1332,6 +1349,10 @@ def _flash_attn_fwd(
             compile_args = [
                 fa_fwd,
                 q_tensor,
+            ]
+            if arch // 10 == 9:
+                compile_args.append(qv_tensor)
+            compile_args.extend([
                 k_tensor,
                 v_tensor,
                 o_tensor,
@@ -1346,7 +1367,7 @@ def _flash_attn_fwd(
                 window_size_left,
                 window_size_right,
                 learnable_sink_tensor,
-            ]
+            ])
             if arch // 10 in [10, 11]:
                 compile_args.append(descale_tensors_tensor)
             compile_args.extend([
@@ -1387,7 +1408,7 @@ def _flash_attn_fwd(
             if q_descale is not None or k_descale is not None or v_descale is not None
             else None
         )
-        if qv is not None:
+        if qv is not None and arch // 10 in [10, 11]:
             _flash_attn_fwd.compile_cache[compile_key](
                 q_call,
                 qv_call,
@@ -1411,6 +1432,10 @@ def _flash_attn_fwd(
         else:
             call_args = [
                 q_call,
+            ]
+            if arch // 10 == 9:
+                call_args.append(qv_call)
+            call_args.extend([
                 k_call,
                 v_call,
                 out_call if not is_split_kv else out_partial,
@@ -1425,7 +1450,7 @@ def _flash_attn_fwd(
                 window_size_left,
                 window_size_right,
                 learnable_sink,
-            ]
+            ])
             if arch // 10 in [10, 11]:
                 call_args.append(descale_tensors)
             call_args.extend([
@@ -3180,8 +3205,9 @@ def flash_attn_varlen_func(
     
     Return:
        out: (total_q, nheads, hdim) or (batch, seqlen_q, nheads, hdim)
-       lse: (nheads, total_q)       or (batch, nheads, seqlen_q) if not has_qv (standard)
-            (total_q, nheads)       or (batch, seqlen_q, nheads) if has_qv
+       lse: (nheads, total_q)       or (batch, nheads, seqlen_q) for standard
+            attention and Hopper qv
+            (total_q, nheads)       or (batch, seqlen_q, nheads) for Blackwell qv
 
     Explanation of some optional arguments & decisions:
 

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -284,7 +284,33 @@ class AttentionMask:
                         acc_S_mn[r, col] = acc_S_mn[r, col] if cond else -cutlass.Float32.inf
 
         else:  # Causal or local
-            if const_expr(not self.swap_AB):
+            if const_expr(mask_causal and self.seqlen_info.cp_world_size > 1):
+                assert not self.swap_AB, "Context-parallel causal masking requires QK layout"
+                assert self.qhead_per_kvhead_packgqa == 1, (
+                    "Context-parallel causal masking does not support PackGQA"
+                )
+                for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+                    row_idx = tScS_mn[r, 0][ROW] + m_block * self.tile_m
+                    global_k_limit = (
+                        row_idx + self.seqlen_info.tot_seqlen_k - self.seqlen_q
+                    )
+                    for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                        local_k_idx = (
+                            thr_col_offset
+                            + t0ScS_mn[0, c][COL]
+                            + n_block * self.tile_n
+                        )
+                        global_k_idx = (
+                            local_k_idx * self.seqlen_info.cp_world_size
+                            + self.seqlen_info.cp_rank
+                        )
+                        if (
+                            local_k_idx >= self.seqlen_k
+                            or global_k_idx > global_k_limit
+                            or global_k_idx >= self.seqlen_info.tot_seqlen_k
+                        ):
+                            acc_S_mn[r, c] = -Float32.inf
+            elif const_expr(not self.swap_AB):
                 # If PackGQA, we split the work of compute divmod among threads in the same row
                 threads_per_row = thr_mma.tv_layout_C.shape[0][0]
                 mma_m_idx = None

--- a/flash_attn/cute/paged_kv.py
+++ b/flash_attn/cute/paged_kv.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Optional, Type
 from dataclasses import dataclass
 
 import cutlass
@@ -39,6 +39,7 @@ class PagedKVManager(ParamsBase):
     gmem_thr_copy_KV: cute.TiledCopy
     tPrPage: cute.Tensor
     tPrPageOffset: cute.Tensor
+    tPrVPtr: Optional[cute.Tensor]
     tKpK: cute.Tensor
     tVpV: cute.Tensor
 
@@ -59,6 +60,7 @@ class PagedKVManager(ParamsBase):
         num_threads: cutlass.Constexpr[Int32],
         dtype: Type[cutlass.Numeric],
         arch: cutlass.Constexpr[int] = 100,
+        cache_v_ptr: cutlass.Constexpr[bool] = False,
     ):
         # SM100 transposes V in gmem to (dv, page_size, num_pages);
         # SM90 keeps V as (page_size, dv, num_pages), same layout as K.
@@ -86,10 +88,16 @@ class PagedKVManager(ParamsBase):
         val_layout = cute.make_layout((1, async_copy_elems))
         gmem_tiled_copy_KV = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
         gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
-        page_entry_per_thread = max(1, n_block_size // num_threads)
+        page_entry_per_thread = max(1, (n_block_size + num_threads - 1) // num_threads)
+        assert not cache_v_ptr or arch == 90
 
         tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
         tPrPageOffset = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
+        tPrVPtr = (
+            cute.make_rmem_tensor((page_entry_per_thread,), cutlass.Int64)
+            if cache_v_ptr
+            else None
+        )
 
         mPageTable = mPageTable[bidb, None]
         mK_paged = mK_paged[None, None, bidh, None]
@@ -129,12 +137,17 @@ class PagedKVManager(ParamsBase):
             gmem_thr_copy_KV,
             tPrPage,
             tPrPageOffset,
+            tPrVPtr,
             tKpK,
             tVpV,
         )
 
     @cute.jit
-    def load_page_table(self, n_block: Int32):
+    def load_page_table(
+        self,
+        n_block: Int32,
+        mask_seqlen: cutlass.Constexpr[bool] = True,
+    ):
         for i in cutlass.range(self.page_entry_per_thread, unroll=1):
             row = (
                 i * self.num_threads
@@ -148,7 +161,7 @@ class PagedKVManager(ParamsBase):
 
             is_valid = (
                 (i + 1) * self.num_threads <= self.n_block_size or row < self.n_block_size
-            ) and row_idx < self.seqlen_k
+            ) and (row_idx < self.seqlen_k if const_expr(mask_seqlen) else True)
             page = self.mPageTable[page_idx] if is_valid else 0
 
             self.tPrPage[i] = page
@@ -171,6 +184,17 @@ class PagedKVManager(ParamsBase):
         return tPrXPtr
 
     @cute.jit
+    def update_V_ptr(self):
+        assert self.arch == 90
+        assert self.tPrVPtr is not None
+        for i in cutlass.range(self.page_entry_per_thread, unroll=1):
+            page = self.tPrPage[i]
+            page_offset = self.tPrPageOffset[i]
+            self.tPrVPtr[i] = utils.elem_pointer(
+                self.mV_paged, (page_offset, 0, page)
+            ).toint()
+
+    @cute.jit
     def _flatten_smem_sm100(self, sX: cute.Tensor, K_or_V: str):
         """Flatten SM100 smem ((a,b), cta_split, k) to (a,(b,k)); transpose V to (d,page_size)."""
         sX_pi = cute.make_tensor(
@@ -191,7 +215,7 @@ class PagedKVManager(ParamsBase):
         tXcX: cute.Tensor,
         mX_paged_cur_copy: cute.Tensor,
         m: Int32,
-        should_load: cute.Tensor,
+        should_load: Optional[cute.Tensor],
     ):
         """Issue cp.async copies for one row across all k-tiles."""
         for k in cutlass.range_constexpr(cute.size(tXsX, mode=[2])):
@@ -199,15 +223,28 @@ class PagedKVManager(ParamsBase):
             mX_paged_cur_copy_ki = mX_paged_cur_copy[None, ki]
             tXsX_k = tXsX[None, m, k]
             mX_paged_cur_copy_ki = cute.make_tensor(mX_paged_cur_copy_ki.iterator, tXsX_k.layout)
-            cute.copy(
-                self.gmem_tiled_copy_KV,
-                mX_paged_cur_copy_ki,
-                tXsX_k,
-                pred=should_load,
-            )
+            if const_expr(should_load is not None):
+                cute.copy(
+                    self.gmem_tiled_copy_KV,
+                    mX_paged_cur_copy_ki,
+                    tXsX_k,
+                    pred=should_load,
+                )
+            else:
+                cute.copy(
+                    self.gmem_tiled_copy_KV,
+                    mX_paged_cur_copy_ki,
+                    tXsX_k,
+                )
 
     @cute.jit
-    def load_KV(self, n_block: Int32, sX: cute.Tensor, K_or_V: str):
+    def load_KV(
+        self,
+        n_block: Int32,
+        sX: cute.Tensor,
+        K_or_V: str,
+        mask_seqlen: cutlass.Constexpr[bool] = True,
+    ):
         assert K_or_V in ("K", "V")
 
         tPrXPtr = self.compute_X_ptr(K_or_V)
@@ -224,15 +261,20 @@ class PagedKVManager(ParamsBase):
         cX = cute.make_identity_tensor((self.n_block_size, head_dim))
         tXsX = self.gmem_thr_copy_KV.partition_D(sX_pi)
         tXcX = self.gmem_thr_copy_KV.partition_S(cX)
-        tXc0X = self.gmem_thr_copy_KV.get_slice(0).partition_S(cX)
-
-        seqlenk_row_limit = (
-            self.seqlen_k - n_block * self.n_block_size - tXcX[0][0] if n_block >= 0 else 0
-        )
+        if const_expr(mask_seqlen):
+            tXc0X = self.gmem_thr_copy_KV.get_slice(0).partition_S(cX)
+            seqlenk_row_limit = (
+                self.seqlen_k - n_block * self.n_block_size - tXcX[0][0]
+                if n_block >= 0
+                else 0
+            )
         for m in cutlass.range_constexpr(cute.size(tXsX, mode=[1])):
-            row_valid = tXc0X[0, m, 0][0] < seqlenk_row_limit
-            should_load = cute.make_fragment_like(tXsX[(0, None), m, 0], cute.Boolean)
-            should_load.fill(row_valid)
+            if const_expr(mask_seqlen):
+                row_valid = tXc0X[0, m, 0][0] < seqlenk_row_limit
+                should_load = cute.make_fragment_like(tXsX[(0, None), m, 0], cute.Boolean)
+                should_load.fill(row_valid)
+            else:
+                should_load = None
 
             x_ptr_i64 = utils.shuffle_sync(
                 tPrXPtr[m // self.gmem_threads_per_row],
@@ -245,3 +287,54 @@ class PagedKVManager(ParamsBase):
             mX_paged_cur = cute.make_tensor(x_gmem_ptr, cute.make_layout((head_dim,)))
             mX_paged_cur_copy = cute.tiled_divide(mX_paged_cur, (self.async_copy_elems,))
             self._copy_row_async(tXsX, tXcX, mX_paged_cur_copy, m, should_load)
+
+    @cute.jit
+    def load_V_cached(
+        self,
+        n_block: Int32,
+        sV: cute.Tensor,
+        update_cache: cutlass.Constexpr[bool] = True,
+    ):
+        assert self.arch == 90
+        assert self.tPrVPtr is not None
+        # Keep this separate from load_KV: passing the cached rmem pointer tensor
+        # through a nested JIT helper violates CuTeDSL region dominance.
+        sV_pi = cute.group_modes(sV, 0, 1)
+
+        cV = cute.make_identity_tensor((self.n_block_size, self.head_dim_v_padded))
+        tVsV = self.gmem_thr_copy_KV.partition_D(sV_pi)
+        tVcV = self.gmem_thr_copy_KV.partition_S(cV)
+        tVc0V = self.gmem_thr_copy_KV.get_slice(0).partition_S(cV)
+        seqlenk_row_limit = (
+            self.seqlen_k - n_block * self.n_block_size - tVcV[0][0]
+            if n_block >= 0
+            else 0
+        )
+        for m in cutlass.range_constexpr(cute.size(tVsV, mode=[1])):
+            row_valid = tVc0V[0, m, 0][0] < seqlenk_row_limit
+            should_load = cute.make_fragment_like(
+                tVsV[(0, None), m, 0], cute.Boolean
+            )
+            should_load.fill(row_valid)
+
+            v_ptr_i64 = utils.shuffle_sync(
+                self.tPrVPtr[m // self.gmem_threads_per_row],
+                m % self.gmem_threads_per_row,
+                width=self.gmem_threads_per_row,
+            )
+            v_gmem_ptr = cute.make_ptr(
+                self.mV_paged.element_type,
+                v_ptr_i64,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            mV_paged_cur = cute.make_tensor(
+                v_gmem_ptr, cute.make_layout((self.head_dim_v_padded,))
+            )
+            mV_paged_cur_copy = cute.tiled_divide(
+                mV_paged_cur, (self.async_copy_elems,)
+            )
+            self._copy_row_async(tVsV, tVcV, mV_paged_cur_copy, m, should_load)
+
+        if const_expr(update_cache):
+            self.update_V_ptr()

--- a/flash_attn/cute/seqlen_info.py
+++ b/flash_attn/cute/seqlen_info.py
@@ -78,6 +78,9 @@ class SeqlenInfoQK:
     has_cu_seqlens_k: cutlass.Constexpr[bool]
     has_seqused_q: cutlass.Constexpr[bool]
     has_seqused_k: cutlass.Constexpr[bool]
+    tot_seqlen_k: Optional[Int32] = None
+    cp_world_size: cutlass.Constexpr[int] = 1
+    cp_rank: cutlass.Constexpr[int] = 0
 
     @staticmethod
     def create(
@@ -88,10 +91,13 @@ class SeqlenInfoQK:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mCpTotSeqUsedK: Optional[cute.Tensor] = None,
         mCuTotalMBlocks: Optional[cute.Tensor] = None,
         mCuBlockIdxOffsets: Optional[cute.Tensor] = None,
         tile_m: cutlass.Constexpr[Int32] = 128,
         tile_n: cutlass.Constexpr[Int32] = 128,
+        cp_world_size: cutlass.Constexpr[int] = 1,
+        cp_rank: cutlass.Constexpr[int] = 0,
     ):
         offset_q = 0 if const_expr(mCuSeqlensQ is None) else mCuSeqlensQ[batch_idx]
         offset_k = 0 if const_expr(mCuSeqlensK is None) else mCuSeqlensK[batch_idx]
@@ -121,6 +127,11 @@ class SeqlenInfoQK:
                 if const_expr(mCuSeqlensK is None)
                 else mCuSeqlensK[batch_idx + 1] - offset_k
             )
+        tot_seqlen_k = (
+            seqlen_k
+            if const_expr(mCpTotSeqUsedK is None)
+            else mCpTotSeqUsedK[batch_idx]
+        )
         m_block_offset = 0 if const_expr(mCuTotalMBlocks is None) else mCuTotalMBlocks[batch_idx]
         num_n_blocks = (seqlen_k + tile_n - 1) // tile_n
         block_idx_offset = (
@@ -142,6 +153,9 @@ class SeqlenInfoQK:
             has_cu_seqlens_k=mCuSeqlensK is not None,
             has_seqused_q=mSeqUsedQ is not None,
             has_seqused_k=mSeqUsedK is not None,
+            tot_seqlen_k=tot_seqlen_k,
+            cp_world_size=cp_world_size,
+            cp_rank=cp_rank,
         )
 
     def offset_batch_Q(

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -37,6 +37,19 @@ class SchedulingMode(IntEnum):
     CLC = auto()
 
 
+def _sm90_gqa_l2_divisor(qhead_per_kvhead):
+    """Round a GQA ratio up to a power-of-two bucket, capped at 16."""
+    if qhead_per_kvhead <= 1:
+        return 1
+    if qhead_per_kvhead <= 2:
+        return 2
+    if qhead_per_kvhead <= 4:
+        return 4
+    if qhead_per_kvhead <= 8:
+        return 8
+    return 16
+
+
 @dataclass
 class ClcState(ParamsBase):
     """Owns the runtime state shared by CLC-capable tile schedulers.
@@ -164,6 +177,11 @@ class TileSchedulerArguments(ParamsBase):
     is_split_kv: cutlass.Constexpr[bool] = False
     head_swizzle: cutlass.Constexpr[bool] = False
     use_cluster_idx: cutlass.Constexpr[bool] = False
+
+
+@dataclass
+class HopperTileSchedulerArguments(TileSchedulerArguments):
+    use_dynamic_gqa_l2_budget: cutlass.Constexpr[bool] = False
 
 
 class SingleTileScheduler:
@@ -817,6 +835,14 @@ class SingleTileVarlenScheduler:
                 f"Only STATIC and CLC are supported, got {scheduling_mode!r}"
             )
             size_l2 = 50 * 1024 * 1024  # 50 MB for K & V
+            if const_expr(
+                isinstance(args, HopperTileSchedulerArguments)
+                and args.use_dynamic_gqa_l2_budget
+            ):
+                size_l2 = Int32(
+                    32 * 1024 * 1024
+                    // _sm90_gqa_l2_divisor(args.qhead_per_kvhead_packgqa)
+                )
             # if backward, this is qdo block size
             kv_block_size = (
                 (args.headdim + args.headdim_v) * args.element_size * args.tile_shape_mn[1]
@@ -1115,6 +1141,111 @@ class SingleTileVarlenScheduler:
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
         return self.__class__(*obj_list, loc=self._loc)
+
+
+class StaticPersistentVarlenTileScheduler(SingleTileVarlenScheduler):
+    """Static persistent scheduler for non-split variable-length attention."""
+
+    @staticmethod
+    def to_underlying_arguments(
+        args: TileSchedulerArguments,
+        *,
+        scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+        loc=None,
+        ip=None,
+    ) -> SingleTileVarlenScheduler.Params:
+        assert scheduling_mode == SchedulingMode.STATIC, (
+            f"StaticPersistentVarlenTileScheduler only supports STATIC, got {scheduling_mode!r}"
+        )
+        assert not args.is_split_kv, "Static persistent varlen does not support split-KV"
+        return SingleTileVarlenScheduler.to_underlying_arguments(
+            args, scheduling_mode=scheduling_mode, loc=loc, ip=ip
+        )
+
+    @staticmethod
+    @cute.jit
+    def create(
+        params: SingleTileVarlenScheduler.Params,
+        clc: ClcState | None = None,
+        *,
+        loc=None,
+        ip=None,
+    ) -> "StaticPersistentVarlenTileScheduler":
+        assert not params.is_split_kv, "Static persistent varlen does not support split-KV"
+        tile_idx = cute.arch.block_idx()[0]
+        return StaticPersistentVarlenTileScheduler(params, tile_idx, Int32(0), loc=loc, ip=ip)
+
+    @staticmethod
+    def get_grid_shape(
+        params: SingleTileVarlenScheduler.Params,
+        *,
+        sm_count: int,
+        loc=None,
+        ip=None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        max_grid_x = SingleTileVarlenScheduler.get_grid_shape(params)[0]
+        # A second wave balances causal tiles while retaining several tiles per CTA.
+        return (cutlass.min(sm_count * 2, max_grid_x), Int32(1), Int32(1))
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        self._tile_idx += cute.arch.grid_dim()[0]
+        return self.get_current_work()
+
+
+class DynamicPersistentVarlenTileScheduler(SingleTileVarlenScheduler):
+    """Atomic persistent scheduler for non-split variable-length attention."""
+
+    @staticmethod
+    def to_underlying_arguments(
+        args: TileSchedulerArguments,
+        *,
+        scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+        loc=None,
+        ip=None,
+    ) -> SingleTileVarlenScheduler.Params:
+        assert scheduling_mode == SchedulingMode.STATIC
+        assert not args.is_split_kv
+        return SingleTileVarlenScheduler.to_underlying_arguments(
+            args, scheduling_mode=scheduling_mode, loc=loc, ip=ip
+        )
+
+    @staticmethod
+    @cute.jit
+    def create(
+        params: SingleTileVarlenScheduler.Params,
+        clc: ClcState | None = None,
+        *,
+        loc=None,
+        ip=None,
+    ) -> "DynamicPersistentVarlenTileScheduler":
+        return DynamicPersistentVarlenTileScheduler(
+            params, Int32(0), Int32(0), loc=loc, ip=ip
+        )
+
+    @staticmethod
+    def get_grid_shape(
+        params: SingleTileVarlenScheduler.Params,
+        *,
+        sm_count: int,
+        loc=None,
+        ip=None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        max_grid_x = SingleTileVarlenScheduler.get_grid_shape(params)[0]
+        return (cutlass.min(sm_count, max_grid_x), Int32(1), Int32(1))
+
+    @cute.jit
+    def claim_next_work(self, mWorkCounter: cute.Tensor) -> WorkTileInfo:
+        lane_idx = cute.arch.lane_idx()
+        tile_idx = Int32(0)
+        if lane_idx == 0:
+            tile_idx = cute.arch.atomic_add(
+                mWorkCounter.iterator.llvm_ptr,
+                Int32(1),
+                sem="relaxed",
+                scope="gpu",
+            )
+        self._tile_idx = cute.arch.shuffle_sync(tile_idx, 0)
+        return self.get_current_work()
 
 
 # -----------------------------------------------------------------------------

--- a/tests/cute/benchmark_mask_mod.py
+++ b/tests/cute/benchmark_mask_mod.py
@@ -403,6 +403,7 @@ class FlashAttentionBenchmark:
         compiled = cute.compile(
             kernel,
             q_cute,
+            None,  # qv
             k_cute,
             v_cute,
             out_cute,
@@ -424,6 +425,7 @@ class FlashAttentionBenchmark:
 
         args = (
             q_cute,
+            None,  # qv
             k_cute,
             v_cute,
             out_cute,

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -96,6 +96,72 @@ def test_flash_attn_sm120_rejects_splitkv():
         flash_attn_func(q, k, v, num_splits=3)
 
 
+@pytest.mark.skipif(not IS_SM90, reason="SM90 paged-KV loader regression")
+def test_flash_attn_sm90_paged_tile_n_larger_than_producer_group():
+    """All KV rows must be loaded when tile N exceeds the 128-thread producer group."""
+    torch.manual_seed(0)
+    batch_size, seqlen_q, seqlen_k = 2, 1, 257
+    page_size, nheads, nheads_kv, head_dim = 16, 8, 2, 64
+    pages_per_seq = math.ceil(seqlen_k / page_size)
+
+    q = torch.randn(
+        batch_size * seqlen_q, nheads, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.randn(
+        batch_size, seqlen_k, nheads_kv, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    v = torch.randn_like(k)
+    k_paged = torch.zeros(
+        batch_size * pages_per_seq,
+        page_size,
+        nheads_kv,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    v_paged = torch.zeros_like(k_paged)
+    for batch_idx in range(batch_size):
+        page_slice = slice(batch_idx * pages_per_seq, (batch_idx + 1) * pages_per_seq)
+        k_paged[page_slice].view(-1, nheads_kv, head_dim)[:seqlen_k].copy_(k[batch_idx])
+        v_paged[page_slice].view(-1, nheads_kv, head_dim)[:seqlen_k].copy_(v[batch_idx])
+
+    cu_seqlens_q = torch.arange(
+        batch_size + 1, device="cuda", dtype=torch.int32
+    )
+    cu_seqlens_k = torch.arange(
+        0, (batch_size + 1) * seqlen_k, seqlen_k, device="cuda", dtype=torch.int32
+    )
+    seqused_k = torch.full((batch_size,), seqlen_k, device="cuda", dtype=torch.int32)
+    page_table = torch.arange(
+        batch_size * pages_per_seq, device="cuda", dtype=torch.int32
+    ).view(batch_size, pages_per_seq)
+
+    out_paged, *_ = _flash_attn_fwd(
+        q,
+        k_paged,
+        v_paged,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_k=seqused_k,
+        max_seqlen_q=seqlen_q,
+        page_table=page_table,
+        tile_mn=(64, 192),
+        num_splits=1,
+    )
+    out_dense, *_ = _flash_attn_fwd(
+        q,
+        k.flatten(0, 1),
+        v.flatten(0, 1),
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_k,
+        tile_mn=(64, 192),
+        num_splits=1,
+    )
+
+    torch.testing.assert_close(out_paged, out_dense, rtol=0, atol=0)
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])

--- a/tests/cute/test_flash_attn_dynamic_causal.py
+++ b/tests/cute/test_flash_attn_dynamic_causal.py
@@ -145,3 +145,70 @@ def test_dynamic_causal_causal_splitkv(seqlen_q, seqlen_k, num_splits, head_dim)
     torch.cuda.synchronize()
     err = _rel_err(out, _ref_causal(q, k, v, scale))
     assert err < 2e-2, f"causal psc=1 rel_err={err:.3e}"
+
+
+@pytest.mark.parametrize(
+    "dynamic_causal_first",
+    [False, True],
+    ids=["none-then-tensor", "tensor-then-none"],
+)
+def test_dynamic_causal_compile_cache_orders(dynamic_causal_first):
+    """Presence changes must compile independently in either cache order."""
+    torch.manual_seed(1)
+    batch, seqlen_q, seqlen_k, num_heads, head_dim = 2, 8, 32, 4, 64
+    scale = head_dim**-0.5
+    q_padded = torch.randn(
+        batch, seqlen_q, num_heads, head_dim, device=DEV, dtype=DT
+    )
+    k_padded = torch.randn(
+        batch, seqlen_k, num_heads, head_dim, device=DEV, dtype=DT
+    )
+    v_padded = torch.randn_like(k_padded)
+    q, k, v = [tensor.flatten(0, 1) for tensor in (q_padded, k_padded, v_padded)]
+    cu_q = torch.arange(
+        0, (batch + 1) * seqlen_q, seqlen_q, device=DEV, dtype=torch.int32
+    )
+    cu_k = torch.arange(
+        0, (batch + 1) * seqlen_k, seqlen_k, device=DEV, dtype=torch.int32
+    )
+    per_sequence_causal = torch.tensor([0, 1], device=DEV, dtype=torch.int32)
+    causal_ref = torch.stack(
+        [
+            _ref_causal(q_padded[idx], k_padded[idx], v_padded[idx], scale)
+            for idx in range(batch)
+        ]
+    )
+    mixed_ref = torch.stack(
+        [
+            _ref_bidirectional(q_padded[0], k_padded[0], v_padded[0], scale),
+            _ref_causal(q_padded[1], k_padded[1], v_padded[1], scale),
+        ]
+    )
+    call_order = (
+        (per_sequence_causal, None)
+        if dynamic_causal_first
+        else (None, per_sequence_causal)
+    )
+
+    _flash_attn_fwd.compile_cache.clear()
+    try:
+        for dynamic_causal in call_order:
+            out, *_ = _flash_attn_fwd(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_k,
+                max_seqlen_q=seqlen_q,
+                max_seqlen_k=seqlen_k,
+                softmax_scale=scale,
+                causal=True,
+                dynamic_causal=dynamic_causal,
+                num_splits=1,
+            )
+            ref = mixed_ref if dynamic_causal is not None else causal_ref
+            err = _rel_err(out.view_as(q_padded), ref)
+            assert err < 2e-2, f"dynamic_causal cache-order rel_err={err:.3e}"
+        assert len(_flash_attn_fwd.compile_cache.cache) == 2
+    finally:
+        _flash_attn_fwd.compile_cache.clear()

--- a/tests/cute/test_hopper_policies.py
+++ b/tests/cute/test_hopper_policies.py
@@ -17,7 +17,7 @@ from flash_attn.cute.tile_scheduler import (
     StaticPersistentVarlenTileScheduler,
     _sm90_gqa_l2_divisor,
 )
-from flash_attn.cute.testing import maybe_fake_tensor_mode
+from flash_attn.cute.testing import attention_ref, maybe_fake_tensor_mode
 
 
 @pytest.mark.parametrize(
@@ -253,6 +253,8 @@ def _dynamic_selector(**overrides):
             },
             True,
         ),
+        ({"batch_size": 2, "mask_mod": object()}, False),
+        ({"num_head_kv": 32, "aux_tensors": []}, False),
         ({"max_seqlen_k": 16 * 1024 - 1}, False),
         ({"num_head": 64, "max_seqlen_q": 8192, "max_seqlen_k": 8192}, True),
         ({"num_head": 60, "max_seqlen_q": 8192, "max_seqlen_k": 8192}, False),
@@ -296,61 +298,38 @@ def test_dynamic_varlen_selector_rejects_non_sm90(arch):
     )
 
 
-@pytest.mark.parametrize("arch", [80, 100, 110, 120])
-@maybe_fake_tensor_mode()
-def test_dynamic_workspace_rejects_non_sm90(arch):
-    dtype = torch.bfloat16
-    q = torch.empty((1, 1, 64), device="cuda", dtype=dtype)
-    k = torch.empty_like(q)
-    v = torch.empty_like(q)
-    cu_seqlens = torch.empty(2, device="cuda", dtype=torch.int32)
-    workspace = torch.zeros(2, device="cuda", dtype=torch.int32)
-
-    with pytest.raises(
-        AssertionError,
-        match="dynamic varlen scheduler is only supported on SM90",
-    ):
-        _flash_attn_fwd(
-            q,
-            k,
-            v,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=1,
-            max_seqlen_k=1,
-            dynamic_scheduler_workspace=workspace,
-            _arch=arch,
-            compile_only=True,
-        )
-
-
 IS_SM90 = (
     torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 9
 )
 
 
 @pytest.mark.skipif(not IS_SM90, reason="SM90 dynamic scheduler regression")
-def test_dynamic_scheduler_workspace_resets_eager_and_graph():
+def test_dynamic_scheduler_uses_internal_state(monkeypatch):
     torch.manual_seed(0)
     device = "cuda"
     dtype = torch.bfloat16
     batch_size, seqlen_q, seqlen_k = 2, 1, 256
     num_heads, head_dim = 4, 64
-    q = torch.randn(
-        batch_size * seqlen_q,
+    q_padded = torch.randn(
+        batch_size,
+        seqlen_q,
         num_heads,
         head_dim,
         device=device,
         dtype=dtype,
     )
-    k = torch.randn(
-        batch_size * seqlen_k,
+    k_padded = torch.randn(
+        batch_size,
+        seqlen_k,
         num_heads,
         head_dim,
         device=device,
         dtype=dtype,
     )
-    v = torch.randn_like(k)
+    v_padded = torch.randn_like(k_padded)
+    q = q_padded.flatten(0, 1)
+    k = k_padded.flatten(0, 1)
+    v = v_padded.flatten(0, 1)
     cu_seqlens_q = torch.arange(
         batch_size + 1, device=device, dtype=torch.int32
     )
@@ -361,11 +340,17 @@ def test_dynamic_scheduler_workspace_resets_eager_and_graph():
         device=device,
         dtype=torch.int32,
     )
-    workspace = torch.zeros(2, device=device, dtype=torch.int32)
-    out = torch.empty_like(q)
+    selected = []
+    original_init = interface.FlashAttentionForwardSm90.__init__
 
-    def run():
-        _flash_attn_fwd(
+    def record_init(self, *args, **kwargs):
+        selected.append(kwargs["use_dynamic_varlen"])
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(interface.FlashAttentionForwardSm90, "__init__", record_init)
+    _flash_attn_fwd.compile_cache.clear()
+    try:
+        out, *_ = _flash_attn_fwd(
             q,
             k,
             v,
@@ -374,93 +359,13 @@ def test_dynamic_scheduler_workspace_resets_eager_and_graph():
             max_seqlen_q=seqlen_q,
             max_seqlen_k=seqlen_k,
             num_splits=1,
-            out=out,
-            dynamic_scheduler_workspace=workspace,
+            causal=True,
         )
-
-    run()
-    torch.cuda.synchronize()
-    assert torch.count_nonzero(workspace).item() == 0
-
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        run()
-    for _ in range(100):
-        graph.replay()
-    torch.cuda.synchronize()
-    assert torch.count_nonzero(workspace).item() == 0
-
-
-@pytest.mark.skipif(not IS_SM90, reason="SM90 dynamic scheduler regression")
-@pytest.mark.parametrize(
-    "batch_size,num_heads,num_heads_kv,num_splits,seqlen_k,head_dim,"
-    "causal,window_size_right",
-    [
-        (1, 8, 1, 1, 640, 64, False, None),  # Short GQA is not selected.
-        (2, 4, 4, 2, 640, 64, False, None),  # Split-K disables dynamic.
-        (1, 8, 1, 1, 16 * 1024, 128, False, 0),  # Explicit right=0.
-    ],
-)
-def test_ineffective_workspace_reuses_compile_key(
-    batch_size,
-    num_heads,
-    num_heads_kv,
-    num_splits,
-    seqlen_k,
-    head_dim,
-    causal,
-    window_size_right,
-):
-    torch.manual_seed(0)
-    device = "cuda"
-    dtype = torch.bfloat16
-    seqlen_q = 1
-    q = torch.randn(
-        batch_size * seqlen_q,
-        num_heads,
-        head_dim,
-        device=device,
-        dtype=dtype,
-    )
-    k = torch.randn(
-        batch_size * seqlen_k,
-        num_heads_kv,
-        head_dim,
-        device=device,
-        dtype=dtype,
-    )
-    v = torch.randn_like(k)
-    cu_seqlens_q = torch.arange(
-        batch_size + 1, device=device, dtype=torch.int32
-    )
-    cu_seqlens_k = torch.arange(
-        0,
-        (batch_size + 1) * seqlen_k,
-        seqlen_k,
-        device=device,
-        dtype=torch.int32,
-    )
-    workspace = torch.zeros(2, device=device, dtype=torch.int32)
-
-    def run(dynamic_scheduler_workspace=None):
-        _flash_attn_fwd(
-            q,
-            k,
-            v,
-            cu_seqlens_q=cu_seqlens_q,
-            cu_seqlens_k=cu_seqlens_k,
-            max_seqlen_q=seqlen_q,
-            max_seqlen_k=seqlen_k,
-            num_splits=num_splits,
-            causal=causal,
-            window_size_right=window_size_right,
-            dynamic_scheduler_workspace=dynamic_scheduler_workspace,
+        torch.cuda.synchronize()
+        assert selected == [True]
+        out_ref, _ = attention_ref(q_padded, k_padded, v_padded, causal=True)
+        torch.testing.assert_close(
+            out.view_as(q_padded), out_ref, atol=1e-2, rtol=1e-2
         )
-
-    _flash_attn_fwd.compile_cache.clear()
-    run()
-    keys_without_workspace = set(_flash_attn_fwd.compile_cache.cache)
-    run(workspace)
-    torch.cuda.synchronize()
-    assert set(_flash_attn_fwd.compile_cache.cache) == keys_without_workspace
-    assert torch.count_nonzero(workspace).item() == 0
+    finally:
+        _flash_attn_fwd.compile_cache.clear()

--- a/tests/cute/test_hopper_policies.py
+++ b/tests/cute/test_hopper_policies.py
@@ -1,0 +1,466 @@
+import pytest
+import torch
+
+import flash_attn.cute.interface as interface
+import flash_attn.cute.tile_scheduler as tile_scheduler
+from flash_attn.cute.flash_fwd_sm90 import _use_paged_kv_overlap_sm90
+from flash_attn.cute.interface import (
+    _combine_max_seqlen_q_sm90,
+    _flash_attn_fwd,
+    _num_splits_sm90,
+    _use_dynamic_varlen_scheduler_sm90,
+    num_splits_heuristic,
+)
+from flash_attn.cute.tile_scheduler import (
+    DynamicPersistentVarlenTileScheduler,
+    SingleTileVarlenScheduler,
+    StaticPersistentVarlenTileScheduler,
+    _sm90_gqa_l2_divisor,
+)
+from flash_attn.cute.testing import maybe_fake_tensor_mode
+
+
+@pytest.mark.parametrize(
+    "total_mblocks,num_n_blocks,batch_size,qhead_per_kvhead,paged_kv,"
+    "head_dim,head_dim_v,expected",
+    [
+        (1, 3, 2, 4, False, 128, 128, 1),
+        (26, 4, 2, 4, False, 128, 128, 4),
+        (27, 4, 2, 4, False, 128, 128, 1),
+        (27, 5, 2, 4, False, 128, 128, 4),
+        (2, 63, 1, 4, False, 128, 128, 63),
+        (2, 64, 1, 4, False, 128, 128, 16),
+        (2, 191, 1, 4, False, 128, 128, 47),
+        (2, 192, 1, 4, False, 128, 128, 24),
+        (66, 5, 1, 8, True, 64, 64, 2),
+        (67, 5, 1, 8, True, 64, 64, 2),
+        (131, 5, 1, 8, True, 64, 64, 2),
+        (132, 5, 1, 8, True, 64, 64, 1),
+        (67, 5, 1, 8, False, 64, 64, 1),
+        (67, 5, 1, 8, True, 128, 128, 1),
+        (67, 5, 2, 8, True, 64, 64, 1),
+        (133, 5, 2, 8, False, 128, 128, 1),
+    ],
+)
+def test_num_splits_sm90_boundaries(
+    total_mblocks,
+    num_n_blocks,
+    batch_size,
+    qhead_per_kvhead,
+    paged_kv,
+    head_dim,
+    head_dim_v,
+    expected,
+):
+    assert (
+        _num_splits_sm90(
+            total_mblocks,
+            132,
+            num_n_blocks,
+            128,
+            batch_size,
+            qhead_per_kvhead,
+            paged_kv,
+            head_dim,
+            head_dim_v,
+        )
+        == expected
+    )
+
+
+def test_generic_num_splits_never_returns_zero():
+    assert num_splits_heuristic(133, 132, 5, 128) == 1
+
+
+@pytest.mark.parametrize(
+    "scheduler,sm_count,expected_grid_x",
+    [
+        (StaticPersistentVarlenTileScheduler, 114, 228),
+        (DynamicPersistentVarlenTileScheduler, 132, 132),
+    ],
+)
+def test_persistent_grid_uses_forward_sm_count(
+    monkeypatch, scheduler, sm_count, expected_grid_x
+):
+    monkeypatch.setattr(
+        SingleTileVarlenScheduler,
+        "get_grid_shape",
+        staticmethod(lambda params: (1000, 1, 1)),
+    )
+
+    class WrongDeviceHardwareInfo:
+        def get_device_multiprocessor_count(self):
+            raise AssertionError("persistent scheduler queried another device")
+
+    monkeypatch.setattr(
+        tile_scheduler, "HardwareInfo", WrongDeviceHardwareInfo
+    )
+    grid = scheduler.get_grid_shape(object(), sm_count=sm_count)
+    assert grid[0] == expected_grid_x
+
+
+@pytest.mark.parametrize(
+    "arch,is_packed_varlen,expected",
+    [
+        (80, True, None),
+        (90, True, 17),
+        (90, False, None),
+        (100, True, None),
+        (110, True, None),
+        (120, True, None),
+    ],
+)
+def test_combine_max_seqlen_q_is_sm90_packed_only(
+    arch, is_packed_varlen, expected
+):
+    assert (
+        _combine_max_seqlen_q_sm90(arch, 17, is_packed_varlen)
+        == expected
+    )
+
+
+@maybe_fake_tensor_mode()
+def test_combine_max_seqlen_q_compile_specialization(monkeypatch):
+    compile_calls = []
+
+    def record_compile(*args):
+        compile_calls.append(args)
+        return object()
+
+    monkeypatch.setattr(interface, "_compile_fwd_combine", record_compile)
+    interface._flash_attn_fwd_combine.compile_cache.clear()
+
+    out_partial = torch.empty(
+        (2, 8, 4, 64), device="cuda", dtype=torch.bfloat16
+    )
+    lse_partial = torch.empty(
+        (2, 8, 4), device="cuda", dtype=torch.float32
+    )
+    out = torch.empty((8, 4, 64), device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.empty((3,), device="cuda", dtype=torch.int32)
+
+    try:
+        interface._flash_attn_fwd_combine(
+            out_partial, lse_partial, out, cu_seqlens=cu_seqlens
+        )
+        assert compile_calls[-1][-1] is False
+
+        interface._flash_attn_fwd_combine(
+            out_partial,
+            lse_partial,
+            out,
+            cu_seqlens=cu_seqlens,
+            max_seqlen_q=4,
+        )
+        assert compile_calls[-1][-1] is True
+    finally:
+        interface._flash_attn_fwd_combine.compile_cache.clear()
+
+
+def test_combine_compile_argument_binding(monkeypatch):
+    compile_calls = []
+
+    def record_compile(*args, **kwargs):
+        compile_calls.append((args, kwargs))
+        return object()
+
+    monkeypatch.setattr(interface.cute, "compile", record_compile)
+    common_args = (
+        interface.torch2cute_dtype_map[torch.bfloat16],
+        interface.Float32,
+        64,
+        16,
+        64,
+        4,
+        True,
+        False,
+        False,
+        False,
+        None,
+    )
+
+    interface._compile_fwd_combine(*common_args, False)
+    args, _ = compile_calls[-1]
+    assert args[-2] is None
+
+    interface._compile_fwd_combine(*common_args, True)
+    args, _ = compile_calls[-1]
+    assert isinstance(args[-2], interface.Int32)
+
+
+@pytest.mark.parametrize(
+    "ratio,expected",
+    [(1, 1), (2, 2), (3, 4), (4, 4), (5, 8), (8, 8), (9, 16), (16, 16), (32, 16)],
+)
+def test_sm90_gqa_l2_divisor(ratio, expected):
+    assert _sm90_gqa_l2_divisor(ratio) == expected
+
+
+@pytest.mark.parametrize(
+    "requested,paged_non_tma,tile_n,expected",
+    [
+        (True, True, 128, True),
+        (True, True, 64, False),
+        (True, False, 128, False),
+        (False, True, 128, False),
+    ],
+)
+def test_sm90_paged_overlap_uses_measured_tile(
+    requested, paged_non_tma, tile_n, expected
+):
+    assert (
+        _use_paged_kv_overlap_sm90(requested, paged_non_tma, tile_n)
+        is expected
+    )
+
+
+def _dynamic_selector(**overrides):
+    args = {
+        "arch": 90,
+        "batch_size": 1,
+        "num_head": 32,
+        "num_head_kv": 4,
+        "head_dim": 128,
+        "max_seqlen_q": 128,
+        "max_seqlen_k": 8192,
+        "no_explicit_window": True,
+        "local": False,
+        "mask_mod": None,
+        "aux_tensors": None,
+    }
+    args.update(overrides)
+    return _use_dynamic_varlen_scheduler_sm90(**args)
+
+
+@pytest.mark.parametrize(
+    "overrides,expected",
+    [
+        (
+            {
+                "batch_size": 2,
+                "head_dim": 64,
+                "no_explicit_window": False,
+                "local": True,
+            },
+            True,
+        ),
+        (
+            {
+                "num_head_kv": 32,
+                "head_dim": 64,
+                "no_explicit_window": False,
+                "local": True,
+            },
+            True,
+        ),
+        ({"max_seqlen_k": 16 * 1024 - 1}, False),
+        ({"num_head": 64, "max_seqlen_q": 8192, "max_seqlen_k": 8192}, True),
+        ({"num_head": 60, "max_seqlen_q": 8192, "max_seqlen_k": 8192}, False),
+        ({"num_head": 64, "max_seqlen_q": 8191, "max_seqlen_k": 8192}, False),
+        ({"num_head": 64, "max_seqlen_q": 8192, "max_seqlen_k": 8191}, False),
+        ({"max_seqlen_k": 16 * 1024, "mask_mod": object()}, False),
+        ({"max_seqlen_k": 16 * 1024, "aux_tensors": []}, False),
+        ({"max_seqlen_k": 16 * 1024, "head_dim": 64}, False),
+        ({}, False),
+    ],
+)
+def test_dynamic_varlen_selector(overrides, expected):
+    assert _dynamic_selector(**overrides) is expected
+
+
+@pytest.mark.parametrize(
+    "no_explicit_window,local,expected",
+    [
+        (False, False, False),  # Explicit right=0 canonicalizes to non-local.
+        (True, False, True),  # Ordinary causal attention has no raw window.
+        (False, True, False),  # Explicit local window.
+    ],
+)
+def test_dynamic_gqa_window_boundaries(
+    no_explicit_window, local, expected
+):
+    assert _dynamic_selector(
+        max_seqlen_k=16 * 1024,
+        no_explicit_window=no_explicit_window,
+        local=local,
+    ) is expected
+
+
+@pytest.mark.parametrize("arch", [80, 100, 110, 120])
+def test_dynamic_varlen_selector_rejects_non_sm90(arch):
+    assert not _dynamic_selector(
+        arch=arch,
+        batch_size=2,
+        num_head=32,
+        num_head_kv=32,
+    )
+
+
+@pytest.mark.parametrize("arch", [80, 100, 110, 120])
+@maybe_fake_tensor_mode()
+def test_dynamic_workspace_rejects_non_sm90(arch):
+    dtype = torch.bfloat16
+    q = torch.empty((1, 1, 64), device="cuda", dtype=dtype)
+    k = torch.empty_like(q)
+    v = torch.empty_like(q)
+    cu_seqlens = torch.empty(2, device="cuda", dtype=torch.int32)
+    workspace = torch.zeros(2, device="cuda", dtype=torch.int32)
+
+    with pytest.raises(
+        AssertionError,
+        match="dynamic varlen scheduler is only supported on SM90",
+    ):
+        _flash_attn_fwd(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=1,
+            max_seqlen_k=1,
+            dynamic_scheduler_workspace=workspace,
+            _arch=arch,
+            compile_only=True,
+        )
+
+
+IS_SM90 = (
+    torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 9
+)
+
+
+@pytest.mark.skipif(not IS_SM90, reason="SM90 dynamic scheduler regression")
+def test_dynamic_scheduler_workspace_resets_eager_and_graph():
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size, seqlen_q, seqlen_k = 2, 1, 256
+    num_heads, head_dim = 4, 64
+    q = torch.randn(
+        batch_size * seqlen_q,
+        num_heads,
+        head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    k = torch.randn(
+        batch_size * seqlen_k,
+        num_heads,
+        head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    v = torch.randn_like(k)
+    cu_seqlens_q = torch.arange(
+        batch_size + 1, device=device, dtype=torch.int32
+    )
+    cu_seqlens_k = torch.arange(
+        0,
+        (batch_size + 1) * seqlen_k,
+        seqlen_k,
+        device=device,
+        dtype=torch.int32,
+    )
+    workspace = torch.zeros(2, device=device, dtype=torch.int32)
+    out = torch.empty_like(q)
+
+    def run():
+        _flash_attn_fwd(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=seqlen_q,
+            max_seqlen_k=seqlen_k,
+            num_splits=1,
+            out=out,
+            dynamic_scheduler_workspace=workspace,
+        )
+
+    run()
+    torch.cuda.synchronize()
+    assert torch.count_nonzero(workspace).item() == 0
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    for _ in range(100):
+        graph.replay()
+    torch.cuda.synchronize()
+    assert torch.count_nonzero(workspace).item() == 0
+
+
+@pytest.mark.skipif(not IS_SM90, reason="SM90 dynamic scheduler regression")
+@pytest.mark.parametrize(
+    "batch_size,num_heads,num_heads_kv,num_splits,seqlen_k,head_dim,"
+    "causal,window_size_right",
+    [
+        (1, 8, 1, 1, 640, 64, False, None),  # Short GQA is not selected.
+        (2, 4, 4, 2, 640, 64, False, None),  # Split-K disables dynamic.
+        (1, 8, 1, 1, 16 * 1024, 128, False, 0),  # Explicit right=0.
+    ],
+)
+def test_ineffective_workspace_reuses_compile_key(
+    batch_size,
+    num_heads,
+    num_heads_kv,
+    num_splits,
+    seqlen_k,
+    head_dim,
+    causal,
+    window_size_right,
+):
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+    seqlen_q = 1
+    q = torch.randn(
+        batch_size * seqlen_q,
+        num_heads,
+        head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    k = torch.randn(
+        batch_size * seqlen_k,
+        num_heads_kv,
+        head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    v = torch.randn_like(k)
+    cu_seqlens_q = torch.arange(
+        batch_size + 1, device=device, dtype=torch.int32
+    )
+    cu_seqlens_k = torch.arange(
+        0,
+        (batch_size + 1) * seqlen_k,
+        seqlen_k,
+        device=device,
+        dtype=torch.int32,
+    )
+    workspace = torch.zeros(2, device=device, dtype=torch.int32)
+
+    def run(dynamic_scheduler_workspace=None):
+        _flash_attn_fwd(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=seqlen_q,
+            max_seqlen_k=seqlen_k,
+            num_splits=num_splits,
+            causal=causal,
+            window_size_right=window_size_right,
+            dynamic_scheduler_workspace=dynamic_scheduler_workspace,
+        )
+
+    _flash_attn_fwd.compile_cache.clear()
+    run()
+    keys_without_workspace = set(_flash_attn_fwd.compile_cache.cache)
+    run(workspace)
+    torch.cuda.synchronize()
+    assert set(_flash_attn_fwd.compile_cache.cache) == keys_without_workspace
+    assert torch.count_nonzero(workspace).item() == 0


### PR DESCRIPTION
* New heuristic to choose number of splits 
* Small Tile heuristic (i.e. one WG) similar to what we do in FA3
* Static Persistent Scheduler at batch size 1 if no split (maybe we can remove this, need to measure perf for 1 batch case)
* Dynamic persistent scheduler at batch size > 1 if no split
* Improved Overlap for KV Paged approach (non TMA case)
* Some minor improvements

Most of above approaches are done similarly in the FA3 code and were adapted (in simplified form) to CuTeDSL. 

On all three benchmarks (`standard_{attention|decode|prefill}`) now FA4 performs better than FA3.
End To End FA4 is on parity with FA3 for decode/prefill/mixed cases now.