### PR TITLE
[SM100] hd256 2CTA fwd: add missing tcgen05.wait::ld before TMEM slot…

### DIFF
--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -1854,6 +1854,8 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         scale = scale_softmax_log2 * (tTMEM_LOADrStats[0] - tTMEM_LOADrStats[1])
         scale = cute.math.exp2(scale, fastmath=True)
+        # tcgen05.wait::ld: loads must complete before the slot is released
+        cute.arch.fence_view_async_tmem_load()
         stats_handle.release()
         o_handle = mma_o_consumer.wait_and_advance()
         for iter in cutlass.range(self.iterations_pv, unroll_full=True):
@@ -1886,6 +1888,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             tTMEM_LOADtO_0 = tTMEM_LOADtO[None, 0, 0]
             cute.copy(tmem_tiled_load, tTMEM_LOADtO_0, tTMrO[None, 0])
             iter_num = cute.size(tTMEM_LOADtO, mode=[1])
+            # No tcgen05.wait::ld needed in this ld -> scale -> st ring: the st to tile i-1
+            # consumes every register the ld of tile i-1 produced, so that load has completed.
             for i in cutlass.range(1, iter_num, unroll_full=True):
                 tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
                 cute.copy(tmem_tiled_load, tTMEM_LOADtO_i, tTMrO[None, i % 2])
@@ -1913,6 +1917,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                 tTMEM_STOREtO[None, iter_num - 1, 0],
             )
         cute.arch.fence_view_async_tmem_store()
+        # tcgen05.wait::ld: loads must complete before the slot is released
+        cute.arch.fence_view_async_tmem_load()
         o_handle.release()
         return mma_o_consumer, s_corr_consumer
 
@@ -1956,6 +1962,9 @@ class BlackwellFusedMultiHeadAttentionForward:
                 tTMEM_LOADsO_i = tTMEM_LOADsO[None, i, 0]
                 tTMrO = cute.make_rmem_tensor(tTMEM_LOADsO[None, 0, i].shape, self.pv_acc_dtype)
                 cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
