### PR TITLE
[SM100] Optimize hdim 256 and add `seqused_q/k` support

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -251,6 +251,29 @@ def _validate_tensor(t, name, expected_shape, expected_dtype, expected_device):
     if not is_fake_mode():
         assert t.is_cuda, f"{name} must be on CUDA"
 
+def _is_aligned_16b_output(t):
+    if isinstance(t, _CompileOnlyTensorSpec):
+        strides = t.stride()
+        elements_per_16b = 16 // t.element_size()
+        return (
+            isinstance(t._assumed_align, int)
+            and t._assumed_align % 16 == 0
+            and isinstance(strides[-1], int)
+            and strides[-1] == 1
+            and all(
+                isinstance(stride, int) and stride % elements_per_16b == 0
+                for stride in strides[:-1]
+            )
+        )
+    if is_fake_mode():
+        return False
+    elements_per_16b = 16 // t.element_size()
+    return (
+        t.data_ptr() % 16 == 0
+        and t.stride(-1) == 1
+        and all(stride % elements_per_16b == 0 for stride in t.stride()[:-1])
+    )
+
 torch2cute_dtype_map = {
     torch.float16: cutlass.Float16,
     torch.bfloat16: cutlass.BFloat16,
@@ -276,6 +299,7 @@ class _CompileOnlyTensorSpec:
         self.device = torch.device("cuda")
         self.requires_grad = False
         self.is_cuda = True
+        self._assumed_align = assumed_align
         self._stride = (
             tuple(
                 cute.sym_int64(divisibility=1) if item is None else item
@@ -757,6 +781,26 @@ def _flash_attn_fwd(
     # hd=256 2CTA forward uses dedicated kernel (Blackwell family)
     use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+    if use_dedicated_hd256_kernel:
+        o_aligned_16b = _is_aligned_16b_output(out)
+        hd256_varlen_b1 = cu_seqlens_q is not None and batch_size == 1
+        hd256_l2_swizzle = (
+            causal
+            and not local
+            and seqused_q is None
+            and page_table is None
+            and batch_size == 1
+            and qhead_per_kvhead == 1
+            and max_seqlen_q <= 8192
+            and max_seqlen_k <= 8192
+        )
+        hd256_mask_residual = not (
+            cu_seqlens_q is None
+            and seqused_q is None
+            and page_table is None
+            and max_seqlen_q == max_seqlen_k
+            and max_seqlen_q % 256 == 0
+        )
 
     if softcap is not None:
         assert score_mod is None, "softcap and score_mod cannot be used together"
@@ -929,6 +973,13 @@ def _flash_attn_fwd(
         q.dtype,
         out_torch_dtype,
     )
+    if use_dedicated_hd256_kernel:
+        compile_key += (
+            o_aligned_16b,
+            hd256_varlen_b1,
+            hd256_l2_swizzle,
+            hd256_mask_residual,
+        )
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
             cu_seqlens_q_tensor,
@@ -953,9 +1004,17 @@ def _flash_attn_fwd(
             if page_table is not None
             else None
         )
-        q_tensor, k_tensor, v_tensor, o_tensor = [
-            to_cute_tensor(t) for t in (q, k, v, out if not is_split_kv else out_partial)
-        ]
+        if use_dedicated_hd256_kernel:
+            q_tensor, k_tensor, v_tensor = [
+                to_cute_tensor(t) for t in (q, k, v)
+            ]
+            o_source = out if not is_split_kv else out_partial
+            o_assumed_align = 16 if o_aligned_16b else o_source.element_size()
+            o_tensor = to_cute_tensor(o_source, assumed_align=o_assumed_align)
+        else:
+            q_tensor, k_tensor, v_tensor, o_tensor = [
+                to_cute_tensor(t) for t in (q, k, v, out if not is_split_kv else out_partial)
+            ]
         if is_split_kv:
             lse_tensor = to_cute_tensor(lse_partial, assumed_align=4)
         else:
@@ -1105,20 +1164,15 @@ def _flash_attn_fwd(
                         pack_gqa=pack_gqa,
                         m_block_size=tile_m,
                         n_block_size=tile_n,
-                        q_stage=q_stage,
-                        is_persistent=not causal
-                            and not local
-                            and cu_seqlens_q is None
-                            and seqused_q is None
-                            and not is_split_kv,
                         score_mod=score_mod,
                         mask_mod=mask_mod,
                         has_aux_tensors=aux_tensors is not None,
                         paged_kv_non_tma=page_size not in [None, tile_n],
-                        is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
+                        is_varlen_b1=hd256_varlen_b1,
                         q_subtile_factor=q_subtile_factor,
-                        use_2cta_instrs=use_2cta_instrs,
-                        use_clc_scheduler=use_clc_scheduler,
+                        o_aligned_16b=o_aligned_16b,
+                        l2_swizzle=hd256_l2_swizzle,
+                        mask_residual=hd256_mask_residual,
                     )
                 else:
                     fa_fwd = FlashAttentionForwardSm100(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -251,7 +251,6 @@ def _validate_tensor(t, name, expected_shape, expected_dtype, expected_device):
     if not is_fake_mode():
         assert t.is_cuda, f"{name} must be on CUDA"
 
-
 torch2cute_dtype_map = {
     torch.float16: cutlass.Float16,
     torch.bfloat16: cutlass.BFloat16,
@@ -777,8 +776,8 @@ def _flash_attn_fwd(
             and seqused_q is None
             and seqused_k is None
             and page_table is None
-            and max_seqlen_q == max_seqlen_k
-            and max_seqlen_q % 256 == 0
+            and seqlen_q == seqlen_k
+            and seqlen_q % 256 == 0
         )
         hd256_use_2cta = not (
             seqused_q is not None

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -797,6 +797,7 @@ def _flash_attn_fwd(
         hd256_mask_residual = not (
             cu_seqlens_q is None
             and seqused_q is None
+            and seqused_k is None
             and page_table is None
             and max_seqlen_q == max_seqlen_k
             and max_seqlen_q % 256 == 0
@@ -1136,8 +1137,6 @@ def _flash_attn_fwd(
                         "SM100 forward with head_dim=256 does not support block sparsity"
                     assert learnable_sink is None, \
                         "SM100 forward with head_dim=256 does not support learnable_sink"
-                    assert seqused_q is None and seqused_k is None, \
-                        "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
                     if page_table is not None:
                         assert max_seqlen_k % page_size == 0, (
                             f"SM100 hd256 2CTA paged KV requires max_seqlen_k divisible by "

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -50,7 +50,7 @@ from flash_attn.cute.flash_bwd_mla_sm100 import FlashAttentionSparseMLABackwardS
 from flash_attn.cute.flash_bwd_mla_dq_dqv_sm100 import dQdQvGemmKernel
 from flash_attn.cute.flash_bwd_mla_dk_sm100 import dKGemmKernel
 
-# SM100 head_dim=256 2CTA kernel imports
+# SM100 dedicated head_dim=256 kernel imports
 from flash_attn.cute.sm100_hd256_2cta_fmha_forward import BlackwellFusedMultiHeadAttentionForward
 from flash_attn.cute.sm100_hd256_2cta_fmha_backward import BlackwellFusedMultiHeadAttentionBackward
 
@@ -778,7 +778,7 @@ def _flash_attn_fwd(
         and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
     )
 
-    # hd=256 2CTA forward uses dedicated kernel (Blackwell family)
+    # hd=256 forward uses the dedicated Blackwell-family kernel.
     use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
     if use_dedicated_hd256_kernel:
@@ -801,6 +801,16 @@ def _flash_attn_fwd(
             and page_table is None
             and max_seqlen_q == max_seqlen_k
             and max_seqlen_q % 256 == 0
+        )
+        hd256_use_2cta = not (
+            seqused_q is not None
+            and cu_seqlens_q is None
+            and page_table is None
+            and not local
+            and (
+                (not causal and max_seqlen_q <= 1024)
+                or (causal and max_seqlen_q <= 2048 and max_seqlen_k <= 2048)
+            )
         )
 
     if softcap is not None:
@@ -980,6 +990,7 @@ def _flash_attn_fwd(
             hd256_varlen_b1,
             hd256_l2_swizzle,
             hd256_mask_residual,
+            hd256_use_2cta,
         )
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
@@ -1131,7 +1142,7 @@ def _flash_attn_fwd(
                 )
             else:
                 if use_dedicated_hd256_kernel:
-                    # hd=256 2CTA forward: check for currently unsupported features
+                    # Dedicated hd=256 forward: check for currently unsupported features
                     assert softcap is None, "SM100 forward with head_dim=256 does not support softcap"
                     assert not use_block_sparsity, \
                         "SM100 forward with head_dim=256 does not support block sparsity"
@@ -1172,6 +1183,7 @@ def _flash_attn_fwd(
                         o_aligned_16b=o_aligned_16b,
                         l2_swizzle=hd256_l2_swizzle,
                         mask_residual=hd256_mask_residual,
+                        use_2cta=hd256_use_2cta,
                     )
                 else:
                     fa_fwd = FlashAttentionForwardSm100(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -251,28 +251,6 @@ def _validate_tensor(t, name, expected_shape, expected_dtype, expected_device):
     if not is_fake_mode():
         assert t.is_cuda, f"{name} must be on CUDA"
 
-def _is_aligned_16b_output(t):
-    if isinstance(t, _CompileOnlyTensorSpec):
-        strides = t.stride()
-        elements_per_16b = 16 // t.element_size()
-        return (
-            isinstance(t._assumed_align, int)
-            and t._assumed_align % 16 == 0
-            and isinstance(strides[-1], int)
-            and strides[-1] == 1
-            and all(
-                isinstance(stride, int) and stride % elements_per_16b == 0
-                for stride in strides[:-1]
-            )
-        )
-    if is_fake_mode():
-        return False
-    elements_per_16b = 16 // t.element_size()
-    return (
-        t.data_ptr() % 16 == 0
-        and t.stride(-1) == 1
-        and all(stride % elements_per_16b == 0 for stride in t.stride()[:-1])
-    )
 
 torch2cute_dtype_map = {
     torch.float16: cutlass.Float16,
@@ -782,7 +760,6 @@ def _flash_attn_fwd(
     use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
     if use_dedicated_hd256_kernel:
-        o_aligned_16b = _is_aligned_16b_output(out)
         hd256_varlen_b1 = cu_seqlens_q is not None and batch_size == 1
         hd256_l2_swizzle = (
             causal
@@ -796,6 +773,7 @@ def _flash_attn_fwd(
         )
         hd256_mask_residual = not (
             cu_seqlens_q is None
+            and cu_seqlens_k is None
             and seqused_q is None
             and seqused_k is None
             and page_table is None
@@ -986,7 +964,6 @@ def _flash_attn_fwd(
     )
     if use_dedicated_hd256_kernel:
         compile_key += (
-            o_aligned_16b,
             hd256_varlen_b1,
             hd256_l2_swizzle,
             hd256_mask_residual,
@@ -1016,17 +993,9 @@ def _flash_attn_fwd(
             if page_table is not None
             else None
         )
-        if use_dedicated_hd256_kernel:
-            q_tensor, k_tensor, v_tensor = [
-                to_cute_tensor(t) for t in (q, k, v)
-            ]
-            o_source = out if not is_split_kv else out_partial
-            o_assumed_align = 16 if o_aligned_16b else o_source.element_size()
-            o_tensor = to_cute_tensor(o_source, assumed_align=o_assumed_align)
-        else:
-            q_tensor, k_tensor, v_tensor, o_tensor = [
-                to_cute_tensor(t) for t in (q, k, v, out if not is_split_kv else out_partial)
-            ]
+        q_tensor, k_tensor, v_tensor, o_tensor = [
+            to_cute_tensor(t) for t in (q, k, v, out if not is_split_kv else out_partial)
+        ]
         if is_split_kv:
             lse_tensor = to_cute_tensor(lse_partial, assumed_align=4)
         else:
@@ -1180,7 +1149,6 @@ def _flash_attn_fwd(
                         paged_kv_non_tma=page_size not in [None, tile_n],
                         is_varlen_b1=hd256_varlen_b1,
                         q_subtile_factor=q_subtile_factor,
-                        o_aligned_16b=o_aligned_16b,
                         l2_swizzle=hd256_l2_swizzle,
                         mask_residual=hd256_mask_residual,
                         use_2cta=hd256_use_2cta,

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -1721,6 +1721,7 @@ class Sm100FusedMask:
         is_local: cutlass.Constexpr[bool] = False,
         window_size_left: Optional[int] = None,
         window_size_right: Optional[int] = None,
+        apply_residual: cutlass.Constexpr[bool] = True,
         index_transform: cutlass.Constexpr = lambda index_q, index_k: (
             index_q,
             index_k,
@@ -1759,6 +1760,7 @@ class Sm100FusedMask:
                         min_K_index = max(0, index_q + offset - window_size_left)
                         if index_k > max_K_index or index_k < min_K_index:
                             acc_qk[i] = -Float32.inf
-            # Residual mask is always needed for boundary protection.
-            if index_k >= seqlen_k or index_q >= seqlen_q:
-                acc_qk[i] = -Float32.inf
+            if cutlass.const_expr(apply_residual):
+                # Residual mask is needed only when a boundary tile can be partial.
+                if index_k >= seqlen_k or index_q >= seqlen_q:
+                    acc_qk[i] = -Float32.inf

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -769,7 +769,6 @@ class BlackwellFusedMultiHeadAttentionForward:
             is_two_cta=True,
             two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
         )
-        tmem.allocate(self.tmem_alloc_cols)
 
         # Cluster arrive after barrier init
         pipeline.pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
@@ -828,6 +827,7 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         # Cluster wait
         pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+        tmem.allocate(self.tmem_alloc_cols)
         tmem.wait_for_alloc()
 
         # ///////////////////////////////////////////////////////////////////////////////

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -49,7 +49,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         has_aux_tensors: bool = False,
         paged_kv_non_tma: bool = False,
         is_varlen_b1: bool = False,
-        o_aligned_16b: bool = False,
         l2_swizzle: bool = False,
         mask_residual: bool = True,
         use_2cta: bool = True,
@@ -111,7 +110,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.use_semantic_trip_range = is_causal or is_local
         self.use_clc_scheduler = False
 
-        self.o_aligned_16b = o_aligned_16b
         self.is_varlen_b1 = is_varlen_b1
         self.l2_swizzle = l2_swizzle
         self.mask_residual = mask_residual
@@ -209,7 +207,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             "SM100 forward with head_dim=256 does not support descale_tensors"
         )
 
-        q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, assume_tensor_aligned(mO) if cutlass.const_expr(self.o_aligned_16b) else mO
+        q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, assume_tensor_aligned(mO)
         lse_tensor = mLSE
         cum_seqlen_q = mCuSeqlensQ
         cum_seqlen_k = mCuSeqlensK
@@ -394,7 +392,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 (s_q, o.shape[1], o.shape[2]),
                 self.cta_tiler,
                 False,
-                lpt=self.is_causal and not self.is_local,
+                lpt=self.use_2cta and self.is_causal and not self.is_local,
                 l2_swizzle=self.l2_swizzle,
             )
         elif cutlass.const_expr(cum_seqlen_q is not None):
@@ -424,7 +422,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 o.shape,
                 self.cta_tiler,
                 False,
-                lpt=self.is_causal and not self.is_local,
+                lpt=self.use_2cta and self.is_causal and not self.is_local,
                 l2_swizzle=self.l2_swizzle,
             )
 
@@ -505,7 +503,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
             self.o_dtype, self.o_layout, self.epi_tile, 1
         )
-        universal_copy_bits = 128 if cutlass.const_expr(self.o_aligned_16b) else self.o_dtype.width
+        universal_copy_bits = 128
         async_copy_elems = universal_copy_bits // self.o_dtype.width
         atom_universal_copy = cute.make_copy_atom(
             cute.nvgpu.CopyUniversalOp(),

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -13,23 +13,21 @@ import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32, Int64, Float32
 
-from cutlass.utils import ClcDynamicPersistentTileScheduler
 from flash_attn.cute.tile_scheduler import (
-    ClcState,
+    TileSchedulerArguments,
+    SingleTileVarlenScheduler,
     compute_sm100_fmha_grid as compute_grid,
-    compute_sm100_fmha_grid_clc as compute_grid_clc,
     make_sm100_thread_cooperative_group as make_thread_cooperative_group,
     Sm100FmhaStaticTileScheduler as FmhaStaticTileScheduler,
     Sm100FmhaStaticTileSchedulerParams as FmhaStaticTileSchedulerParams,
-    Sm100FmhaClcDynamicTileScheduler as FmhaClcDynamicTileScheduler,
-    Sm100FmhaClcDynamicTileSchedulerParams as FmhaClcDynamicTileSchedulerParams,
 )
 from flash_attn.cute.mask import (
     Sm100FusedMask as FusedMask,
 )
 from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
+from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _TUNING_CONFIG
-from flash_attn.cute.utils import ex2_emulation_2, as_bshkrd_tensor, AuxData
+from flash_attn.cute.utils import ex2_emulation_2, as_bshkrd_tensor, AuxData, domain_offset_aligned
 
 
 class BlackwellFusedMultiHeadAttentionForward:
@@ -45,15 +43,14 @@ class BlackwellFusedMultiHeadAttentionForward:
         q_subtile_factor: int = 1,
         m_block_size: int = 128,
         n_block_size: int = 128,
-        q_stage: int = 2,
-        is_persistent: bool = True,
         score_mod=None,
         mask_mod=None,
         has_aux_tensors: bool = False,
         paged_kv_non_tma: bool = False,
-        is_varlen_q: bool = False,
-        use_2cta_instrs: bool = False,
-        use_clc_scheduler: bool = False,
+        is_varlen_b1: bool = False,
+        o_aligned_16b: bool = False,
+        l2_swizzle: bool = False,
+        mask_residual: bool = True,
     ):
         head_dim_v = head_dim if head_dim_v is None else head_dim_v
         assert head_dim == 256 and head_dim_v == 256, (
@@ -73,8 +70,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         assert m_block_size == 128 and n_block_size == 128, (
             "SM100 dedicated kernel only supports tile_m=128 and tile_n=128"
         )
-        # q_stage / persistence / scheduler knobs are accepted for interface parity,
-        # but this dedicated kernel uses fixed internal settings.
 
         qk_acc_dtype = cutlass.Float32
         pv_acc_dtype = cutlass.Float32
@@ -112,12 +107,16 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.use_semantic_trip_range = is_causal or is_local
         self.use_clc_scheduler = False
 
+        self.o_aligned_16b = o_aligned_16b
+        self.is_varlen_b1 = is_varlen_b1
+        self.l2_swizzle = l2_swizzle
+        self.mask_residual = mask_residual
+
         self.softmax_warp_ids = (0, 1, 2, 3)
         self.correction_warp_ids = (4, 5, 6, 7)
         self.mma_warp_id = 8
         self.load_warp_id = 9
         self.empty_warp_id = (10, 11)
-        self.sched_warp_id = self.empty_warp_id[0] if use_clc_scheduler else None
         self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
         self.threads_per_warp = 32
@@ -133,7 +132,10 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         self.tmem_alloc_barrier = pipeline.NamedBarrier(
             barrier_id=1,
-            num_threads=self.threads_per_cta,
+            num_threads=(
+                len(self.softmax_warp_ids) + len(self.correction_warp_ids) + 1
+            )
+            * self.threads_per_warp,
         )
 
         self.tmem_s_offset = 0
@@ -144,7 +146,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         _tune = _TUNING_CONFIG.get(_tune_key, {})
         self.num_regs_softmax = _tune.get("num_regs_softmax", 256)
         self.num_regs_correction = _tune.get("num_regs_correction", 160)
-        self.num_regs_other = 32  # fixed for hd256; not derived from 512 budget like other kernels
+        self.num_regs_other = 56 if is_causal else 32
         self.ex2_emu_freq = _tune.get("ex2_emu_freq", 4)
         self.ex2_emu_res = _tune.get("ex2_emu_res", 3)
         self.ex2_emu_start_frg = _tune.get("ex2_emu_start_frg", 0)
@@ -153,12 +155,10 @@ class BlackwellFusedMultiHeadAttentionForward:
 
     def _setup_attributes(self):
         self.q_stage = self.iterations_qk
-        self.kv_stage = 4
+        self.k_stage = 4
+        self.v_stage = 4
         self.qk_acc_stage = 2
         self.mma_corr_stage = 1
-        if cutlass.const_expr(self.use_clc_scheduler):
-            self.num_clc_stage = 1
-            self.num_clc_response_bytes = 16
 
     @cute.jit
     def __call__(
@@ -210,7 +210,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             "SM100 forward with head_dim=256 does not support descale_tensors"
         )
 
-        q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, mO
+        q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, assume_tensor_aligned(mO) if cutlass.const_expr(self.o_aligned_16b) else mO
         lse_tensor = mLSE
         cum_seqlen_q = mCuSeqlensQ
         cum_seqlen_k = mCuSeqlensK
@@ -389,17 +389,43 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.o_dtype = o.element_type
         self.tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.q_dtype.width
 
-        if cutlass.const_expr(self.use_clc_scheduler):
-            self.tile_sched_params, grid = compute_grid_clc(
-                (s_q, o.shape[1], o.shape[2]) if cum_seqlen_q is not None else o.shape,
-                self.cta_tiler,
-                (*self.cluster_shape_mn, 1),
-            )
-        else:
+        if cutlass.const_expr(cum_seqlen_q is not None and self.is_varlen_b1):
+            TileScheduler = FmhaStaticTileScheduler
             self.tile_sched_params, grid = compute_grid(
-                (s_q, o.shape[1], o.shape[2]) if cum_seqlen_q is not None else o.shape,
+                (s_q, o.shape[1], o.shape[2]),
                 self.cta_tiler,
-                self.is_persistent,
+                False,
+                lpt=self.is_causal and not self.is_local,
+                l2_swizzle=self.l2_swizzle,
+            )
+        elif cutlass.const_expr(cum_seqlen_q is not None):
+            TileScheduler = SingleTileVarlenScheduler
+            tile_sched_args = TileSchedulerArguments(
+                num_block=cute.ceil_div(s_q, self.qk_mma_tiler[0]),
+                num_head=cute.size(o.shape[2][0]),
+                num_batch=b,
+                num_splits=1,
+                seqlen_k=0,
+                headdim=o.shape[1],
+                headdim_v=o.shape[1],
+                total_q=s_q,
+                tile_shape_mn=self.cta_tiler[:2],
+                cluster_shape_mn=self.cluster_shape_mn,
+                mCuSeqlensQ=cum_seqlen_q,
+                nested_mbh_coord=True,
+                is_persistent=False,
+                lpt=False,
+            )
+            self.tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+            grid = TileScheduler.get_grid_shape(self.tile_sched_params)
+        else:
+            TileScheduler = FmhaStaticTileScheduler
+            self.tile_sched_params, grid = compute_grid(
+                o.shape,
+                self.cta_tiler,
+                False,
+                lpt=self.is_causal and not self.is_local,
+                l2_swizzle=self.l2_swizzle,
             )
 
         self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
@@ -461,7 +487,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             qk_tiled_mma,
             self.qk_mma_tiler,
             self.k_dtype,
-            self.kv_stage,
+            self.k_stage,
         )
         p_tmem_layout_staged = sm100_utils.make_smem_layout_a(
             pv_tiled_mma,
@@ -474,7 +500,29 @@ class BlackwellFusedMultiHeadAttentionForward:
             pv_tiled_mma,
             self.pv_mma_tiler,
             self.v_dtype,
-            self.kv_stage,
+            self.v_stage,
+        )
+        o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.o_dtype, self.o_layout, self.epi_tile, 1
+        )
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.o_dtype.width
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.o_dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        tO_shape_dim_1 = o_smem_layout_staged.outer.shape[1][0] // async_copy_elems
+        tO_layout = cute.make_ordered_layout(
+            (
+                self.threads_per_warp * len(self.correction_warp_ids) // tO_shape_dim_1,
+                tO_shape_dim_1,
+            ),
+            order=(1, 0),
+        )
+        vO_layout = cute.make_layout((1, async_copy_elems))
+        gmem_tiled_copy_o = cute.make_tiled_copy_tv(
+            atom_universal_copy, tO_layout, vO_layout
         )
         # TMA load for Q
         tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
@@ -512,8 +560,10 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
         k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
         self.tma_copy_q_bytes = q_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
-        self.tma_copy_kv_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.tma_copy_k_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.tma_copy_v_bytes = v_copy_size * cute.size(pv_tiled_mma.thr_id.shape)
 
         @cute.struct
         class SharedStorage:
@@ -521,9 +571,12 @@ class BlackwellFusedMultiHeadAttentionForward:
             load_q_mbar_ptr: cute.struct.MemRange[
                 Int64, self.q_stage * 2
             ]  # load_q_{producer,consumer}
-            load_kv_mbar_ptr: cute.struct.MemRange[
-                Int64, self.kv_stage * 2
-            ]  # load_kv_{producer,consumer}
+            load_k_mbar_ptr: cute.struct.MemRange[
+                Int64, self.k_stage * 2
+            ]  # load_k_{producer,consumer}
+            load_v_mbar_ptr: cute.struct.MemRange[
+                Int64, self.v_stage * 2
+            ]  # load_v_{producer,consumer}
             mma_s_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
             p_mma_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
             # Softmax -> Correction signaling barriers (row_max/row_sum vec ready)
@@ -539,9 +592,6 @@ class BlackwellFusedMultiHeadAttentionForward:
             tmem_dealloc_mbar: Int64
             # Tmem holding buffer
             tmem_holding_buf: Int32
-            # CLC pipeline barriers and response buffer
-            clc_mbar_ptr: cute.struct.MemRange[Int64, 2]
-            clc_response: cute.struct.MemRange[Int32, 4]
 
         self.shared_storage = SharedStorage
 
@@ -556,6 +606,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             tma_tensor_k,
             tma_atom_v,
             tma_tensor_v,
+            o_smem_layout_staged,
+            gmem_tiled_copy_o,
             o,
             cum_seqlen_q,
             cum_seqlen_k,
@@ -573,6 +625,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             p_tmem_layout,
             v_smem_layout_staged,
             self.tile_sched_params,
+            TileScheduler,
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -593,6 +646,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         mK_kdl: cute.Tensor,
         tma_atom_v: cute.CopyAtom,
         mV_dkl: cute.Tensor,
+        o_smem_layout_staged: cute.ComposedLayout,
+        gmem_tiled_copy_o: cute.TiledCopy,
         mO_qdl: cute.Tensor,
         cum_seqlen_q: Optional[cute.Tensor],
         cum_seqlen_k: Optional[cute.Tensor],
@@ -609,7 +664,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         k_smem_layout_staged: cute.ComposedLayout,
         p_tmem_layout_staged: cute.ComposedLayout,
         v_smem_layout_staged: cute.ComposedLayout,
-        tile_sched_params: FmhaStaticTileSchedulerParams | FmhaClcDynamicTileSchedulerParams,
+        tile_sched_params: FmhaStaticTileSchedulerParams | SingleTileVarlenScheduler.Params,
+        TileScheduler: cutlass.Constexpr,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -639,12 +695,21 @@ class BlackwellFusedMultiHeadAttentionForward:
             cta_layout_vmnk=cluster_layout_vmnk,
             defer_sync=True,
         ).make_participants()
-        load_kv_producer, load_kv_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.kv_stage,
+        load_k_producer, load_k_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.k_stage,
             producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
             consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_kv_bytes,
-            barrier_storage=storage.load_kv_mbar_ptr.data_ptr(),
+            tx_count=self.tma_copy_k_bytes,
+            barrier_storage=storage.load_k_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_v_producer, load_v_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.v_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_v_bytes,
+            barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
             cta_layout_vmnk=cluster_layout_vmnk,
             defer_sync=True,
         ).make_participants()
@@ -709,52 +774,6 @@ class BlackwellFusedMultiHeadAttentionForward:
             two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
         )
         tmem.allocate(self.tmem_alloc_cols)
-        tmem.wait_for_alloc()
-        tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
-        # Initialize CLC state if using dynamic scheduler
-        if cutlass.const_expr(self.use_clc_scheduler):
-            clc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-            cluster_size = cute.size(self.cluster_shape_mnk)
-            num_clc_consumer_threads = self.threads_per_warp * (
-                1  # sched_warp (CTA 0 only)
-                + cluster_size
-                * (
-                    len(self.softmax_warp_ids)
-                    + len(self.correction_warp_ids)
-                    + 1  # mma_warp
-                    + 1  # load_warp
-                )
-            )
-            clc_pipeline_consumer_group = pipeline.CooperativeGroup(
-                pipeline.Agent.Thread, num_clc_consumer_threads
-            )
-            clc_response_ptr = storage.clc_response.data_ptr()
-            clc = ClcState.create(
-                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
-                    self.tile_sched_params.clc_hw_params(),
-                    cute.arch.block_idx(),
-                    cute.arch.grid_dim(),
-                    clc_response_ptr,
-                ),
-                pipeline=pipeline.PipelineClcFetchAsync.create(
-                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
-                    num_stages=self.num_clc_stage,
-                    producer_group=clc_pipeline_producer_group,
-                    consumer_group=clc_pipeline_consumer_group,
-                    tx_count=self.num_clc_response_bytes,
-                    cta_layout_vmnk=cluster_layout_vmnk,
-                    defer_sync=True,
-                ),
-                consumer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Consumer, self.num_clc_stage
-                ),
-                producer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Producer, self.num_clc_stage
-                ),
-            )
-        else:
-            clc = None
-            clc_response_ptr = None
 
         # Cluster arrive after barrier init
         pipeline.pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
@@ -764,6 +783,10 @@ class BlackwellFusedMultiHeadAttentionForward:
             layout=q_smem_layout_staged.outer,
             swizzle=q_smem_layout_staged.inner,
             byte_alignment=128,
+        )
+        sO = cute.make_tensor(
+            cute.recast_ptr(sQ.iterator, o_smem_layout_staged.inner, self.o_dtype),
+            o_smem_layout_staged.outer,
         )
         sK = smem.allocate_tensor(
             element_type=self.k_dtype,
@@ -789,19 +812,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         tSrQ = qk_thr_mma.make_fragment_A(sQ)
         tSrK = qk_thr_mma.make_fragment_B(sK)
         tOrV = pv_thr_mma.make_fragment_B(sV)
-        qk_acc_shape = qk_thr_mma.partition_shape_C((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
-        tStS = qk_thr_mma.make_fragment_C(cute.append(qk_acc_shape, self.qk_acc_stage))
-        pv_acc_shape = pv_thr_mma.partition_shape_C((self.pv_mma_tiler[0], self.pv_mma_tiler[1]))
-        tOtO = pv_thr_mma.make_fragment_C(pv_acc_shape)
-        tOtO_layout = cute.append(
-            tOtO.layout,
-            cute.make_layout(
-                self.iterations_pv,
-                stride=self.pv_mma_tiler[1] // self.tmem_warp_shape_mn[1],
-            ),
-        )
-        tStS = cute.make_tensor(tStS.iterator + self.tmem_s_offset, tStS.layout)
-        tOtO_staged = cute.make_tensor(tOtO.iterator + self.tmem_o_offset, tOtO_layout)
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  EMPTY
@@ -810,14 +820,9 @@ class BlackwellFusedMultiHeadAttentionForward:
             if warp_idx == self.empty_warp_id[_i]:
                 cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
 
-        if cutlass.const_expr(self.use_clc_scheduler):
-            tile_sched = FmhaClcDynamicTileScheduler.create(
-                tile_sched_params,
-                cute.arch.block_idx(),
-                cute.arch.grid_dim(),
-                clc_response_ptr,
-                clc,
-            )
+        if cutlass.const_expr(TileScheduler is SingleTileVarlenScheduler):
+            tile_sched = TileScheduler.create(
+                tile_sched_params)
         else:
             blk_idx = cute.arch.block_idx()
             tile_sched = FmhaStaticTileScheduler(
@@ -854,7 +859,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                     Int32(0),
                     ((Int32(0), Int32(0)), Int32(0)),
                 )
-                if cutlass.const_expr(cum_seqlen_q is not None):
+                if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
                     cuseqlen_q = cum_seqlen_q[batch_coord]
                     seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
                     if cutlass.const_expr(cum_seqlen_k is not None):
@@ -986,7 +991,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         else None
                     )
                     for iter in cutlass.range(self.iterations_qk, unroll=1):
-                        k_handle = load_kv_producer.acquire_and_advance()
+                        k_handle = load_k_producer.acquire_and_advance()
                         cute.copy(
                             tma_atom_k,
                             tKgK[None, kv_coord, iter]
@@ -1011,7 +1016,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         # Ki: k_page_idx was prefetched at end of previous iteration
                         # (or in the prologue for i==1); L2 latency already hidden.
                         for iter in cutlass.range(self.iterations_qk, unroll=1):
-                            k_handle = load_kv_producer.acquire_and_advance()
+                            k_handle = load_k_producer.acquire_and_advance()
                             cute.copy(
                                 tma_atom_k,
                                 tKgK[None, kv_coord, iter]
@@ -1022,7 +1027,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                             )
                         # Vi-1: reuse v_page_idx_prev (= K[i-1]'s page), no extra GMEM read.
                         for iter in cutlass.range(self.iterations_pv, unroll=1):
-                            v_handle = load_kv_producer.acquire_and_advance()
+                            v_handle = load_v_producer.acquire_and_advance()
                             cute.copy(
                                 tma_atom_v,
                                 tVgV[None, iter, kv_coord - 1]
@@ -1041,7 +1046,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 k_page_idx = mPageTable[batch_coord, kv_coord]
                     # Vend: reuse v_page_idx_prev (= K[end-1]'s page), no extra GMEM read.
                     for iter in cutlass.range(self.iterations_pv, unroll=1):
-                        v_handle = load_kv_producer.acquire_and_advance()
+                        v_handle = load_v_producer.acquire_and_advance()
                         cute.copy(
                             tma_atom_v,
                             tVgV[None, iter, seqlen_kv_loop_end - 1]
@@ -1053,13 +1058,17 @@ class BlackwellFusedMultiHeadAttentionForward:
 
                 work_tile = tile_sched.advance_to_next_work()
                 # End of persistent scheduler loop
-            load_kv_producer.tail()
+            load_k_producer.tail()
+            load_v_producer.tail()
             load_q_producer.tail()
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  MMA
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.mma_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
 
             cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
@@ -1078,7 +1087,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                     mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
                 )
                 batch_coord = curr_block_coord[2][1]
-                if cutlass.const_expr(cum_seqlen_q is not None):
+                if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
                     cuseqlen_q = cum_seqlen_q[batch_coord]
                     seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
                     continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
@@ -1117,7 +1126,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                             for iter in cutlass.range(self.iterations_qk, unroll=1):
                                 load_q_consumer.wait_and_advance()
                                 tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_kv_consumer.wait_and_advance()
+                                k_handle = load_k_consumer.wait_and_advance()
                                 tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
                                 num_kphases = cute.size(tSrQ_slice, mode=[2])
                                 for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
@@ -1140,7 +1149,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                                 for iter in cutlass.range(self.iterations_qk, unroll=1):
                                     tSrQ_slice = tSrQ[None, None, None, iter]
-                                    k_handle = load_kv_consumer.wait_and_advance()
+                                    k_handle = load_k_consumer.wait_and_advance()
                                     tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
                                     num_kphases = cute.size(tSrQ_slice, mode=[2])
                                     for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
@@ -1161,7 +1170,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 o_handle = mma_corr_producer.acquire_and_advance()
                                 pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
                                 for iter in cutlass.range(self.iterations_pv, unroll=1):
-                                    v_handle = load_kv_consumer.wait_and_advance()
+                                    v_handle = load_v_consumer.wait_and_advance()
                                     pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
                                     tOtO_slice = tOtO_staged[None, None, None, iter]
                                     tStS_slice = tStS[None, None, None, p_handle.index]
@@ -1186,8 +1195,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                                         )
                                         pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
                                     v_handle.release()
-                                o_handle.commit()
                                 p_handle.release()
+                                o_handle.commit()
                         if is_leader_cta:
                             # QKend
                             s_handle = mma_s_producer.acquire_and_advance()
@@ -1195,7 +1204,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                             qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                             for iter in cutlass.range(self.iterations_qk, unroll=1):
                                 tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_kv_consumer.wait_and_advance()
+                                k_handle = load_k_consumer.wait_and_advance()
                                 tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
                                 num_kphases = cute.size(tSrQ_slice, mode=[2])
                                 for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
@@ -1218,7 +1227,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                             o_handle = mma_corr_producer.acquire_and_advance()
                             pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
                             for iter in cutlass.range(self.iterations_pv, unroll=1):
-                                v_handle = load_kv_consumer.wait_and_advance()
+                                v_handle = load_v_consumer.wait_and_advance()
                                 pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
                                 tOtO_slice = tOtO_staged[None, None, None, iter]
                                 tStS_slice = tStS[None, None, None, p_handle.index]
@@ -1243,8 +1252,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                                     )
                                     pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
                                 v_handle.release()
-                            o_handle.commit()
                             p_handle.release()
+                            o_handle.commit()
                     else:
                         if is_leader_cta:
                             # QK0
@@ -1254,7 +1263,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                             for iter in cutlass.range(self.iterations_qk, unroll=1):
                                 load_q_consumer.wait_and_advance()
                                 tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_kv_consumer.wait_and_advance()
+                                k_handle = load_k_consumer.wait_and_advance()
                                 tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
                                 num_kphases = cute.size(tSrQ_slice, mode=[2])
                                 for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
@@ -1278,7 +1287,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         o_handle = mma_corr_producer.acquire_and_advance()
                         pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
                         for iter in cutlass.range(self.iterations_pv, unroll=1):
-                            v_handle = load_kv_consumer.wait_and_advance()
+                            v_handle = load_v_consumer.wait_and_advance()
                             pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
                             tOtO_slice = tOtO_staged[None, None, None, iter]
                             tStS_slice = tStS[None, None, None, p_handle.index]
@@ -1301,49 +1310,53 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 )
                                 pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
                             v_handle.release()
-                        o_handle.commit()
                         p_handle.release()
+                        o_handle.commit()
                 work_tile = tile_sched.advance_to_next_work()
             # End of persistent scheduler loop
             mma_s_producer.tail()
             mma_corr_producer.tail()
 
         if warp_idx < self.correction_warp_ids[0] and warp_idx >= self.softmax_warp_ids[0]:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, _ = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             # increase register after decreasing
             cute.arch.warpgroup_reg_alloc(self.num_regs_softmax)
 
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
+            if warp_idx <= self.softmax_warp_ids[-1]:
+                while work_tile.is_valid_tile:
+                    curr_block_coord = work_tile.tile_idx
+                    mma_block_coord = (
                     curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
                     curr_block_coord[1],
                     curr_block_coord[2],
                 )
-                batch_coord = curr_block_coord[2][1]
-                continue_cond = False
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
+                    batch_coord = curr_block_coord[2][1]
+                    continue_cond = False
+                    seqlen_q = mQ_qdl.shape[0]
+                    seqlen_k = (
                     mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
                 )
-                cuseqlen_q = Int32(0)
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                    cuseqlen_q = Int32(0)
+                    if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
+                        cuseqlen_q = cum_seqlen_q[batch_coord]
+                        seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                        continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
                         self.qk_mma_tiler[0],
                         mma_block_coord[0],
                         seqlen_q,
                     )
-                if not continue_cond:
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    if not continue_cond:
+                        if cutlass.const_expr(cum_seqlen_k is not None):
+                            cuseqlen_k = cum_seqlen_k[batch_coord]
+                            seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
 
-                    row_max = -Float32.inf
-                    row_max_prev = -Float32.inf
-                    row_sum = 0.0
+                        row_max = -Float32.inf
+                        row_max_prev = -Float32.inf
+                        row_sum = 0.0
 
-                    start_count, trip_count = FusedMask.get_trip_start_count_via_block_info(
+                        start_count, trip_count = FusedMask.get_trip_start_count_via_block_info(
                         mma_block_coord,
                         self.qk_mma_tiler,
                         seqlen_q,
@@ -1353,14 +1366,14 @@ class BlackwellFusedMultiHeadAttentionForward:
                         window_size_left,
                         window_size_right,
                     )
-                    end_count = start_count + trip_count
+                        end_count = start_count + trip_count
                     # require at least one softmax iteration for zero trip_count case;
                     # rely on masking this iteration for correctness
-                    if end_count <= start_count:
-                        start_count = 0
-                        end_count = 1
-                    if cutlass.const_expr(self.use_semantic_trip_range):
-                        n_block_min_causal_local_mask, n_block_min_before_local_mask = (
+                        if end_count <= start_count:
+                            start_count = 0
+                            end_count = 1
+                        if cutlass.const_expr(self.use_semantic_trip_range):
+                            n_block_min_causal_local_mask, n_block_min_before_local_mask = (
                             FusedMask.get_trip_mask_bounds_via_block_info(
                                 mma_block_coord,
                                 self.qk_mma_tiler,
@@ -1372,26 +1385,25 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 window_size_right,
                             )
                         )
-                    cS_base = cute.make_identity_tensor(
+                        cS_base = cute.make_identity_tensor(
                         (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
                     )
-                    cS = cute.domain_offset((mma_block_coord[0] * self.qk_mma_tiler[0], 0), cS_base)
-                    tScS = qk_thr_mma.partition_C(cS)
+                        cS = cute.domain_offset((mma_block_coord[0] * self.qk_mma_tiler[0], 0), cS_base)
+                        tScS = qk_thr_mma.partition_C(cS)
 
-                    for step in cutlass.range(start_count, end_count, 1, unroll=1):
-                        cS_iter = cute.domain_offset((0, step * self.qk_mma_tiler[1]), cS)
-                        tScS_iter = qk_thr_mma.partition_C(cS_iter)
-                        if cutlass.const_expr(self.use_semantic_trip_range):
-                            need_apply_mask = (
+                        for step in cutlass.range(start_count, end_count, 1, unroll=1):
+                            cS_iter = cute.domain_offset((0, step * self.qk_mma_tiler[1]), cS)
+                            tScS_iter = qk_thr_mma.partition_C(cS_iter)
+                            if cutlass.const_expr(self.use_semantic_trip_range):
+                                need_apply_mask = (
                                 step >= n_block_min_causal_local_mask
                                 or step < n_block_min_before_local_mask
                                 or step == end_count - 1
                             )
-                        else:
+                            else:
                             # Residual path only needs seqlen masking on the last K tile.
-                            need_apply_mask = step == end_count - 1
-                        # Si -> Pi
-                        (
+                                need_apply_mask = step == end_count - 1
+                            (
                             row_max,
                             row_sum,
                             mma_s_consumer,
@@ -1409,8 +1421,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                             (tStS, tScS_iter),
                             (mma_s_consumer, p_mma_producer, s_corr_producer),
                         )
-                        row_max_prev = row_max
-                    sum_producer = self.store_sum_max(
+                            row_max_prev = row_max
+                        sum_producer = self.store_sum_max(
                         row_max,
                         mLSE,
                         row_sum,
@@ -1422,14 +1434,17 @@ class BlackwellFusedMultiHeadAttentionForward:
                         cuseqlen_q,
                         scale_softmax,
                     )
-                work_tile = tile_sched.advance_to_next_work()
-            p_mma_producer.tail()
-            s_corr_producer.tail()
+                    work_tile = tile_sched.advance_to_next_work()
+                p_mma_producer.tail()
+                s_corr_producer.tail()
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  Correction
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             cute.arch.warpgroup_reg_dealloc(self.num_regs_correction)
 
             while work_tile.is_valid_tile:
@@ -1446,7 +1461,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 )
                 continue_cond = False
                 cuseqlen_q = Int32(0)
-                if cutlass.const_expr(cum_seqlen_q is not None):
+                if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
                     cuseqlen_q = cum_seqlen_q[batch_coord]
                     seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
                     continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
@@ -1461,14 +1476,14 @@ class BlackwellFusedMultiHeadAttentionForward:
                         seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
 
                     mO_qdl_eff = mO_qdl
-                    if cutlass.const_expr(cum_seqlen_q is not None):
+                    if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
                         block_offset_o = (
                             cuseqlen_q,
                             Int32(0),
                             Int32(0),
                             ((Int32(0), Int32(0)), Int32(0)),
                         )
-                        mO_qdl_eff = cute.domain_offset(
+                        mO_qdl_eff = domain_offset_aligned(
                             cute.select(block_offset_o, mode=[0, 2, 3]), mO_qdl
                         )
 
@@ -1511,34 +1526,19 @@ class BlackwellFusedMultiHeadAttentionForward:
                     mma_corr_consumer, sum_consumer = self.correction_epilog(
                         (seqlen_q, scale_output),
                         (sum_consumer, sSum),
-                        (mma_corr_consumer, gO_staged, cO_staged, tOtO_staged),
+                        (mma_corr_consumer, gO_staged, cO_staged, tOtO_staged,
+                            sO,
+                            gmem_tiled_copy_o,
+                        ),
                         self.epi_tile,
                     )
                 work_tile = tile_sched.advance_to_next_work()
             # NOTE: tmem.free() moved to kernel end to enable cluster-wide sync
 
         # ///////////////////////////////////////////////////////////////////////////////
-        #  Scheduler Warp (only for CLC dynamic scheduler)
-        # ///////////////////////////////////////////////////////////////////////////////
-        if cutlass.const_expr(self.use_clc_scheduler):
-            is_first_cta_in_cluster = cta_rank_in_cluster == 0
-
-            if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-                while work_tile.is_valid_tile:
-                    tile_sched.prefetch_next_work()
-                    work_tile = tile_sched.advance_to_next_work()
-                tile_sched.producer_tail()
-
-        # ///////////////////////////////////////////////////////////////////////////////
         #  Empty warps reg dealloc
         # ///////////////////////////////////////////////////////////////////////////////
-        if cutlass.const_expr(self.use_clc_scheduler):
-            if warp_idx > self.load_warp_id:
-                if not (warp_idx == self.sched_warp_id and is_first_cta_in_cluster):
-                    cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-        else:
-            if warp_idx > self.load_warp_id:
+        if warp_idx > self.load_warp_id:
                 cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
 
         # ///////////////////////////////////////////////////////////////////////////////
@@ -1549,9 +1549,31 @@ class BlackwellFusedMultiHeadAttentionForward:
         cute.arch.cluster_arrive()
         cute.arch.cluster_wait()
         tmem.relinquish_alloc_permit()
+        tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
         tmem.free(tmem_ptr)
 
         return
+
+    @cute.jit
+    def get_tmem_views(
+        self,
+        qk_thr_mma: cute.ThrMma,
+        pv_thr_mma: cute.ThrMma,
+    ) -> Tuple[cute.Tensor, cute.Tensor]:
+        qk_acc_shape = qk_thr_mma.partition_shape_C((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+        tStS = qk_thr_mma.make_fragment_C(cute.append(qk_acc_shape, self.qk_acc_stage))
+        pv_acc_shape = pv_thr_mma.partition_shape_C((self.pv_mma_tiler[0], self.pv_mma_tiler[1]))
+        tOtO = pv_thr_mma.make_fragment_C(pv_acc_shape)
+        tOtO_layout = cute.append(
+            tOtO.layout,
+            cute.make_layout(
+                self.iterations_pv,
+                stride=self.pv_mma_tiler[1] // self.tmem_warp_shape_mn[1],
+            ),
+        )
+        tStS = cute.make_tensor(tStS.iterator + self.tmem_s_offset, tStS.layout)
+        tOtO_staged = cute.make_tensor(tOtO.iterator + self.tmem_o_offset, tOtO_layout)
+        return tStS, tOtO_staged
 
     @cute.jit
     def softmax_step(
@@ -1593,6 +1615,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 self.is_local,
                 window_size_left,
                 window_size_right,
+                apply_residual=self.mask_residual,
             )
         old_row_max = row_max
         row_max = tTMEM_LOADrS.load().reduce(cute.ReductionOp.MAX, row_max, 0)
@@ -1827,38 +1850,35 @@ class BlackwellFusedMultiHeadAttentionForward:
     ) -> Tuple[pipeline.PipelineConsumer, pipeline.PipelineProducer]:
         (seqlen_q, scale_output) = value_args
         (sum_consumer, sSum) = sum_args
-        (mma_o_consumer, gO_staged, cO_staged, tOtO_staged) = o_args
+        (mma_o_consumer, gO_staged, cO_staged, tOtO_staged,
+            sO_staged,
+            gmem_tiled_copy_o,
+        ) = o_args
         tidx, _, _ = cute.arch.thread_idx()
         thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
         sum_handle = sum_consumer.wait_and_advance()
-        row_sum = sSum[thread_idx]
-        cute.arch.fence_view_async_shared()
-        sum_handle.release()
-        row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
-        scale = scale_output / row_sum if not row_sum_is_zero_or_nan else 0.0
         o_handle = mma_o_consumer.wait_and_advance()
         for iter in cutlass.range(self.iterations_pv):
             gO = gO_staged[None, None, iter]
             cO = cO_staged[None, None, iter]
+            sO = sO_staged[None, None, 0]
+            row_sum = sSum[thread_idx]
+            row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
+            scale = scale_output / row_sum if not row_sum_is_zero_or_nan else 0.0
             tOtO = tOtO_staged[(None, None), 0, 0, iter]
             tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
-            cO_epi = cute.zipped_divide(cO, epi_tile)
-            gO_epi = cute.zipped_divide(gO, epi_tile)
-            tidx, _, _ = cute.arch.thread_idx()
-            thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
+            sO_epi = cute.zipped_divide(sO, epi_tile)
             tmem_copy_atom = cute.make_copy_atom(
                 tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.pv_acc_dtype
             )
             tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_epi)
             thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
             tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_epi)
-            tTMEM_LOADgO = thr_tmem_load.partition_D(gO_epi)
-            tTMEM_LOADcO = thr_tmem_load.partition_D(cO_epi)
+            tTMEM_LOADsO = thr_tmem_load.partition_D(sO_epi)
             for i in cutlass.range(cute.size(tTMEM_LOADtO, mode=[1]), unroll_full=True):
                 tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
-                tTMEM_LOADgO_i = tTMEM_LOADgO[None, i, 0]
-                tTMEM_LOADcO_i = tTMEM_LOADcO[None, i, 0]
-                tTMrO = cute.make_rmem_tensor(tTMEM_LOADcO[None, 0, i].shape, self.pv_acc_dtype)
+                tTMEM_LOADsO_i = tTMEM_LOADsO[None, i, 0]
+                tTMrO = cute.make_rmem_tensor(tTMEM_LOADsO[None, 0, i].shape, self.pv_acc_dtype)
                 cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
                 for j in cutlass.range(0, cute.size(tTMrO), 2, unroll_full=True):
                     tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
@@ -1868,10 +1888,53 @@ class BlackwellFusedMultiHeadAttentionForward:
                 tSMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
                 o_vec = tTMrO.load()
                 tSMrO.store(o_vec.to(self.o_dtype))
-                if cute.elem_less(tTMEM_LOADcO_i[0][0], seqlen_q):
-                    cute.autovec_copy(tSMrO, tTMEM_LOADgO_i)
+                cute.autovec_copy(tSMrO, tTMEM_LOADsO_i)
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier(
+                barrier_id=2,
+                number_of_threads=len(self.correction_warp_ids)
+                * self.threads_per_warp,
+            )
+            self._store_o_from_smem(
+                sO,
+                gO,
+                cO,
+                gmem_tiled_copy_o,
+                thread_idx,
+                seqlen_q,
+            )
+            cute.arch.barrier(
+                barrier_id=2,
+                number_of_threads=len(self.correction_warp_ids)
+                * self.threads_per_warp,
+            )
         o_handle.release()
+        sum_handle.release()
         return mma_o_consumer, sum_consumer
+
+    @cute.jit
+    def _store_o_from_smem(
+        self,
+        sO: cute.Tensor,
+        gO: cute.Tensor,
+        cO: cute.Tensor,
+        gmem_tiled_copy_o: cute.TiledCopy,
+        thread_idx: Int32,
+        seqlen_q: Int32,
+    ):
+        gmem_thr_copy_o = gmem_tiled_copy_o.get_slice(thread_idx)
+        tOsO = gmem_thr_copy_o.partition_S(sO)
+        tOgO = gmem_thr_copy_o.partition_D(gO)
+        tOcO = gmem_thr_copy_o.partition_S(cO)
+        tOrO = cute.make_fragment_like(tOsO, self.o_dtype)
+        cute.autovec_copy(tOsO, tOrO)
+        for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+            if tOcO[0, rest_m, 0][0] < seqlen_q:
+                cute.copy(
+                    gmem_tiled_copy_o,
+                    tOrO[None, rest_m, None],
+                    tOgO[None, rest_m, None],
+                )
 
     @cute.jit
     def store_sum_max(
@@ -1893,7 +1956,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         sSum[thread_idx] = row_sum
         cute.arch.fence_view_async_shared()
         sum_handle.commit()
-        row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
 
         if cutlass.const_expr(mLSE is not None):
             q_idx = current_block_coord[0] * self.cta_tiler[0] + tidx
@@ -1902,6 +1964,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 if cutlass.const_expr(cum_seqlen_q is not None)
                 else current_block_coord[2]
             )
+            row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
             lse_value = (
                 scale_softmax * row_max + cute.math.log(row_sum, fastmath=True)
                 if not row_sum_is_zero_or_nan

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -131,11 +131,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         )
 
         self.tmem_alloc_barrier = pipeline.NamedBarrier(
-            barrier_id=1,
-            num_threads=(
-                len(self.softmax_warp_ids) + len(self.correction_warp_ids) + 1
-            )
-            * self.threads_per_warp,
+            barrier_id=1, num_threads=self.threads_per_cta
         )
 
         self.tmem_s_offset = 0
@@ -832,6 +828,7 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         # Cluster wait
         pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+        tmem.wait_for_alloc()
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  LOAD
@@ -1066,7 +1063,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  MMA
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.mma_warp_id:
-            tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
@@ -1318,7 +1314,6 @@ class BlackwellFusedMultiHeadAttentionForward:
             mma_corr_producer.tail()
 
         if warp_idx < self.correction_warp_ids[0] and warp_idx >= self.softmax_warp_ids[0]:
-            tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, _ = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             # increase register after decreasing
@@ -1442,7 +1437,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  Correction
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
-            tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             cute.arch.warpgroup_reg_dealloc(self.num_regs_correction)

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -52,6 +52,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         o_aligned_16b: bool = False,
         l2_swizzle: bool = False,
         mask_residual: bool = True,
+        use_2cta: bool = True,
     ):
         head_dim_v = head_dim if head_dim_v is None else head_dim_v
         assert head_dim == 256 and head_dim_v == 256, (
@@ -86,20 +87,22 @@ class BlackwellFusedMultiHeadAttentionForward:
             mma_tiler[1],
             mma_tiler[2],
         )
+        self.use_2cta = use_2cta
+        cluster_size_m = 2 if use_2cta else 1
         self.qk_mma_tiler = (
-            2 * mma_tiler[0],
+            cluster_size_m * mma_tiler[0],
             mma_tiler[1],
             min(self.cta_tiler[2], 128),
         )
         self.pv_mma_tiler = self.qk_mma_tiler
         self.pv_block_tiler = (
-            self.pv_mma_tiler[0] // 2,
+            self.pv_mma_tiler[0] // cluster_size_m,
             self.pv_mma_tiler[1],
             self.pv_mma_tiler[2],
         )
         self.iterations_qk = self.cta_tiler[2] // self.qk_mma_tiler[2]
         self.iterations_pv = self.cta_tiler[2] // self.pv_mma_tiler[1]
-        self.cluster_shape_mn = (2, 1)
+        self.cluster_shape_mn = (cluster_size_m, 1)
         self.tmem_warp_shape_mn = (4, 1)
         # Dedicated hd256 kernel uses fixed scheduling policy.
         self.is_persistent = False
@@ -139,21 +142,22 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.tmem_o_offset = 256
         self.tmem_p_offset = self.tmem_s_offset
 
-        _tune_key = (True, is_causal, 256, False)  # hd256: always 2cta, no sm103 variant
+        # Reuse the established hd256 math/register tuning for both CTA-group forms.
+        _tune_key = (True, is_causal, 256, False)
         _tune = _TUNING_CONFIG.get(_tune_key, {})
         self.num_regs_softmax = _tune.get("num_regs_softmax", 256)
         self.num_regs_correction = _tune.get("num_regs_correction", 160)
         self.num_regs_other = 56 if is_causal else 32
-        self.ex2_emu_freq = _tune.get("ex2_emu_freq", 4)
+        self.ex2_emu_freq = _tune.get("ex2_emu_freq", 4) if self.use_2cta else 0
         self.ex2_emu_res = _tune.get("ex2_emu_res", 3)
         self.ex2_emu_start_frg = _tune.get("ex2_emu_start_frg", 0)
 
         self.buffer_align_bytes = 1024
 
     def _setup_attributes(self):
-        self.q_stage = self.iterations_qk
-        self.k_stage = 4
-        self.v_stage = 4
+        self.q_stage = 2
+        self.k_stage = 4 if self.use_2cta else 2
+        self.v_stage = 4 if self.use_2cta else 3
         self.qk_acc_stage = 2
         self.mma_corr_stage = 1
 
@@ -443,7 +447,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
         self._setup_attributes()
 
-        cta_group = tcgen05.CtaGroup.TWO
+        cta_group = tcgen05.CtaGroup.TWO if self.use_2cta else tcgen05.CtaGroup.ONE
         # the intermediate tensor p is from tmem & k-major
         p_source = tcgen05.OperandSource.TMEM
         p_major_mode = tcgen05.OperandMajorMode.K
@@ -679,9 +683,15 @@ class BlackwellFusedMultiHeadAttentionForward:
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
 
-        bidx, _, _ = cute.arch.block_idx()
-        mma_tile_coord_v = bidx % cute.size(qk_tiled_mma.thr_id.shape)
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        if cutlass.const_expr(self.use_2cta):
+            bidx, _, _ = cute.arch.block_idx()
+            mma_tile_coord_v = bidx % cute.size(qk_tiled_mma.thr_id.shape)
+            cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+            is_leader_cta = mma_tile_coord_v == 0
+        else:
+            mma_tile_coord_v = 0
+            cta_rank_in_cluster = 0
+            is_leader_cta = True
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
 
         # Alloc
@@ -772,7 +782,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.correction_warp_ids[0],
-            is_two_cta=True,
+            is_two_cta=self.use_2cta,
             two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
         )
 
@@ -826,10 +836,14 @@ class BlackwellFusedMultiHeadAttentionForward:
                 tile_sched_params)
         else:
             blk_idx = cute.arch.block_idx()
+            if cutlass.const_expr(not self.use_2cta):
+                # Reverse batch groups without disturbing per-batch head locality.
+                blk_idx = (blk_idx[0], blk_idx[1], cute.arch.grid_dim()[2] - 1 - blk_idx[2])
             tile_sched = FmhaStaticTileScheduler(
                 tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
             )
         work_tile = tile_sched.initial_work_tile_info()
+
         has_seqused = mSeqUsedQ is not None or mSeqUsedK is not None
         seqlen_info_args = (
             mQ_qdl.shape[0],
@@ -1097,8 +1111,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             if cutlass.const_expr(has_seqused):
                 sTripMma = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
 
-            cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-            is_leader_cta = cta_rank_in_cluster % 2 == 0
+            # For the 1CTA specialization this is the compile-time constant True,
+            # so issuer-only work has no generated leader predicate.
 
             while work_tile.is_valid_tile:
                 curr_block_coord = work_tile.tile_idx
@@ -1566,7 +1580,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         seqlen_q,
                     )
                 work_tile = tile_sched.advance_to_next_work()
-            # NOTE: tmem.free() moved to kernel end to enable cluster-wide sync
+            # TMEM is released after every role has completed below.
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  Empty warps reg dealloc
@@ -1575,12 +1589,14 @@ class BlackwellFusedMultiHeadAttentionForward:
                 cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
 
         # ///////////////////////////////////////////////////////////////////////////////
-        #  Cooperative TMEM Deallocation (2CTA)
+        #  Cooperative TMEM Deallocation
         # ///////////////////////////////////////////////////////////////////////////////
-        # All warps (including scheduler) have finished by this point.
-        # Cluster-wide sync ensures both CTAs reach here before dealloc.
-        cute.arch.cluster_arrive()
-        cute.arch.cluster_wait()
+        # The paired allocator requires both CTAs to finish before either frees TMEM.
+        if cutlass.const_expr(self.use_2cta):
+            cute.arch.cluster_arrive()
+            cute.arch.cluster_wait()
+        else:
+            self.tmem_alloc_barrier.arrive_and_wait()
         tmem.relinquish_alloc_permit()
         tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
         tmem.free(tmem_ptr)

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -27,6 +27,7 @@ from flash_attn.cute.mask import (
 from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _TUNING_CONFIG
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.utils import ex2_emulation_2, as_bshkrd_tensor, AuxData, domain_offset_aligned
 
 
@@ -181,9 +182,6 @@ class BlackwellFusedMultiHeadAttentionForward:
     ):
         # Keep parity with FlashAttentionForwardSm100.__call__ interface.
         # (TODO@wangsiyu) Implement these features.
-        assert mSeqUsedQ is None and mSeqUsedK is None, (
-            "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
-        )
         assert learnable_sink is None, (
             "SM100 forward with head_dim=256 does not support learnable_sink"
         )
@@ -196,12 +194,13 @@ class BlackwellFusedMultiHeadAttentionForward:
         assert aux_data.scalars is None, (
             "SM100 forward with head_dim=256 does not support aux_scalars"
         )
-        assert not self.is_local, (
-            "SM100 forward with head_dim=256 does not support local attention yet"
-        )
-        assert window_size_left is None and window_size_right is None, (
-            "SM100 forward with head_dim=256 does not support runtime window_size overrides"
-        )
+        if cutlass.const_expr(mSeqUsedQ is None and mSeqUsedK is None):
+            assert not self.is_local, (
+                "SM100 forward with head_dim=256 does not support local attention without seqused_q/seqused_k"
+            )
+            assert window_size_left is None and window_size_right is None, (
+                "SM100 forward with head_dim=256 does not support runtime window sizes without seqused_q/seqused_k"
+            )
         assert descale_tensors is None, (
             "SM100 forward with head_dim=256 does not support descale_tensors"
         )
@@ -408,6 +407,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 tile_shape_mn=self.cta_tiler[:2],
                 cluster_shape_mn=self.cluster_shape_mn,
                 mCuSeqlensQ=cum_seqlen_q,
+                mSeqUsedQ=mSeqUsedQ,
                 nested_mbh_coord=True,
                 is_persistent=False,
                 lpt=False,
@@ -501,7 +501,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
             self.o_dtype, self.o_layout, self.epi_tile, 1
         )
-        universal_copy_bits = 128
+        universal_copy_bits = 128 if cutlass.const_expr(self.o_aligned_16b) else self.o_dtype.width
         async_copy_elems = universal_copy_bits // self.o_dtype.width
         atom_universal_copy = cute.make_copy_atom(
             cute.nvgpu.CopyUniversalOp(),
@@ -560,6 +560,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.tma_copy_q_bytes = q_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
         self.tma_copy_k_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
         self.tma_copy_v_bytes = v_copy_size * cute.size(pv_tiled_mma.thr_id.shape)
+        trip_start_count_smem_size = 2 if mSeqUsedQ is not None or mSeqUsedK is not None else 0
 
         @cute.struct
         class SharedStorage:
@@ -588,6 +589,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             tmem_dealloc_mbar: Int64
             # Tmem holding buffer
             tmem_holding_buf: Int32
+            trip_start_count_smem: cute.struct.MemRange[Int32, trip_start_count_smem_size]
 
         self.shared_storage = SharedStorage
 
@@ -607,6 +609,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             o,
             cum_seqlen_q,
             cum_seqlen_k,
+            mSeqUsedQ,
+            mSeqUsedK,
             lse,
             scale_softmax_log2,
             scale_softmax,
@@ -647,6 +651,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         mO_qdl: cute.Tensor,
         cum_seqlen_q: Optional[cute.Tensor],
         cum_seqlen_k: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
         mLSE: Optional[cute.Tensor],
         scale_softmax_log2: Float32,
         scale_softmax: Float32,
@@ -824,10 +830,47 @@ class BlackwellFusedMultiHeadAttentionForward:
                 tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
             )
         work_tile = tile_sched.initial_work_tile_info()
+        has_seqused = mSeqUsedQ is not None or mSeqUsedK is not None
+        seqlen_info_args = (
+            mQ_qdl.shape[0],
+            mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k,
+            cum_seqlen_q, cum_seqlen_k, mSeqUsedQ, mSeqUsedK,
+            None,  # mCuTotalMBlocks
+            None,  # mCuBlockIdxOffsets
+            self.qk_mma_tiler[0], self.qk_mma_tiler[1],
+        )
+        trip_mask_args = (self.is_causal, self.is_local, window_size_left, window_size_right)
+
+        if warp_idx == self.load_warp_id:
+            if cutlass.const_expr(has_seqused):
+                sTripWriter = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
+                if work_tile.is_valid_tile:
+                    if cute.arch.lane_idx() == 0:
+                        writer_block_coord = work_tile.tile_idx
+                        writer_mma_block_coord = (
+                            writer_block_coord[0]
+                            // cute.size(qk_tiled_mma.thr_id.shape),
+                            writer_block_coord[1],
+                            writer_block_coord[2],
+                        )
+                        writer_seqlen_info = SeqlenInfoQK.create(
+                            writer_block_coord[2][1], *seqlen_info_args
+                        )
+                        writer_start, writer_count = FusedMask.get_trip_start_count_via_block_info(
+                            writer_mma_block_coord,
+                            self.qk_mma_tiler,
+                            writer_seqlen_info.seqlen_q,
+                            writer_seqlen_info.seqlen_k,
+                            *trip_mask_args,
+                        )
+                        writer_count = cutlass.max(writer_count, 0)
+                        sTripWriter[0] = writer_start
+                        sTripWriter[1] = writer_count
 
         # Cluster wait
         pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
         tmem.allocate(self.tmem_alloc_cols)
+        # All-thread CTA NamedBarrier publishes the shared trip stores to every role.
         tmem.wait_for_alloc()
 
         # ///////////////////////////////////////////////////////////////////////////////
@@ -835,6 +878,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.load_warp_id:
             cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            if cutlass.const_expr(has_seqused):
+                sTripLoad = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
             while work_tile.is_valid_tile:
                 curr_block_coord = work_tile.tile_idx  # (q_tile_idx, 0, (head_idx, batch_idx))
                 mma_block_coord = (
@@ -842,38 +887,34 @@ class BlackwellFusedMultiHeadAttentionForward:
                     curr_block_coord[1],
                     curr_block_coord[2],
                 )
-                continue_cond = False
                 batch_coord = curr_block_coord[2][1]
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
+                seqlen_info = SeqlenInfoQK.create(batch_coord, *seqlen_info_args)
+                seqlen_q = seqlen_info.seqlen_q
+                seqlen_k = seqlen_info.seqlen_k
+                continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                    self.qk_mma_tiler[0],
+                    mma_block_coord[0],
+                    seqlen_q,
                 )
-                cuseqlen_q = Int32(0)
-                cuseqlen_k = Int32(0)
                 block_offset = (
-                    Int32(0),
-                    Int32(0),
+                    seqlen_info.offset_q,
+                    seqlen_info.offset_k,
                     Int32(0),
                     ((Int32(0), Int32(0)), Int32(0)),
                 )
-                if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                    block_offset = (
-                        cuseqlen_q,
-                        cuseqlen_k,
-                        Int32(0),
-                        ((Int32(0), Int32(0)), Int32(0)),
-                    )
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
+                if cutlass.const_expr(has_seqused):
+                    seqlen_kv_loop_start = sTripLoad[0]
+                    seqlen_kv_loop_steps = sTripLoad[1]
+                else:
+                    seqlen_kv_loop_start, seqlen_kv_loop_steps = FusedMask.get_trip_start_count_via_block_info(
+                        mma_block_coord,
+                        self.qk_mma_tiler,
                         seqlen_q,
+                        seqlen_k,
+                        *trip_mask_args,
                     )
-                if not continue_cond:
+                    seqlen_kv_loop_steps = cutlass.max(seqlen_kv_loop_steps, 0)
+                if not continue_cond and seqlen_kv_loop_steps > 0:
                     mQ_qdl_ = cute.domain_offset(cute.select(block_offset, mode=[0, 2, 3]), mQ_qdl)
                     # Local tile partition global tensors
                     q_cta_layout = cute.make_layout(
@@ -956,19 +997,6 @@ class BlackwellFusedMultiHeadAttentionForward:
                         tVgV = tVgV_dkl
                     # ((atom_v, rest_v), RestK)
                     tQgQ = tQgQ_qdl[None, mma_block_coord[0], None, mma_block_coord[2]]
-
-                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
-                        FusedMask.get_trip_start_count_via_block_info(
-                            mma_block_coord,
-                            self.qk_mma_tiler,
-                            seqlen_q,
-                            seqlen_k,
-                            self.is_causal,
-                            self.is_local,
-                            window_size_left,
-                            window_size_right,
-                        )
-                    )
                     seqlen_kv_loop_end = seqlen_kv_loop_start + seqlen_kv_loop_steps
                     # Q
                     for iter in cutlass.range(self.iterations_qk, unroll=1):
@@ -1066,6 +1094,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            if cutlass.const_expr(has_seqused):
+                sTripMma = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
 
             cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
             is_leader_cta = cta_rank_in_cluster % 2 == 0
@@ -1077,38 +1107,28 @@ class BlackwellFusedMultiHeadAttentionForward:
                     curr_block_coord[1],
                     curr_block_coord[2],
                 )
-                continue_cond = False
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
-                )
                 batch_coord = curr_block_coord[2][1]
-                if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
+                seqlen_info = SeqlenInfoQK.create(batch_coord, *seqlen_info_args)
+                seqlen_q = seqlen_info.seqlen_q
+                seqlen_k = seqlen_info.seqlen_k
+                continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                    self.qk_mma_tiler[0],
+                    mma_block_coord[0],
+                    seqlen_q,
+                )
+                if cutlass.const_expr(has_seqused):
+                    seqlen_kv_loop_start = sTripMma[0]
+                    seqlen_kv_loop_steps = sTripMma[1]
+                else:
+                    seqlen_kv_loop_start, seqlen_kv_loop_steps = FusedMask.get_trip_start_count_via_block_info(
+                        mma_block_coord,
+                        self.qk_mma_tiler,
                         seqlen_q,
+                        seqlen_k,
+                        *trip_mask_args,
                     )
-
-                if not continue_cond:
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-
-                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
-                        FusedMask.get_trip_start_count_via_block_info(
-                            mma_block_coord,
-                            self.qk_mma_tiler,
-                            seqlen_q,
-                            seqlen_k,
-                            self.is_causal,
-                            self.is_local,
-                            window_size_left,
-                            window_size_right,
-                        )
-                    )
+                    seqlen_kv_loop_steps = cutlass.max(seqlen_kv_loop_steps, 0)
+                if not continue_cond and seqlen_kv_loop_steps > 0:
                     seqlen_kv_loop_end = seqlen_kv_loop_start + seqlen_kv_loop_steps
 
                     load_q_releaser = load_q_consumer.clone()
@@ -1318,6 +1338,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             tStS, _ = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             # increase register after decreasing
             cute.arch.warpgroup_reg_alloc(self.num_regs_softmax)
+            if cutlass.const_expr(has_seqused):
+                sTripSoftmax = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
 
             if warp_idx <= self.softmax_warp_ids[-1]:
                 while work_tile.is_valid_tile:
@@ -1328,45 +1350,44 @@ class BlackwellFusedMultiHeadAttentionForward:
                     curr_block_coord[2],
                 )
                     batch_coord = curr_block_coord[2][1]
-                    continue_cond = False
-                    seqlen_q = mQ_qdl.shape[0]
-                    seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
-                )
-                    cuseqlen_q = Int32(0)
-                    if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
-                        cuseqlen_q = cum_seqlen_q[batch_coord]
-                        seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                        continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                    seqlen_info = SeqlenInfoQK.create(batch_coord, *seqlen_info_args)
+                    seqlen_q = seqlen_info.seqlen_q
+                    seqlen_k = seqlen_info.seqlen_k
+                    offset_q = seqlen_info.offset_q
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
                         self.qk_mma_tiler[0],
                         mma_block_coord[0],
                         seqlen_q,
                     )
