### PR TITLE
fix(cute): pass mDynamicCausal to kernel and init is_split_kv in SM80/SM120 FA4 forward

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -626,6 +626,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         assert self.output_quant_key is None, (
             f"Fused quant output not implemented for {type(self).__name__}"
         )
+        self.is_split_kv = False
 
     def _get_smem_layout_atom(self):
         sQ_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.tile_hdim)
@@ -793,6 +794,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             aux_data,
             fastdiv_mods,
             output_scale,
+            mDynamicCausal,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -833,6 +835,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
         output_scale: Optional[cute.Tensor] = None,
+        mDynamicCausal: Optional[cute.Tensor] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()


### PR DESCRIPTION
Fixes vllm-project/vllm#51776

## Why are these changes needed?

`FlashAttentionForwardSm80` (and by inheritance `FlashAttentionForwardSm120`) in `flash_attn/cute/flash_fwd.py` fails on the very first call, before any kernel runs, with two Python-level errors:

1. **`NameError: name 'mDynamicCausal' is not defined`** — `mDynamicCausal` is a parameter of the `__call__` method but is referenced from the body of the `@cute.kernel def kernel(...)` method, which is a separate method (not a closure), so the name is out of scope. The launch site passes kernel args positionally and ends at `output_scale`, so it is never supplied.

2. **`AttributeError: 'FlashAttentionForwardSm120' object has no attribute 'is_split_kv'`** — `self.is_split_kv` is read in four places but `FlashAttentionForwardSm80.__init__` never assigns it. Both sibling implementations (`flash_fwd_sm90.py`, `flash_fwd_sm100.py`) assign it in `__init__`; the kernel launch hardcodes `False`, so `False` is the intended value here.

This path is effectively dead on SM80-class GPUs (C++ FA2/FA3 kernels are used there) but is selected on **sm_120**, where anything routing through `vllm.vllm_flash_attn.cute.flash_attn_varlen_func` hits it.

## What changed?

- Pass `mDynamicCausal` in the kernel launch list and add it to the `kernel` signature (after `output_scale`, leaving existing argument order untouched).
- Initialize `self.is_split_kv = False` in `FlashAttentionForwardSm80.__init__`.

## Test plan

Reproduced on unmodified `vllm/vllm-openai:v0.26.0` (sm_120, RTX PRO 6000 Blackwell) with the ~25-line script from vllm-project/vllm#51776 (single GPU, no model, batch 1, `flash_attn_varlen_func` direct call):

- Before: Bug 1 (`NameError: mDynamicCausal`), then after applying Bug 1 fix: Bug 2 (`AttributeError: is_split_kv`).
- After both fixes: `OK` — kernel compiles and runs, returning finite output across batch 1–8, seqlen_k 128–8192, causal / sliding-window / decode-shaped q, with and without `score_mod`/`aux_tensors`.