+                # tcgen05.wait::ld: load must complete before the O slot is released
+                # (register use alone does not order the TMEM read)
+                cute.arch.fence_view_async_tmem_load()
                 for j in cutlass.range(0, cute.size(tTMrO), 2, unroll_full=True):
                     tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
                         (tTMrO[j], tTMrO[j + 1]),

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -24,7 +24,6 @@ from flash_attn.cute.tile_scheduler import (
 from flash_attn.cute.mask import (
     Sm100FusedMask as FusedMask,
 )
-from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _TUNING_CONFIG
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
@@ -119,7 +118,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.mma_warp_id = 8
         self.load_warp_id = 9
         self.empty_warp_id = (10, 11)
-        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+        self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
 
         self.threads_per_warp = 32
         self.threads_per_cta = self.threads_per_warp * len(
@@ -431,11 +430,11 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
         self.o_layout = utils.LayoutEnum.from_tensor(o)
 
-        if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
+        if cutlass.const_expr(self.q_major_mode != cute.nvgpu.OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
-        if cutlass.const_expr(self.k_major_mode != tcgen05.OperandMajorMode.K):
+        if cutlass.const_expr(self.k_major_mode != cute.nvgpu.OperandMajorMode.K):
             raise RuntimeError("The layout of k is not supported")
-        if cutlass.const_expr(self.v_major_mode != tcgen05.OperandMajorMode.MN):
+        if cutlass.const_expr(self.v_major_mode != cute.nvgpu.OperandMajorMode.MN):
             raise RuntimeError("The layout of v is not supported")
 
         # check type consistency
@@ -448,9 +447,10 @@ class BlackwellFusedMultiHeadAttentionForward:
         cta_group = tcgen05.CtaGroup.TWO if self.use_2cta else tcgen05.CtaGroup.ONE
         # the intermediate tensor p is from tmem & k-major
         p_source = tcgen05.OperandSource.TMEM
-        p_major_mode = tcgen05.OperandMajorMode.K
+        p_major_mode = cute.nvgpu.OperandMajorMode.K
         qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.q_dtype,
+            self.k_dtype,
             self.q_major_mode,
             self.k_major_mode,
             self.qk_acc_dtype,
@@ -458,6 +458,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             self.qk_mma_tiler[:2],
         )
         pv_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
             self.v_dtype,
             p_major_mode,
             self.v_major_mode,
@@ -827,7 +828,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         # ///////////////////////////////////////////////////////////////////////////////
         for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
             if warp_idx == self.empty_warp_id[_i]:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+                cute.arch.setmaxregister_decrease(self.num_regs_other)
 
         if cutlass.const_expr(TileScheduler is SingleTileVarlenScheduler):
             tile_sched = TileScheduler.create(
@@ -889,7 +890,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  LOAD
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.load_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
             if cutlass.const_expr(has_seqused):
                 sTripLoad = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
             while work_tile.is_valid_tile:
@@ -1105,7 +1106,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         if warp_idx == self.mma_warp_id:
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
             if cutlass.const_expr(has_seqused):
                 sTripMma = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
 
@@ -1349,7 +1350,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, _ = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
             # increase register after decreasing
-            cute.arch.warpgroup_reg_alloc(self.num_regs_softmax)
+            cute.arch.setmaxregister_increase(self.num_regs_softmax)
             if cutlass.const_expr(has_seqused):
                 sTripSoftmax = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
 
@@ -1469,7 +1470,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, tOtO_staged = self.get_tmem_views(qk_thr_mma, pv_thr_mma)
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_correction)
+            cute.arch.setmaxregister_decrease(self.num_regs_correction)
             if cutlass.const_expr(has_seqused):
                 sTripCorrection = storage.trip_start_count_smem.get_tensor(cute.make_layout(2))
 
@@ -1584,7 +1585,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  Empty warps reg dealloc
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx > self.load_warp_id:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+                cute.arch.setmaxregister_decrease(self.num_regs_other)
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  Cooperative TMEM Deallocation


### PR DESCRIPTION
# [SM100] hd256 2CTA fwd: missing `tcgen05.wait::ld` before TMEM slot releases

Followup to https://github.com/vllm-project/flash-attention/pull/180.
The issue described above was already present in the kernel that we performance tuned in above PR, however only during further perf tuning i discovered this minor inconsistency with PTX docs.

---

`tcgen05.ld` is asynchronous. Consuming its destination registers is ordered by the register
scoreboard; the load's TMEM read is not ordered against a later TMEM writer. PTX ISA 9.7.17.6.4.5:
"a register dependency does not imply that a dependee instruction's memory accesses will be
performed before a dependent instruction's memory accesses … `tcgen05.wait::ld` must be used."
Required producer pattern (9.7.17.6.4.4): `tcgen05.ld → tcgen05.wait::ld → mbarrier.arrive`.

Three releases in `sm100_hd256_2cta_fmha_forward.py` skipped the wait:

| site | load | release |
|---|---|---|
| `correction_epilog` O tile | `Ld32x32bOp(32)` ×4 | `o_handle.release()` → MMA warp overwrites O |
| `correction_rescale` stats | `Ld32x32bOp(2)` | `stats_handle.release()` → softmax warp `tcgen05.st` |
| `correction_rescale` O | ld/st ring | `o_handle.release()` → MMA warp overwrites O |

The softmax warp's S-tile release already had the wait.

## Fix

`cute.arch.fence_view_async_tmem_load()` (`tcgen05.wait::ld.sync.aligned`) before each release.

The ld→scale→st ring inside `correction_rescale` is left alone: the `st` to tile i-1 consumes
every register the `ld` of tile i-1 produced, so that read has completed before the store issues.
CUTLASS `77_blackwell_fmha` uses the same ring without a wait.

## Evidence

B300, sm_103a. `tcgen05.wait::ld` in kernel PTX: 1 → 7; ld/st/mma counts unchanged.

**`correction_epilog`** before:
```
tcgen05.ld.sync.aligned.32x32b.x32.b32 {%r3622, ...}, [...];
mul.rn.f32x2 ...
st.shared.v4.b32 ...
bar.sync 2, 128;
mbarrier.arrive.shared::cluster.b64 _, [%r3710], %r3711;   // o_handle.release()
```
after: `tcgen05.wait::ld.sync.aligned;` follows each of the four loads.

**`correction_rescale` stats** before — ptxas issues the arrive ahead of the scoreboard wait:
```
tcgen05.ld.sync.aligned.32x32b.x2.b32 {%r2785, %r2786}, [%r2784];
sub.f32 / mul.f32 / ex2.approx.ftz.f32
mbarrier.arrive.shared.b64 %rd1219, [%r2780+240], %r2792;   // stats_handle.release()

LDTM.x2 R4, tmem[UR4+0x40] ;                        wbar=SB0
SYNCS.ARRIVE.TRANS64.A1T0 RZ, [R3+URZ+0xf0], RZ ;   waitmask=000000
FADD R4, R4, -R5 ;                                  waitmask=000001
```
after:
```
ex2.approx.ftz.f32 %r2791, %r2790;
tcgen05.wait::ld.sync.aligned;
mbarrier.arrive.shared.b64 %rd1219, [%r2780+240], %r2792;

LDTM.x2 R4, tmem[UR4+0x40] ;                        wbar=SB0
SYNCS.ARRIVE.TRANS64.A1T0 RZ, [R3+URZ+0xf0], RZ ;   waitmask=010001
```

**`correction_rescale` O release** after:
```
tcgen05.wait::st.sync.aligned;
tcgen05.wait::ld.sync.aligned;
mbarrier.arrive.shared::cluster.b64 _, [%r170], %r2792;
```
No SASS change here — the ring's register chain had already retired the loads.

## Benchmark

Local Benchmark was run and performance stays invariant under above changes.