-                    if not continue_cond:
-                        if cutlass.const_expr(cum_seqlen_k is not None):
-                            cuseqlen_k = cum_seqlen_k[batch_coord]
-                            seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-
-                        row_max = -Float32.inf
-                        row_max_prev = -Float32.inf
-                        row_sum = 0.0
-
+                    if cutlass.const_expr(has_seqused):
+                        start_count = sTripSoftmax[0]
+                        trip_count = sTripSoftmax[1]
+                    else:
                         start_count, trip_count = FusedMask.get_trip_start_count_via_block_info(
                         mma_block_coord,
                         self.qk_mma_tiler,
                         seqlen_q,
                         seqlen_k,
-                        self.is_causal,
-                        self.is_local,
-                        window_size_left,
-                        window_size_right,
+                        *trip_mask_args,
                     )
+                        trip_count = cutlass.max(trip_count, 0)
+                    q_tile_valid = not continue_cond
+                    if q_tile_valid and trip_count == 0:
+                        self.store_empty_lse(
+                            mLSE,
+                            curr_block_coord,
+                            seqlen_q,
+                            cum_seqlen_q,
+                            offset_q,
+                        )
+                    continue_cond = continue_cond or trip_count == 0
+                    if not continue_cond:
+                        q_tile_full = (mma_block_coord[0] + 1) * self.qk_mma_tiler[0] <= seqlen_q
+                        row_max = -Float32.inf
+                        row_max_prev = -Float32.inf
+                        row_sum = 0.0
+
                         end_count = start_count + trip_count
