### PR TITLE
Apply split-K to varlen paged KV when max_seqlen_q > 1 (spec decode)

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -753,16 +753,11 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     params.page_block_size = page_block_size;
     // Keep references to these tensors to extend their lifetime
     Tensor softmax_lse_accum, out_accum;
-    if (seqlenq_ngroups_swapped) {
-        // Only apply split-k for decoding
-        std::tie(softmax_lse_accum, out_accum) =
-            set_params_splitkv(params, batch_size, num_heads, head_size,
-                               max_seqlen_k, max_seqlen_q, head_size_rounded,
-                               p_dropout, num_splits, get_num_sm(get_current_device()), q);
-    } else if (paged_KV) {
-        STD_TORCH_CHECK(num_splits <= 1, "num_splits > 1 is not supported for varlen paged KV");
-        params.num_splits = num_splits;
-    }
+    std::tie(softmax_lse_accum, out_accum) =
+        set_params_splitkv(params, batch_size, num_heads, head_size,
+                           max_seqlen_k, max_seqlen_q, head_size_rounded,
+                           p_dropout, num_splits, get_num_sm(get_current_device()), q);
+    if (num_splits < 1 && params.num_splits == 1) { params.num_splits = 0; }
 
     if (leftpad_k_.has_value()) {
         auto leftpad_k = leftpad_k_.value();

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -1222,7 +1222,18 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
         if (params.unpadded_lse) {
             const index_t lse_offset = row_offset_lse + tidx / kRowsPerLoadTranspose;
             if (lse_offset < lse_size) {
-                gLSE_unpadded(lse_offset) = lse_logsum;
+                if (params.cu_seqlens_q == nullptr) {
+                    gLSE_unpadded(lse_offset) = lse_logsum;
+                } else {
+                    const int batch_idx = lse_offset / (params.h * params.seqlen_q);
+                    const int head_idx = (lse_offset - batch_idx * (params.h * params.seqlen_q)) / params.seqlen_q;
+                    const int row = lse_offset - batch_idx * (params.h * params.seqlen_q) - head_idx * params.seqlen_q;
+                    const int q_start = params.cu_seqlens_q[batch_idx];
+                    if (row < params.cu_seqlens_q[batch_idx + 1] - q_start) {
+                        reinterpret_cast<ElementAccum *>(params.softmax_lse_ptr)[
+                            head_idx * index_t(params.total_q) + q_start + row] = lse_logsum;
+                    }
+                }
             }
         } else {
             gLSE(tidx / kRowsPerLoadTranspose) = lse_logsum;
@@ -1295,7 +1306,13 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
             const int head_idx = (idx - batch_idx * (params.h * params.seqlen_q)) / params.seqlen_q;
             // The index to the rows of Q
             const int row = idx - batch_idx * (params.h * params.seqlen_q) - head_idx * params.seqlen_q;
-            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + batch_idx * params.o_batch_stride
+            index_t batch_offset = batch_idx * params.o_batch_stride;
+            if (params.cu_seqlens_q != nullptr) {
+                const int q_start = params.cu_seqlens_q[batch_idx];
+                if (row >= params.cu_seqlens_q[batch_idx + 1] - q_start) { continue; }
+                batch_offset = index_t(q_start) * params.o_row_stride;
+            }
+            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + batch_offset
                 + head_idx * params.o_head_stride + row * params.o_row_stride;
             #pragma unroll
             for (int k = 0; k < size<2>(rO); ++k) {


### PR DESCRIPTION
FA2 silently disables split-K for **every speculative-decode step**. `set_params_splitkv` is gated on `seqlenq_ngroups_swapped`, which requires `max_seqlen_q == 1`; spec decode makes the verify pass carry `q_len = K+1`, so the gate never opens. This affects MTP, EAGLE, Medusa, draft-model and n-gram equally.

Measured impact: the decode-attention grid collapses from **172 to 12 blocks**, so 12 of 128 SMs get work — **3.5% of DRAM peak instead of ~79%**.

## Why the gate could not simply be removed

The n-groups swap is the only path that sets `cu_seqlens_q_d = nullptr`, and that is the sole branch in `set_params_fprop` that assigns `o_batch_stride` — which is what `combine_attn_seqk_parallel` uses to address O. In a true varlen call `o_batch_stride` stays **0**, so the combine kernel folds every sequence onto sequence 0. At batch 1 `batch_idx * 0 == 0`, so a naive gate flip passes a single-sequence benchmark and silently corrupts batch > 1. That hazard is exactly what the existing `TORCH_CHECK(num_splits <= 1, "not supported for varlen paged KV")` encodes.

This PR therefore addresses O and LSE through `cu_seqlens_q` in the combine kernel and skips rows past `actual_seqlen_q`, **then** drops the gate. The n-groups swap stays gated on `max_seqlen_q == 1`, where it belongs. 40 changed lines across `flash_api.cpp` and `flash_fwd_kernel.h`.

## Not a duplicate

Searched `vllm-project/flash-attention` open PRs for `split-K spec decode`, `seqlenq_ngroups_swapped`, and `varlen paged num_splits` — no open PR addresses this.

## Tests run, and results

Added coverage exercises the batch > 1 case the old guard was protecting, including **non-uniform query lengths**, where the padded scratch layout and the unpadded output layout diverge:

```
seq_lens: [(6, 16384)]                       batch 1
          [(6, 8192), (6, 8191), (6, 4097)]  batch 3
          [(1, 4096), (6, 4096), (37, 4096)] batch 3, non-uniform q (1, 6, 37)
          [(4, 129), (1, 8000), (12, 33)]    batch 3, non-uniform q and kv
```
crossed with `num_splits` {2, 5, 16}, `num_heads` {(12,2), (4,4)}, `head_size` {128, 256}, `sliding_window` {None, 256} = 96 cases.

Run red-before-green against two images differing **only** in `_vllm_fa2_C.abi3.so`, with each arm verified to load its own binary (md5 `39d84a04` unpatched vs `3ab40ce6` patched) before trusting the result:

```
unpatched .so : 96 failed
patched   .so : 96 passed
```

## Effect on model output

RTX 4090 sm_89, Qwen3.6-27B-AWQ-INT4, TP2, MTP K=5, batch 1, ISL 16384, bf16 KV, clocks locked 2700 MHz:

| arm | tok/s | TPOT ms | accept_len | TTFT p50 | step ms |
|---|---|---|---|---|---|
| base (x3 reps) | 70.0 | 14.28 | 3.11 | 6041 | 44.42 |
| patched (x2 reps) | **108.9** | **9.19** | **3.20** | 6027 | **29.41** |

**+55.4% tok/s, -35.6% TPOT.** Noise band ±0.07%. The base arm was repeated non-adjacently on a fresh boot *after* the patched arm (70.1) to rule out drift. TTFT is flat, as a decode-only change must be.

Accuracy is not degraded — it improves slightly. Acceptance length rises 3.11 → 3.20 because split-K replaces one long sequential fp32 accumulation with 19 shorter ones and lands closer to an fp64 oracle (rel-L2 0.002195 vs 0.002292), so the target rejects its own draft marginally less often. A paired greedy check gave **6/6 prompts byte-identical** over 1152 sampled positions, and `q_len == 1` is bit-identical. Boots clean under full CUDA-graph capture.

The win concentrates at low batch, long context and few KV heads; at high batch the grid already fills and the change is inert.

## AI assistance

**AI assistance (Claude) was used for this change.** The C++ change, the test design, and every measurement above were produced with AI assistance and reviewed by the human submitter.

Note for maintainers: I have not added a `Signed-off-by` trailer, as DCO sign-off is the submitter's own attestation — happy to amend if required.