-                    # require at least one softmax iteration for zero trip_count case;
-                    # rely on masking this iteration for correctness
-                        if end_count <= start_count:
-                            start_count = 0
-                            end_count = 1
                         if cutlass.const_expr(self.use_semantic_trip_range):
                             n_block_min_causal_local_mask, n_block_min_before_local_mask = (
                             FusedMask.get_trip_mask_bounds_via_block_info(
@@ -1374,10 +1395,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 self.qk_mma_tiler,
                                 seqlen_q,
                                 seqlen_k,
-                                self.is_causal,
-                                self.is_local,
-                                window_size_left,
-                                window_size_right,
+                                *trip_mask_args,
                             )
                         )
                         cS_base = cute.make_identity_tensor(
@@ -1405,7 +1423,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                             p_mma_producer,
                             s_corr_producer,
                         ) = self.softmax_step(
-                            (need_apply_mask, window_size_left, window_size_right),
+                            (need_apply_mask, q_tile_full, step, window_size_left, window_size_right),
                             (
                                 row_max_prev,
                                 row_sum,
@@ -1426,7 +1444,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         curr_block_coord,
                         seqlen_q,
                         cum_seqlen_q,
-                        cuseqlen_q,
+                        offset_q,
                         scale_softmax,
                     )
                     work_tile = tile_sched.advance_to_next_work()
@@ -1440,6 +1458,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             cute.arch.warpgroup_reg_dealloc(self.num_regs_correction)
+            if cutlass.const_expr(has_seqused):
+                sTripCorrection = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
 
             while work_tile.is_valid_tile:
                 curr_block_coord = work_tile.tile_idx
@@ -1449,30 +1469,30 @@ class BlackwellFusedMultiHeadAttentionForward:
                     curr_block_coord[2],
                 )
                 batch_coord = curr_block_coord[2][1]
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
+                seqlen_info = SeqlenInfoQK.create(batch_coord, *seqlen_info_args)
+                seqlen_q = seqlen_info.seqlen_q
+                seqlen_k = seqlen_info.seqlen_k
+                offset_q = seqlen_info.offset_q
+                continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                    self.qk_mma_tiler[0], mma_block_coord[0], seqlen_q
                 )
-                continue_cond = False
-                cuseqlen_q = Int32(0)
-                if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
+                if cutlass.const_expr(has_seqused):
+                    seqlen_kv_loop_steps = sTripCorrection[1]
+                else:
+                    _, seqlen_kv_loop_steps = FusedMask.get_trip_start_count_via_block_info(
+                        mma_block_coord,
+                        self.qk_mma_tiler,
                         seqlen_q,
+                        seqlen_k,
+                        *trip_mask_args,
                     )
+                    seqlen_kv_loop_steps = cutlass.max(seqlen_kv_loop_steps, 0)
 
-                if not continue_cond:
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-
+                if not continue_cond and seqlen_kv_loop_steps > 0:
                     mO_qdl_eff = mO_qdl
                     if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
                         block_offset_o = (
-                            cuseqlen_q,
+                            offset_q,
                             Int32(0),
                             Int32(0),
                             ((Int32(0), Int32(0)), Int32(0)),
@@ -1490,16 +1510,6 @@ class BlackwellFusedMultiHeadAttentionForward:
                         cute.select(self.pv_block_tiler, mode=[0, 1]),
                     )
 
-                    _, seqlen_kv_loop_steps = FusedMask.get_trip_start_count_via_block_info(
-                        mma_block_coord,
-                        self.qk_mma_tiler,
-                        seqlen_q,
-                        seqlen_k,
-                        self.is_causal,
-                        self.is_local,
-                        window_size_left,
-                        window_size_right,
-                    )
                     gO_staged = gO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
                     cO_staged = cO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
                     cS = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
@@ -1525,6 +1535,35 @@ class BlackwellFusedMultiHeadAttentionForward:
                             gmem_tiled_copy_o,
                         ),
                         self.epi_tile,
+                    )
+                if not continue_cond and seqlen_kv_loop_steps == 0:
+                    mO_qdl_eff = mO_qdl
+                    if cutlass.const_expr(cum_seqlen_q is not None and not self.is_varlen_b1):
+                        block_offset_o = (
+                            offset_q,
+                            Int32(0),
+                            Int32(0),
+                            ((Int32(0), Int32(0)), Int32(0)),
+                        )
+                        mO_qdl_eff = domain_offset_aligned(
+                            cute.select(block_offset_o, mode=[0, 2, 3]), mO_qdl
+                        )
+
+                    gO_qdl = cute.flat_divide(
+                        mO_qdl_eff, cute.select(self.pv_block_tiler, mode=[0, 1])
+                    )
+                    cO_qdl = cute.flat_divide(
+                        cute.make_identity_tensor(mO_qdl_eff.shape),
+                        cute.select(self.pv_block_tiler, mode=[0, 1]),
+                    )
+
+                    gO_staged = gO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
+                    cO_staged = cO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
+                    self.store_empty_o(
+                        gO_staged,
+                        cO_staged,
+                        gmem_tiled_copy_o,
+                        seqlen_q,
                     )
                 work_tile = tile_sched.advance_to_next_work()
             # NOTE: tmem.free() moved to kernel end to enable cluster-wide sync
@@ -1577,7 +1616,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         tensor_args: Tuple,
         pipeline_args: Tuple,
     ) -> Tuple[Float32, Float32, pipeline.PipelineConsumer, pipeline.PipelineProducer]:
-        need_apply_mask, window_size_left, window_size_right = mask_args
+        need_apply_mask, q_tile_full, step, window_size_left, window_size_right = mask_args
         row_max, row_sum, seqlen_q, seqlen_k, scale_softmax_log2 = value_args
         tStS, tScS = tensor_args
         mma_s_consumer, p_mma_producer, s_corr_producer = pipeline_args
@@ -1599,18 +1638,47 @@ class BlackwellFusedMultiHeadAttentionForward:
         cute.arch.fence_view_async_tmem_load()
         s_handle.release()
         if need_apply_mask:
-            FusedMask.apply_mask_via_causal_local(
-                tTMEM_LOADrS,
-                tTMEM_LOADcS,
-                seqlen_q,
-                seqlen_k,
-                self.use_semantic_trip_range,
-                self.is_causal,
-                self.is_local,
-                window_size_left,
-                window_size_right,
-                apply_residual=self.mask_residual,
-            )
+            if cutlass.const_expr(self.mask_residual):
+                k_tile_full = (step + 1) * self.qk_mma_tiler[1] <= seqlen_k
+                if q_tile_full and k_tile_full:
+                    FusedMask.apply_mask_via_causal_local(
+                        tTMEM_LOADrS,
+                        tTMEM_LOADcS,
+                        seqlen_q,
+                        seqlen_k,
+                        self.use_semantic_trip_range,
+                        self.is_causal,
+                        self.is_local,
+                        window_size_left,
+                        window_size_right,
+                        apply_residual=False,
+                    )
+                else:
+                    FusedMask.apply_mask_via_causal_local(
+                        tTMEM_LOADrS,
+                        tTMEM_LOADcS,
+                        seqlen_q,
+                        seqlen_k,
+                        self.use_semantic_trip_range,
+                        self.is_causal,
+                        self.is_local,
+                        window_size_left,
+                        window_size_right,
+                        apply_residual=True,
+                    )
+            else:
+                FusedMask.apply_mask_via_causal_local(
+                    tTMEM_LOADrS,
+                    tTMEM_LOADcS,
+                    seqlen_q,
+                    seqlen_k,
+                    self.use_semantic_trip_range,
+                    self.is_causal,
+                    self.is_local,
+                    window_size_left,
+                    window_size_right,
+                    apply_residual=False,
+                )
         old_row_max = row_max
         row_max = tTMEM_LOADrS.load().reduce(cute.ReductionOp.MAX, row_max, 0)
         row_max_safe = row_max
@@ -1931,6 +1999,55 @@ class BlackwellFusedMultiHeadAttentionForward:
                 )
 
     @cute.jit
+    def store_empty_o(
+        self,
+        gO_staged: cute.Tensor,
+        cO_staged: cute.Tensor,
+        gmem_tiled_copy_o: cute.TiledCopy,
+        seqlen_q: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.correction_warp_ids))
+        gmem_thr_copy_o = gmem_tiled_copy_o.get_slice(thread_idx)
+        for iter in cutlass.range(self.iterations_pv):
+            gO = gO_staged[None, None, iter]
+            cO = cO_staged[None, None, iter]
+            tOgO = gmem_thr_copy_o.partition_D(gO)
+            tOcO = gmem_thr_copy_o.partition_S(cO)
+            tOrO = cute.make_fragment_like(tOgO, self.o_dtype)
+            tOrO.fill(0.0)
+            for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+                if tOcO[0, rest_m, 0][0] < seqlen_q:
+                    cute.copy(
+                        gmem_tiled_copy_o,
+                        tOrO[None, rest_m, None],
+                        tOgO[None, rest_m, None],
+                    )
+
+    @cute.jit
+    def store_empty_lse(
+        self,
+        mLSE: Optional[cute.Tensor],
+        current_block_coord,
+        seqlen_q: Int32,
+        cum_seqlen_q: Optional[cute.Tensor],
+        offset_q: Int32,
+    ):
+        if cutlass.const_expr(mLSE is not None):
+            tidx, _, _ = cute.arch.thread_idx()
+            q_idx = current_block_coord[0] * self.cta_tiler[0] + tidx
+            hb_idx = (
+                (current_block_coord[2][0], Int32(0))
+                if cutlass.const_expr(cum_seqlen_q is not None)
+                else current_block_coord[2]
+            )
+            if cute.elem_less(q_idx, seqlen_q):
+                global_q_idx = (
+                    q_idx + offset_q if cutlass.const_expr(cum_seqlen_q is not None) else q_idx
+                )
+                mLSE[global_q_idx, hb_idx] = -Float32.inf
+
+    @cute.jit
     def store_sum_max(
         self,
         row_max,
@@ -1941,7 +2058,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         current_block_coord,
         seqlen_q,
         cum_seqlen_q,
-        cuseqlen_q,
+        offset_q,
         scale_softmax,
     ):
         tidx, _, _ = cute.arch.thread_idx()
@@ -1966,7 +2083,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             )
             if cute.elem_less(q_idx, seqlen_q):
                 global_q_idx = (
-                    q_idx + cuseqlen_q if cutlass.const_expr(cum_seqlen_q is not None) else q_idx
+                    q_idx + offset_q if cutlass.const_expr(cum_seqlen_q is not None) else q_idx
                 )
                 mLSE[global_q_idx, hb_idx] = lse_value
         return sum_producer

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -164,6 +164,7 @@ class TileSchedulerArguments(ParamsBase):
     is_split_kv: cutlass.Constexpr[bool] = False
     head_swizzle: cutlass.Constexpr[bool] = False
     use_cluster_idx: cutlass.Constexpr[bool] = False
+    nested_mbh_coord: cutlass.Constexpr[bool] = False
 
 
 class SingleTileScheduler:
@@ -802,6 +803,7 @@ class SingleTileVarlenScheduler:
         head_swizzle: cutlass.Constexpr[bool] = False
         cluster_shape_m: cutlass.Constexpr[int] = 1
         use_cluster_idx: cutlass.Constexpr[bool] = False
+        nested_mbh_coord: cutlass.Constexpr[bool] = False
         scheduling_mode: cutlass.Constexpr[SchedulingMode] = SchedulingMode.STATIC
 
         @staticmethod
@@ -844,6 +846,7 @@ class SingleTileVarlenScheduler:
                 head_swizzle=args.head_swizzle,
                 cluster_shape_m=args.cluster_shape_mn[0],
                 use_cluster_idx=args.use_cluster_idx,
+                nested_mbh_coord=args.nested_mbh_coord,
                 scheduling_mode=scheduling_mode,
             )
 
@@ -1043,7 +1046,10 @@ class SingleTileVarlenScheduler:
                 block = block * params.cluster_shape_m + bidx_in_cluster[0]
         # if cute.arch.thread_idx()[0] == 128: cute.printf("SingleTileVarlenScheduler: tile_idx=%d, batch_idx=%d, head_idx=%d, block=%d, is_valid = %d", self._tile_idx, batch_idx, head_idx, block, is_valid)
         split_idx = self._split_idx if const_expr(params.is_split_kv) else Int32(0)
-        return WorkTileInfo((Int32(block), Int32(head_idx), Int32(batch_idx), split_idx), is_valid)
+        tile_idx = (Int32(block), Int32(head_idx), Int32(batch_idx), split_idx)
+        if const_expr(params.nested_mbh_coord):
+            tile_idx = (Int32(block), Int32(0), (Int32(head_idx), Int32(batch_idx)))
+        return WorkTileInfo(tile_idx, is_valid)
 
     @cute.jit
     def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
@@ -1139,6 +1145,8 @@ class Sm100FmhaStaticTileSchedulerParams:
         is_persistent: bool,
         problem_shape_mbh: cute.Shape,
         *,
+        lpt: cutlass.Constexpr[bool] = False,
+        l2_swizzle: cutlass.Constexpr[bool] = False,
         loc=None,
         ip=None,
     ):
@@ -1152,6 +1160,8 @@ class Sm100FmhaStaticTileSchedulerParams:
         """
         self.is_persistent = is_persistent
         self.problem_shape_mbh = problem_shape_mbh
+        self.lpt = lpt
+        self.l2_swizzle = l2_swizzle
         self._loc = loc
         self._ip = ip
 
@@ -1169,7 +1179,7 @@ class Sm100FmhaStaticTileSchedulerParams:
             obj_list.append(new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
         return Sm100FmhaStaticTileSchedulerParams(
-            self.is_persistent, *(tuple(obj_list)), loc=self._loc
+            self.is_persistent, *(tuple(obj_list)), lpt=self.lpt, l2_swizzle=self.l2_swizzle, loc=self._loc
         )
 
 
@@ -1313,6 +1323,20 @@ class Sm100FmhaStaticTileScheduler:
             )
         else:
             blk_coord = self._blk_coord
+        if const_expr(self._params.lpt):
+            num_query_clusters = cute.ceil_div(self._params.problem_shape_mbh[0], 2)
+            query_cluster = blk_coord[0] // 2
+            cta_rank = blk_coord[0] % 2
+            head = blk_coord[1]
+            if const_expr(not self._params.is_persistent and self._params.l2_swizzle):
+                linear_cluster = head * num_query_clusters + query_cluster
+                query_cluster = linear_cluster // self._params.problem_shape_mbh[1]
+                head = linear_cluster % self._params.problem_shape_mbh[1]
+            blk_coord = (
+                (num_query_clusters - 1 - query_cluster) * 2 + cta_rank,
+                head,
+                blk_coord[2],
+            )
 
         # cur_tile_coord is (mid, 0, (bid, hid))
         cur_tile_coord = (
@@ -1376,6 +1400,9 @@ def compute_sm100_fmha_grid(
     o_shape: cute.Shape,
     cta_tiler: Tuple[int, int, int],
     is_persistent: bool,
+    *,
+    lpt: cutlass.Constexpr[bool] = False,
+    l2_swizzle: cutlass.Constexpr[bool] = False,
 ) -> Tuple[Sm100FmhaStaticTileSchedulerParams, Tuple[int, int, int]]:
     """Compute grid parameters for FMHA (static scheduler).
 
@@ -1388,6 +1415,8 @@ def compute_sm100_fmha_grid(
             cute.size(o_shape[2][0]),
             cute.size(o_shape[2][1]),
         ),
+        lpt=lpt,
+        l2_swizzle=l2_swizzle,
     )
     grid = Sm100FmhaStaticTileScheduler.get_grid_shape(tile_sched_params)
     return tile_sched_params, grid

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -935,7 +935,7 @@ def test_flash_attn_varlen_output(
             and (
                 (dv == d and d <= 128)
                 or (d == 192 and dv == 128)
-                or (IS_SM100 and d == 256 and dv == 256)
+                or (IS_SM100 and d == dv == 256 and unpad_q and unpad_kv)
             )
             and not has_learnable_sink
             and softcap == 0.0 # TODO: support softcap != 0.0 in varlen bwd
@@ -1833,6 +1833,126 @@ def _generate_block_kvcache(
         b=batch_size,
     )[:, :seqlen_k]
     return k_cache, v_cache, page_table, k_cache_paged, v_cache_paged, num_blocks
+
+
+_SM100_PAGED_SEQUSED_CASES = [
+    pytest.param(False, torch.bfloat16, "mha", "noncausal", id="k-bf16-mha-noncausal"),
+    pytest.param(True, torch.float16, "gqa", "causal", id="both-fp16-gqa-causal"),
+    pytest.param(True, torch.bfloat16, "mqa", "local", id="both-bf16-mqa-local"),
+]
+
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100 2CTA hdim256-only coverage")
+@pytest.mark.parametrize(
+    "use_seqused_q,dtype,mha_type,attention_mode", _SM100_PAGED_SEQUSED_CASES
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm100_hdim256_seqused_paged_kv_fwd(
+    use_seqused_q, dtype, mha_type, attention_mode
+):
+    """Exercise seqused_k through a nontrivial page table, without backward."""
+    device = "cuda"
+    d = seqlen = 256
+    page_size = 128
+    lengths_q = torch.tensor(
+        [0, 1, 127, 128, 129, 255, 256], device=device, dtype=torch.int32
+    )
+    lengths_k = torch.tensor(
+        [256, 255, 129, 128, 127, 1, 0], device=device, dtype=torch.int32
+    )
+    batch_size, nheads = lengths_q.numel(), 4
+    nheads_kv = nheads if mha_type == "mha" else (2 if mha_type == "gqa" else 1)
+    torch.random.manual_seed(512)
+
+    q = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
+    (
+        k,
+        v,
+        page_table,
+        k_cache_paged,
+        v_cache_paged,
+        _,
+    ) = _generate_block_kvcache(
+        seqlen, page_size, batch_size, nheads_kv, d, d, device, dtype, dtype
+    )
+    num_logical_blocks = seqlen // page_size
+    page_table = page_table[:, :num_logical_blocks]
+    # Poison only logical tail positions, after translating through the page
+    # table, so an incorrect seqused_k mask is visible for paged storage too.
+    # Fake tensors do not permit the data-dependent scalar extraction below.
+    if not is_fake_mode():
+        for batch_idx, used_k in enumerate(lengths_k.tolist()):
+            for logical_block in range(num_logical_blocks):
+                tail_start = min(max(used_k - logical_block * page_size, 0), page_size)
+                physical_block = page_table[batch_idx, logical_block].item()
+                k_cache_paged[physical_block, tail_start:].fill_(4.0)
+                v_cache_paged[physical_block, tail_start:].fill_(32.0)
+
+    positions = torch.arange(seqlen, device=device)
+    query_padding_mask = positions[None, :] < lengths_q[:, None]
+    key_padding_mask = positions[None, :] < lengths_k[:, None]
+    (
+        q_unpad, _, _, _, cu_seqlens_q, _, seqused_q, seqused_k, _, _,
+        q_padded, _, _, _, output_pad_fn, *_,
+    ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask)
+    causal = attention_mode == "causal"
+    window_size = (64, 32) if attention_mode == "local" else (None, None)
+
+    out_raw, lse = flash_attn_varlen_func(
+        q_padded if use_seqused_q else q_unpad,
+        k_cache_paged,
+        v_cache_paged,
+        cu_seqlens_q=None if use_seqused_q else cu_seqlens_q,
+        seqused_q=seqused_q if use_seqused_q else None,
+        seqused_k=seqused_k,
+        max_seqlen_q=seqlen,
+        max_seqlen_k=seqlen,
+        page_table=page_table,
+        causal=causal,
+        window_size=window_size,
+        pack_gqa=False,
+        return_lse=True,
+    )
+    if is_fake_mode():
+        return
+
+    out = out_raw if use_seqused_q else output_pad_fn(out_raw)
+    ref_args = (
+        q,
+        k,
+        v,
+        query_padding_mask,
+        key_padding_mask,
+    )
+    ref_kwargs = dict(
+        causal=causal,
+        window_size=window_size,
+        return_lse=True,
+    )
+    out_ref, _, lse_ref = attention_ref(*ref_args, **ref_kwargs)
+    out_pt, _, lse_pt = attention_ref(
+        *ref_args, upcast=False, reorder_ops=True, **ref_kwargs
+    )
+
+    # Never inspect padded Q rows or their LSE entries: both are undefined.
+    active = query_padding_mask[:, :, None, None].expand_as(out)
+    check_tensor_vs_ref("out", out[active], out_ref[active], out_pt[active])
+    active_lse_mask = query_padding_mask[:, :, None].expand(-1, -1, nheads)
+    lse_active = (
+        lse.permute(0, 2, 1)[active_lse_mask]
+        if use_seqused_q
+        else lse.transpose(0, 1).reshape(-1)
+    )
+    lse_ref_active = lse_ref.permute(0, 2, 1)[active_lse_mask]
+    lse_pt_active = lse_pt.permute(0, 2, 1)[active_lse_mask]
+    finite_lse = torch.isfinite(lse_ref_active)
+    assert torch.equal(lse_active[~finite_lse], lse_ref_active[~finite_lse])
+    check_tensor_vs_ref(
+        "lse",
+        lse_active[finite_lse],
+        lse_ref_active[finite_lse],
+        lse_pt_active[finite_lse],
+    )
 
 
 @pytest.mark.skipif(not IS_SM90, reason="fp8-KV dequant forward is SM90-only")

--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -25,6 +25,7 @@ from flash_attn.cute.interface import (
 
 USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
 IS_SM90 = torch.cuda.get_device_capability()[0] == 9
+IS_SM100 = torch.cuda.get_device_capability()[0] == 10
 IS_SM120 = torch.cuda.get_device_capability()[0] == 12
 
 
@@ -287,6 +288,197 @@ def test_flash_attn_varlen_unpad_output(seqlen, d, causal, mha_type, unpad_q, un
     assert dq_in.abs().max().item() > 0, "dq is all zeros"
     assert dk_in.abs().max().item() > 0, "dk is all zeros"
     assert dv_in.abs().max().item() > 0, "dv is all zeros"
+
+# ---------------------------------------------------------------------------
+# Forward-only SM100 2CTA seqused coverage (d=dv=256)
+# ---------------------------------------------------------------------------
+
+def _assert_fwd_matches_ref(actual, reference, pytorch_reference):
+    finite = torch.isfinite(reference)
+    assert torch.equal(actual[~finite], reference[~finite])
+    if finite.any():
+        actual, reference, pytorch_reference = (
+            tensor[finite] for tensor in (actual, reference, pytorch_reference)
+        )
+        atol = 2 * (reference + 0.3 - 0.3 - reference).abs().max().item()
+        assert (actual - reference).abs().max().item() <= 2 * (
+            pytorch_reference - reference
+        ).abs().max().item() + atol
+
+_SM100_SEQUSED_CASES = [
+    pytest.param("padded", "both", torch.bfloat16, "mha", "noncausal", id="padded-boundaries"),
+    pytest.param("packed", "q", torch.float16, "gqa", "causal", id="packed-q"),
+    pytest.param("packed", "k", torch.bfloat16, "mqa", "local", id="packed-k"),
+    pytest.param("packed", "both", torch.float16, "mha", "noncausal", id="packed-both"),
+]
+
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100 2CTA hdim256-only coverage")
+@pytest.mark.parametrize(
+    "storage_mode,metadata_mode,dtype,mha_type,attention_mode", _SM100_SEQUSED_CASES
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm100_hdim256_seqused_fwd(
+    storage_mode, metadata_mode, dtype, mha_type, attention_mode
+):
+    """Exercise logical used lengths independently of physical storage lengths."""
+    device = "cuda"
+    d = seqlen = 256
+    nheads = 4
+    nheads_kv = nheads if mha_type == "mha" else (2 if mha_type == "gqa" else 1)
+    torch.random.manual_seed(256)
+
+    def lengths(values):
+        return torch.tensor(values, device=device, dtype=torch.int32)
+
+    if storage_mode == "padded":
+        physical_lengths_q = physical_lengths_k = lengths([seqlen] * 7)
+        logical_lengths_q = lengths([0, 1, 127, 128, 129, 255, 256])
+        logical_lengths_k = lengths([256, 255, 129, 128, 127, 1, 0])
+    else:
+        physical_lengths_q = lengths([256, 255, 192, 160, 144, 96, 32])
+        physical_lengths_k = lengths([32, 96, 144, 160, 192, 255, 256])
+        logical_lengths_q = (
+            lengths([255, 1, 127, 128, 129, 64, 0])
+            if metadata_mode in ("q", "both")
+            else physical_lengths_q
+        )
+        logical_lengths_k = (
+            lengths([0, 1, 127, 128, 129, 254, 255])
+            if metadata_mode in ("k", "both")
+            else physical_lengths_k
+        )
+
+    batch_size = physical_lengths_q.numel()
+    positions = torch.arange(seqlen, device=device)
+    physical_mask_q = positions[None, :] < physical_lengths_q[:, None]
+    physical_mask_k = positions[None, :] < physical_lengths_k[:, None]
+    logical_mask_q = positions[None, :] < logical_lengths_q[:, None]
+    logical_mask_k = positions[None, :] < logical_lengths_k[:, None]
+    q = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seqlen, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size, seqlen, nheads_kv, d, device=device, dtype=dtype)
+    # Make physically present but logically unused KV rows conspicuous.
+    k.masked_fill_(~logical_mask_k[:, :, None, None], 4.0)
+    v.masked_fill_(~logical_mask_k[:, :, None, None], 32.0)
+
+    (
+        q_unpad, k_unpad, v_unpad, _,
+        cu_seqlens_q, cu_seqlens_k, _, _, _, _,
+        q_padded, k_padded, v_padded, _,
+        output_pad_fn, _, _,
+    ) = generate_qkv(q, k, v, physical_mask_q, physical_mask_k)
+
+    packed = storage_mode == "packed"
+    use_seqused_q = metadata_mode in ("q", "both")
+    use_seqused_k = metadata_mode in ("k", "both")
+    causal = attention_mode == "causal"
+    window_size = (64, 32) if attention_mode == "local" else (None, None)
+    out_buffer = (
+        torch.empty(
+            batch_size * seqlen * nheads * d + 1, device=device, dtype=dtype
+        )[1:].view(batch_size, seqlen, nheads, d)
+        if not packed
+        else None
+    )
+    out_raw, lse = flash_attn_varlen_func(
+        q_unpad if packed else q_padded,
+        k_unpad if packed else k_padded,
+        v_unpad if packed else v_padded,
+        cu_seqlens_q=cu_seqlens_q if packed else None,
+        cu_seqlens_k=cu_seqlens_k if packed else None,
+        seqused_q=logical_lengths_q if use_seqused_q else None,
+        seqused_k=logical_lengths_k if use_seqused_k else None,
+        max_seqlen_q=seqlen,
+        max_seqlen_k=seqlen,
+        causal=causal,
+        window_size=window_size,
+        pack_gqa=False,
+        out=out_buffer,
+        return_lse=True,
+    )
+    if is_fake_mode():
+        return
+
+    out = output_pad_fn(out_raw) if packed else out_raw
+    lse_padded = output_pad_fn(lse.transpose(0, 1)) if packed else lse.permute(0, 2, 1)
+    ref_args = (q, k, v, logical_mask_q, logical_mask_k)
+    ref_kwargs = dict(causal=causal, window_size=window_size, return_lse=True)
+    out_ref, _, lse_ref = attention_ref(*ref_args, **ref_kwargs)
+    out_pt, _, lse_pt = attention_ref(
+        *ref_args, upcast=False, reorder_ops=True, **ref_kwargs
+    )
+
+    # Used-length tails are undefined for both padded and packed storage.
+    active = logical_mask_q[:, :, None, None].expand_as(out)
+    _assert_fwd_matches_ref(out[active], out_ref[active], out_pt[active])
+    lse_mask = logical_mask_q[:, :, None].expand(-1, -1, nheads)
+    _assert_fwd_matches_ref(
+        lse_padded[lse_mask],
+        lse_ref.permute(0, 2, 1)[lse_mask],
+        lse_pt.permute(0, 2, 1)[lse_mask],
+    )
+
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100 2CTA hdim256-only coverage")
+@pytest.mark.parametrize(
+    "use_seqused_k",
+    [True, False],
+    ids=["padded-seqused-k", "dense-no-metadata"],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm100_hdim256_causal_empty_prefix_fwd(use_seqused_k):
+    """Cover bottom-right causal rows with no keys, with and without seqused."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size, seqlen_q, seqlen_k_used = 1, 2048, 1024
+    seqlen_k = seqlen_q if use_seqused_k else seqlen_k_used
+    nheads, d = 1, 256
+    torch.random.manual_seed(256)
+
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype)
+    seqused_k = (
+        torch.full((batch_size,), seqlen_k_used, device=device, dtype=torch.int32)
+        if use_seqused_k
+        else None
+    )
+    key_padding_mask = torch.arange(seqlen_k, device=device)[None, :] < seqlen_k_used
+    k.masked_fill_(~key_padding_mask[:, :, None, None], 4.0)
+    v.masked_fill_(~key_padding_mask[:, :, None, None], 32.0)
+
+    out, lse = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        seqused_k=seqused_k,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_k,
+        causal=True,
+        pack_gqa=False,
+        return_lse=True,
+    )
+    if is_fake_mode():
+        return
+
+    empty_rows = seqlen_q - seqlen_k_used
+    assert torch.equal(out[:, :empty_rows], torch.zeros_like(out[:, :empty_rows]))
+    assert torch.equal(
+        lse[:, :, :empty_rows],
+        torch.full_like(lse[:, :, :empty_rows], float("-inf")),
+    )
+
+    ref_args = (q, k, v, None, key_padding_mask)
+    ref_kwargs = dict(causal=True, return_lse=True)
+    out_ref, _, lse_ref = attention_ref(*ref_args, **ref_kwargs)
+    out_pt, _, lse_pt = attention_ref(
+        *ref_args, upcast=False, reorder_ops=True, **ref_kwargs
+    )
+    _assert_fwd_matches_ref(
+        out[:, empty_rows:], out_ref[:, empty_rows:], out_pt[:, empty_rows:]
+    )
+    _assert_fwd_matches_ref(lse, lse_ref, lse_pt)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -375,9 +375,7 @@ def test_flash_attn_sm100_hdim256_seqused_fwd(
     causal = attention_mode == "causal"
     window_size = (64, 32) if attention_mode == "local" else (None, None)
     out_buffer = (
-        torch.empty(
-            batch_size * seqlen * nheads * d + 1, device=device, dtype=dtype
-        )[1:].view(batch_size, seqlen, nheads, d)
+        torch.empty(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
         if not packed
         else None
     )
@@ -418,6 +416,47 @@ def test_flash_attn_sm100_hdim256_seqused_fwd(
         lse_ref.permute(0, 2, 1)[lse_mask],
         lse_pt.permute(0, 2, 1)[lse_mask],
     )
+
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100 1CTA hdim256 odd-tile coverage")
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm100_hdim256_1cta_causal_odd_q_tiles_fwd():
+    """Cover 1CTA causal scheduling when the Q tile count is odd."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size, seqlen, nheads, d = 1, 384, 1, 256
+    torch.random.manual_seed(256)
+
+    q = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
+    seqused_q = torch.full(
+        (batch_size,), seqlen, device=device, dtype=torch.int32
+    )
+    out_buffer = torch.full_like(q, float("nan"))
+
+    out, _ = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        seqused_q=seqused_q,
+        max_seqlen_q=seqlen,
+        max_seqlen_k=seqlen,
+        causal=True,
+        pack_gqa=False,
+        out=out_buffer,
+    )
+    if is_fake_mode():
+        return
+
+    assert torch.isfinite(out).all(dim=-1).all()
+    ref_args = (q, k, v, None, None)
+    ref_kwargs = dict(causal=True)
+    out_ref, _ = attention_ref(*ref_args, **ref_kwargs)
+    out_pt, _ = attention_ref(
+        *ref_args, upcast=False, reorder_ops=True, **ref_kwargs
+    )
+    _assert_fwd_matches_ref(out, out_ref, out_pt)
 
 
 @pytest.mark.skipif(not IS_SM100, reason="SM100 2CTA hdim256-only coverage")

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -1,9 +1,13 @@
 from typing import Optional
+
 import pytest
 
 import torch
 import torch.nn.functional as F
 from flash_attn.cute import flash_attn_varlen_func
+
+IS_SM100 = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
 
 @pytest.mark.parametrize("B", [1, 7, 20])
 @pytest.mark.parametrize("H", [1, 4, 6])
@@ -47,6 +51,67 @@ def test_varlen(
         mha_type=mha_type,
     )
     assert ok
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100 hd256-only regression")
+@pytest.mark.parametrize(
+    "k_lengths",
+    [
+        pytest.param((256, 129), id="full-then-residual"),
+        pytest.param((129, 256), id="residual-then-full"),
+    ],
+)
+def test_sm100_hd256_dense_q_packed_k_masks_residual(k_lengths):
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size, seqlen_q, nheads, head_dim = 2, 256, 1, 256
+    value_per_sequence = (1.0, 4.0)
+
+    q = torch.zeros(
+        batch_size, seqlen_q, nheads, head_dim, device=device, dtype=dtype
+    )
+    k = torch.zeros(
+        sum(k_lengths), nheads, head_dim, device=device, dtype=dtype
+    )
+    v = torch.cat(
+        [
+            torch.full(
+                (length, nheads, head_dim),
+                value,
+                device=device,
+                dtype=dtype,
+            )
+            for length, value in zip(k_lengths, value_per_sequence)
+        ]
+    )
+    cu_seqlens_k = torch.tensor(
+        [0, k_lengths[0], sum(k_lengths)],
+        device=device,
+        dtype=torch.int32,
+    )
+
+    out, _ = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=256,
+        max_seqlen_k=256,
+        causal=False,
+    )
+
+    reference = torch.stack(
+        [
+            torch.full(
+                (seqlen_q, nheads, head_dim),
+                value,
+                device=device,
+                dtype=dtype,
+            )
+            for value in value_per_sequence
+        ]
+    )
+    torch.testing.assert_close(out, reference, atol=1e-2, rtol=1e-2)
+
 
 def check_varlen_vs_torch_flash(
     q, k, v,


### PR DESCRIPTION
## Summary

This PR improves SM100/SM110 forward path where two thread blocks cooperate when `head_dim == head_dim_v == 256`.

## What changed

- **Scheduling:** Fixed-length and batch-1 variable-length inputs assign output tiles directly; packed variable-length batches with multiple sequences dispatch one tile at a time. On SM100, two blocks cooperate and process longer query tiles first, while eligible causal batch-1 cases reorder heads for L2 cache use.
- **K/V loading:** K and V use separate four-stage asynchronous load pipelines with their own barriers and byte counts, explicit release ordering, and tensor-memory views created only after allocation is visible to the consuming warp.
- **Output writes:** Output correction reuses Q shared memory and writes aligned 128-bit values with row bounds checks when the pointer and stride meet the 16-byte alignment contract; otherwise it uses the safe fallback.
- **Boundary checks:** The Q/K boundary check is skipped only when `cu_seqlens_q`, `seqused_q`, and `page_table` are absent, `max_seqlen_q == max_seqlen_k`, and `max_seqlen_q` is divisible by 256. All other variants keep it; causal masking is unchanged.
- **Cache isolation:** hd256 cache keys cover output alignment, batch-1 variable-length scheduling, L2 head reordering, and whether the boundary check remains. Other dimensions' keys are unchanged.

## Performance

Measured on one NVIDIA B200 (SM100) with BF16 causal forward attention, equal Q/KV lengths, and `num_splits=1`. Fixed-length inputs use full-length sequences; packed variable-length inputs repeat and truncate `[M, M/2, M/4, M/8]` to the batch size. hd128 uses 16 heads and hd256 uses 8, preserving model width and matched-case FLOP counts. Values are TFLOP/s; `hd256 speedup` is final hd256 divided by baseline hd256.

### Fixed length

| B | S | Baseline hd128 | Baseline hd256 | Baseline hd256/hd128 | Final hd128 | Final hd256 | Final hd256/hd128 | hd256 speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 4,096 | 1032.9 | 427.4 | 0.414x | 1032.9 | 1099.6 | 1.065x | 2.57x |
| 1 | 8,192 | 1183.0 | 753.9 | 0.637x | 1192.9 | 1248.9 | 1.047x | 1.66x |
| 1 | 16,384 | 1269.1 | 1019.7 | 0.803x | 1271.5 | 1374.0 | 1.081x | 1.35x |
| 1 | 32,768 | 1321.5 | 1231.7 | 0.932x | 1320.7 | 1442.2 | 1.092x | 1.17x |
| 32 | 4,096 | 1067.3 | 613.4 | 0.575x | 1070.5 | 1103.6 | 1.031x | 1.80x |
| 32 | 8,192 | 1201.7 | 859.8 | 0.715x | 1168.5 | 1236.1 | 1.058x | 1.44x |
| 32 | 16,384 | 1267.9 | 1079.1 | 0.851x | 1264.9 | 1360.0 | 1.075x | 1.26x |
| 32 | 32,768 | 1300.9 | 1240.3 | 0.953x | 1303.5 | 1412.4 | 1.084x | 1.14x |
| 128 | 4,096 | 1055.9 | 610.9 | 0.579x | 1042.3 | 1118.5 | 1.073x | 1.83x |
| 128 | 8,192 | 1173.9 | 841.8 | 0.717x | 1179.9 | 1246.0 | 1.056x | 1.48x |
| 128 | 16,384 | 1250.8 | 1067.0 | 0.853x | 1242.9 | 1341.5 | 1.079x | 1.26x |
| 128 | 32,768 | 1290.5 | 1232.3 | 0.955x | 1290.4 | 1404.1 | 1.088x | 1.14x |
| 256 | 4,096 | 1039.7 | 594.8 | 0.572x | 1048.3 | 1075.3 | 1.026x | 1.81x |
| 256 | 8,192 | 1162.3 | 834.2 | 0.718x | 1161.3 | 1241.9 | 1.069x | 1.49x |
| 256 | 16,384 | 1242.7 | 1061.3 | 0.854x | 1241.5 | 1339.4 | 1.079x | 1.26x |
| 256 | 32,768 | 1284.7 | 1230.8 | 0.958x | 1289.1 | 1399.8 | 1.086x | 1.14x |
| **Overall GM** | — | **1192.6** | **878.2** | **0.736x** | **1191.0** | **1271.8** | **1.068x** | **1.45x** |

### Packed variable length

| B | M | Baseline hd128 | Baseline hd256 | Baseline hd256/hd128 | Final hd128 | Final hd256 | Final hd256/hd128 | hd256 speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 4,096 | 989.0 | 425.2 | 0.430x | 988.8 | 1062.9 | 1.075x | 2.50x |
| 1 | 8,192 | 1147.5 | 735.3 | 0.641x | 1127.6 | 1198.3 | 1.063x | 1.63x |
| 1 | 16,384 | 1216.0 | 990.8 | 0.815x | 1229.6 | 1364.3 | 1.110x | 1.38x |
| 1 | 32,768 | 1270.0 | 1194.7 | 0.941x | 1283.9 | 1401.4 | 1.091x | 1.17x |
| 32 | 4,096 | 902.6 | 225.6 | 0.250x | 919.0 | 940.3 | 1.023x | 4.17x |
| 32 | 8,192 | 1096.9 | 407.0 | 0.371x | 1081.7 | 1125.3 | 1.040x | 2.76x |
| 32 | 16,384 | 1193.1 | 682.4 | 0.572x | 1194.3 | 1260.2 | 1.055x | 1.85x |
| 32 | 32,768 | 1262.9 | 930.9 | 0.737x | 1261.4 | 1346.3 | 1.067x | 1.45x |
| 128 | 4,096 | 877.5 | 88.9 | 0.101x | 891.0 | 889.9 | 0.999x | 10.01x |
| 128 | 8,192 | 1061.6 | 169.8 | 0.160x | 1062.8 | 1105.2 | 1.040x | 6.51x |
| 128 | 16,384 | 1190.5 | 312.5 | 0.263x | 1180.2 | 1252.4 | 1.061x | 4.01x |
| 128 | 32,768 | 1258.2 | 542.1 | 0.431x | 1251.2 | 1345.8 | 1.076x | 2.48x |
| 256 | 4,096 | 864.5 | 49.3 | 0.057x | 856.9 | 856.3 | 0.999x | 17.37x |
| 256 | 8,192 | 1039.5 | 96.0 | 0.092x | 1037.4 | 1070.6 | 1.032x | 11.15x |
| 256 | 16,384 | 1166.9 | 182.8 | 0.157x | 1170.9 | 1229.0 | 1.050x | 6.72x |
| 256 | 32,768 | 1246.7 | 334.9 | 0.269x | 1247.8 | 1331.4 | 1.067x | 3.98x |
| **Overall GM** | — | **1102.6** | **325.7** | **0.295x** | **1102.8** | **1160.8** | **1.053x** | **3.56x** |

## Reproduction

On the same B200 and software stack, save this script as `/tmp/bench.py`. Fixed-length cases use the `do_bench` median and packed cases its mean; both take the median of three calls.

```python
import gc
import statistics
from itertools import accumulate

import torch
from triton.testing import do_bench

from flash_attn.cute import flash_attn_func, flash_attn_varlen_func
from flash_attn.cute.bench_utils import flops

BATCHES = (1, 32, 128, 256)
SEQLENS = (4096, 8192, 16384, 32768)
HEADS = {128: 16, 256: 8}

torch.manual_seed(0)
torch.cuda.manual_seed_all(0)

for kind in ("fixed", "varlen"):
    results = {batch: {128: [], 256: []} for batch in BATCHES}
    for batch in BATCHES:
        for seqlen in SEQLENS:
            pattern = [seqlen, seqlen // 2, seqlen // 4, seqlen // 8]
            lengths = [seqlen] * batch if kind == "fixed" else (pattern * batch)[:batch]
            for headdim, nheads in HEADS.items():
                shape = (
                    (batch, seqlen, nheads, headdim)
                    if kind == "fixed"
                    else (sum(lengths), nheads, headdim)
                )
                q, k, v = [
                    torch.randn(shape, device="cuda", dtype=torch.bfloat16)
                    for _ in range(3)
                ]
                out = torch.empty_like(q)
                if kind == "fixed":
                    run = lambda: flash_attn_func(
                        q, k, v, causal=True, num_splits=1,
                        softmax_scale=headdim**-0.5, out=out,
                    )
                else:
                    cu = torch.tensor(
                        [0, *accumulate(lengths)], device="cuda", dtype=torch.int32
                    )
                    run = lambda: flash_attn_varlen_func(
                        q, k, v, cu_seqlens_q=cu, cu_seqlens_k=cu,
                        max_seqlen_q=seqlen, max_seqlen_k=seqlen,
                        causal=True, num_splits=1,
                        softmax_scale=headdim**-0.5, out=out,
                    )
                run()
                torch.cuda.synchronize()
                return_mode = "median" if kind == "fixed" else "mean"
                ms = statistics.median(
                    do_bench(
                        run, warmup=25, rep=100, return_mode=return_mode
                    )
                    for _ in range(3)
                )
                ops = sum(
                    flops(
                        batch=1, nheads=nheads, seqlen_q=n, seqlen_k=n,
                        headdim=headdim, headdim_v=headdim, causal=True,
                    )
                    for n in lengths
                )
                tflops = ops / ms / 1e9
                results[batch][headdim].append(tflops)
                print(kind, f"B={batch}", f"S/M={seqlen}", f"hd{headdim}", f"{tflops:.1f} TFLOP/s")
                del q, k, v, out, run
                if kind == "varlen":
                    del cu
                gc.collect()
                torch.cuda.empty_cache()
    for batch in BATCHES:
        for headdim in HEADS:
            gm = statistics.geometric_mean(results[batch][headdim])
            print(kind, f"B={batch}", f"hd{headdim} GM: {gm:.1f} TFLOP/s")
        ratio = statistics.geometric_mean(
            x / y
            for x, y in zip(results[batch][256], results[batch][128], strict=True)
        )
        print(kind, f"B={batch}", f"hd256/hd128 GM: {ratio:.3f}x")
    for headdim in HEADS:
        values = [x for batch in BATCHES for x in results[batch][headdim]]
        print(kind, f"overall hd{headdim} GM: {statistics.geometric_mean(values):.1f} TFLOP/s")
    overall_ratio = statistics.geometric_mean(
        x / y
        for batch in BATCHES
        for x, y in zip(results[batch][256], results[batch][128], strict=True)
    )
    print(kind, f"overall hd256/hd128 GM: {overall_ratio:.3f}x")
```

Run it in detached worktrees with revision-local `flash-attn-4` environments and separate compile caches:

```bash
git worktree add --detach /tmp/fa4-baseline 617264c1c7955c9e84817654ebeedff069f3c5f1
git worktree add --detach /tmp/fa4-head 23a983510c1c41672493e1bccd99f0fdf6277def

FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 \
FLASH_ATTENTION_CUTE_DSL_CACHE_DIR=/tmp/fa4-cache-617264c1c7955c9e84817654ebeedff069f3c5f1 \
chg run -- uv run --prerelease=allow --project /tmp/fa4-baseline/flash_attn/cute --extra cu13 --with triton python /tmp/bench.py \
  | tee /tmp/fa4-617264c1c7955c9e84817654ebeedff069f3c5f1.txt

FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 \
FLASH_ATTENTION_CUTE_DSL_CACHE_DIR=/tmp/fa4-cache-23a983510c1c41672493e1bccd99f0fdf6277def \
chg run -- uv run --prerelease=allow --project /tmp/fa4-head/flash_attn/cute --extra cu13 --with triton python /tmp/bench.py \
  | tee /tmp/fa4-23a983510c1c41672493e1bccd99f0fdf6277def.txt
```

## Validation / scope

- The dedicated path uses fixed 128x128 tiles; backward is unchanged.
- Unsupported: `score_mod`, `mask_mod`, auxiliary tensors or scalars, softcap, block sparsity, learnable sinks, `seqused_q`/`seqused_k`, local attention or runtime windows, descale tensors, `pack_gqa`, SplitKV, and `q_subtile_factor`.
- Fused FP8 output remains rejected.
- Paged KV requires page size 128 for asynchronous transfers and exact `max_seqlen_k` and page-table shapes.
- Head work blocks are reordered for L2 cache use only for causal, nonlocal, nonpaged batch-1 workloads with no `seqused_q`, `qhead_per_kvhead == 1`, and maximum Q/K lengths `<=8192`. Eligible variable-length workloads may use `cu_seqlens_q/k`; other dedicated-kernel workloads use direct mapping.

