### PR TITLE
[SM103/SM100] Further HDim 256 Optimization

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -91,6 +91,8 @@ _TUNING_CONFIG = {
     (False, True, 192, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 72},
     (True, False, 256, False): {"ex2_emu_freq": 14, "ex2_emu_res": 6, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
     (True, True, 256, False): {"ex2_emu_freq": 14, "ex2_emu_res": 6, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
+    (True, False, 256, True): {"ex2_emu_freq": 0, "ex2_emu_res": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
+    (True, True, 256, True): {"ex2_emu_freq": 0, "ex2_emu_res": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
 }
 _FP8_TUNING_CONFIG = {
     (True, False, 128, False): {'ex2_emu_freq': 10, 'ex2_emu_start_frg': 1, 'num_regs_softmax': 160, 'num_regs_correction': 72},

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -789,6 +789,18 @@ def _flash_attn_fwd(
                 or (causal and max_seqlen_q <= 2048 and max_seqlen_k <= 2048)
             )
         )
+        hd256_clc = (
+            cu_seqlens_q is not None
+            and not hd256_varlen_b1
+            and causal
+            and not local
+            and seqused_q is None
+            and seqused_k is None
+            and page_table is None
+            and hd256_use_2cta
+            and max_seqlen_q <= 4096
+            and max_seqlen_k <= 4096
+        )
 
     if softcap is not None:
         assert score_mod is None, "softcap and score_mod cannot be used together"
@@ -967,6 +979,7 @@ def _flash_attn_fwd(
             hd256_l2_swizzle,
             hd256_mask_residual,
             hd256_use_2cta,
+            hd256_clc,
         )
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
@@ -1151,6 +1164,7 @@ def _flash_attn_fwd(
                         l2_swizzle=hd256_l2_swizzle,
                         mask_residual=hd256_mask_residual,
                         use_2cta=hd256_use_2cta,
+                        use_clc_scheduler=hd256_clc,
                     )
                 else:
                     fa_fwd = FlashAttentionForwardSm100(

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -12,9 +12,14 @@ import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32, Int64, Float32
+from cutlass.utils import ClcDynamicPersistentTileScheduler
+from cutlass.base_dsl.arch import Arch
+from cutlass.cutlass_dsl import BaseDSL
 
 from cutlass.cute import FastDivmodDivisor
 from flash_attn.cute.tile_scheduler import (
+    ClcState,
+    SchedulingMode,
     TileSchedulerArguments,
     SingleTileVarlenScheduler,
     compute_sm100_fmha_grid as compute_grid,
@@ -59,6 +64,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         l2_swizzle: bool = False,
         mask_residual: bool = True,
         use_2cta: bool = True,
+        use_clc_scheduler: bool = False,
     ):
         head_dim_v = head_dim if head_dim_v is None else head_dim_v
         assert head_dim == 256 and head_dim_v == 256, (
@@ -108,14 +114,26 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.iterations_pv = self.cta_tiler[2] // self.pv_mma_tiler[1]
         self.cluster_shape_mn = (cluster_size_m, 1)
         self.tmem_warp_shape_mn = (4, 1)
-        # Dedicated hd256 kernel uses fixed scheduling policy.
+        # Dedicated hd256 uses a static scheduler except for the selected short
+        # causal-varlen path, where Cluster Launch Control makes it persistent.
         self.is_persistent = False
         self.is_causal = is_causal
         self.is_local = is_local
         self.mask_mod = mask_mod
         self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
         self.use_semantic_trip_range = is_causal or is_local
-        self.use_clc_scheduler = False
+        self.use_clc_scheduler = use_clc_scheduler
+        if use_clc_scheduler:
+            assert self.cluster_shape_mn[1] == 1, (
+                f"CLC requires cluster N == 1: {self.cluster_shape_mn}"
+            )
+            assert self.cluster_shape_mn[0] in (1, 2), (
+                f"bad CLC cluster M: {self.cluster_shape_mn}"
+            )
+        self.scheduling_mode = (
+            SchedulingMode.CLC if use_clc_scheduler else SchedulingMode.STATIC
+        )
+        self.sched_stages = 1
 
         self.is_varlen_b1 = is_varlen_b1
         self.l2_swizzle = l2_swizzle
@@ -126,6 +144,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.mma_warp_id = 8
         self.load_warp_id = 9
         self.empty_warp_id = (10, 11)
+        self.clc_scheduler_warp_id = self.empty_warp_id[0] if use_clc_scheduler else None
         self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
 
         self.threads_per_warp = 32
@@ -148,7 +167,9 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.tmem_p_offset = self.tmem_s_offset
 
         # Reuse the established hd256 math/register tuning for both CTA-group forms.
-        _tune_key = (True, is_causal, 256, False)
+        self.arch = BaseDSL._get_dsl().get_arch_enum()
+        self.is_sm103 = self.arch.is_family_of(Arch.sm_103f)
+        _tune_key = (True, is_causal, 256, self.is_sm103)
         _tune = _TUNING_CONFIG.get(_tune_key, {})
         self.num_regs_softmax = _tune.get("num_regs_softmax", 256)
         self.num_regs_correction = _tune.get("num_regs_correction", 160)
@@ -207,6 +228,13 @@ class BlackwellFusedMultiHeadAttentionForward:
         assert descale_tensors is None, (
             "SM100 forward with head_dim=256 does not support descale_tensors"
         )
+        if cutlass.const_expr(self.use_clc_scheduler):
+            assert mCuSeqlensQ is not None and not self.is_varlen_b1, (
+                "SM100 hd256 CLC scheduling requires the varlen (non-b1) tile scheduler"
+            )
+            assert mSeqUsedQ is None and mSeqUsedK is None, (
+                "SM100 hd256 CLC scheduling does not support seqused_q/seqused_k"
+            )
 
         q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, assume_tensor_aligned(mO)
         lse_tensor = mLSE
@@ -423,8 +451,13 @@ class BlackwellFusedMultiHeadAttentionForward:
                 nested_mbh_coord=True,
                 is_persistent=False,
                 lpt=False,
+                m_block_slowest=(
+                    self.use_clc_scheduler and self.is_causal and not self.is_local
+                ),
             )
-            self.tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+            self.tile_sched_params = TileScheduler.to_underlying_arguments(
+                tile_sched_args, scheduling_mode=self.scheduling_mode
+            )
             grid = TileScheduler.get_grid_shape(self.tile_sched_params)
         else:
             TileScheduler = FmhaStaticTileScheduler
@@ -575,6 +608,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.tma_copy_k_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
         self.tma_copy_v_bytes = v_copy_size * cute.size(pv_tiled_mma.thr_id.shape)
         trip_start_count_smem_size = 2 if mSeqUsedQ is not None or mSeqUsedK is not None else 0
+        clc_mbar_size = self.sched_stages * 2 if self.use_clc_scheduler else 0
+        clc_response_size = self.sched_stages * 4 if self.use_clc_scheduler else 0
 
         @cute.struct
         class SharedStorage:
@@ -599,10 +634,14 @@ class BlackwellFusedMultiHeadAttentionForward:
             mma_corr_mbar_ptr: cute.struct.MemRange[
                 Int64, self.mma_corr_stage * 2
             ]  # mma_corr_{producer,consumer}
+            clc_mbar_ptr: cute.struct.MemRange[Int64, clc_mbar_size]
             # A CTA-wide "TMEM lifetime" barrier used to safely deallocate TMEM after all users finish.
             tmem_dealloc_mbar: Int64
             # Tmem holding buffer
             tmem_holding_buf: Int32
+            clc_response: cute.struct.Align[
+                cute.struct.MemRange[Int32, clc_response_size], 16
+            ]
             trip_start_count_smem: cute.struct.MemRange[Int32, trip_start_count_smem_size]
 
         self.shared_storage = SharedStorage
@@ -809,10 +848,18 @@ class BlackwellFusedMultiHeadAttentionForward:
             swizzle=q_smem_layout_staged.inner,
             byte_alignment=128,
         )
-        sO = cute.make_tensor(
-            cute.recast_ptr(sQ.iterator, o_smem_layout_staged.inner, self.o_dtype),
-            o_smem_layout_staged.outer,
-        )
+        if cutlass.const_expr(self.use_clc_scheduler):
+            sO = smem.allocate_tensor(
+                element_type=self.o_dtype,
+                layout=o_smem_layout_staged.outer,
+                swizzle=o_smem_layout_staged.inner,
+                byte_alignment=128,
+            )
+        else:
+            sO = cute.make_tensor(
+                cute.recast_ptr(sQ.iterator, o_smem_layout_staged.inner, self.o_dtype),
+                o_smem_layout_staged.outer,
+            )
         sK = smem.allocate_tensor(
             element_type=self.k_dtype,
             layout=k_smem_layout_staged.outer,
@@ -838,25 +885,28 @@ class BlackwellFusedMultiHeadAttentionForward:
         tSrK = qk_thr_mma.make_fragment_B(sK)
         tOrV = pv_thr_mma.make_fragment_B(sV)
 
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  EMPTY
-        # ///////////////////////////////////////////////////////////////////////////////
-        for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
-            if warp_idx == self.empty_warp_id[_i]:
-                cute.arch.setmaxregister_decrease(self.num_regs_other)
+        # The CLC scheduler is initialized only after the cluster pipeline
+        # handshake. Static schedulers remain on their existing setup path.
+        if cutlass.const_expr(not self.use_clc_scheduler):
+            for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
+                if warp_idx == self.empty_warp_id[_i]:
+                    cute.arch.setmaxregister_decrease(self.num_regs_other)
 
-        if cutlass.const_expr(TileScheduler is SingleTileVarlenScheduler):
-            tile_sched = TileScheduler.create(
-                tile_sched_params)
-        else:
-            blk_idx = cute.arch.block_idx()
-            if cutlass.const_expr(not self.use_2cta):
-                # Reverse batch groups without disturbing per-batch head locality.
-                blk_idx = (blk_idx[0], blk_idx[1], cute.arch.grid_dim()[2] - 1 - blk_idx[2])
-            tile_sched = FmhaStaticTileScheduler(
-                tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
-            )
-        work_tile = tile_sched.initial_work_tile_info()
+            if cutlass.const_expr(TileScheduler is SingleTileVarlenScheduler):
+                tile_sched = TileScheduler.create(tile_sched_params)
+            else:
+                blk_idx = cute.arch.block_idx()
+                if cutlass.const_expr(not self.use_2cta):
+                    # Reverse batch groups without disturbing per-batch head locality.
+                    blk_idx = (
+                        blk_idx[0],
+                        blk_idx[1],
+                        cute.arch.grid_dim()[2] - 1 - blk_idx[2],
+                    )
+                tile_sched = FmhaStaticTileScheduler(
+                    tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
+                )
+            work_tile = tile_sched.initial_work_tile_info()
 
         has_seqused = mSeqUsedQ is not None or mSeqUsedK is not None
         seqlen_info_args = (
@@ -897,9 +947,58 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         # Cluster wait
         pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+        if cutlass.const_expr(self.use_clc_scheduler):
+            num_clc_consumer_warps = (
+                self.threads_per_cta // self.threads_per_warp
+            ) * self.cluster_shape_mnk[0]
+            clc = ClcState.create(
+                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
+                    TileScheduler.clc_problem_shape(tile_sched_params),
+                    cute.arch.block_idx(),
+                    cute.arch.grid_dim(),
+                    storage.clc_response.data_ptr(),
+                ),
+                pipeline=pipeline.PipelineClcFetchAsync.create(
+                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
+                    num_stages=self.sched_stages,
+                    producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+                    consumer_group=pipeline.CooperativeGroup(
+                        pipeline.Agent.Thread,
+                        self.threads_per_warp * num_clc_consumer_warps,
+                    ),
+                    tx_count=16,
+                    cta_layout_vmnk=cluster_layout_vmnk,
+                ),
+                consumer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Consumer, self.sched_stages
+                ),
+                producer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Producer, self.sched_stages
+                ),
+            )
+            tile_sched = TileScheduler.create(tile_sched_params, clc=clc)
+            work_tile = tile_sched.initial_work_tile_info()
         tmem.allocate(self.tmem_alloc_cols)
         # All-thread CTA NamedBarrier publishes the shared trip stores to every role.
         tmem.wait_for_alloc()
+        if cutlass.const_expr(self.use_clc_scheduler):
+            for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
+                if warp_idx == self.empty_warp_id[_i]:
+                    cute.arch.setmaxregister_decrease(self.num_regs_other)
+                    if cutlass.const_expr(
+                        self.empty_warp_id[_i] == self.clc_scheduler_warp_id
+                    ):
+                        if is_leader_cta:
+                            while work_tile.is_valid_tile:
+                                tile_sched.prefetch_next_work()
+                                work_tile = tile_sched.advance_to_next_work()
+                            tile_sched.producer_tail()
+                        else:
+                            while work_tile.is_valid_tile:
+                                work_tile = tile_sched.advance_to_next_work()
+                    else:
+                        while work_tile.is_valid_tile:
+                            work_tile = tile_sched.advance_to_next_work()
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  LOAD
@@ -2010,68 +2109,139 @@ class BlackwellFusedMultiHeadAttentionForward:
     ) -> Tuple[pipeline.PipelineConsumer, pipeline.PipelineProducer]:
         (seqlen_q, scale_output) = value_args
         (sum_consumer, sSum) = sum_args
-        (mma_o_consumer, gO_staged, cO_staged, tOtO_staged,
+        (
+            mma_o_consumer,
+            gO_staged,
+            cO_staged,
+            tOtO_staged,
             sO_staged,
             gmem_tiled_copy_o,
         ) = o_args
         tidx, _, _ = cute.arch.thread_idx()
         thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
         sum_handle = sum_consumer.wait_and_advance()
-        o_handle = mma_o_consumer.wait_and_advance()
-        for iter in cutlass.range(self.iterations_pv):
-            gO = gO_staged[None, None, iter]
-            cO = cO_staged[None, None, iter]
-            sO = sO_staged[None, None, 0]
+        if cutlass.const_expr(self.use_clc_scheduler):
             row_sum = sSum[thread_idx]
             row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
             scale = scale_output / row_sum if not row_sum_is_zero_or_nan else 0.0
-            tOtO = tOtO_staged[(None, None), 0, 0, iter]
-            tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
-            sO_epi = cute.zipped_divide(sO, epi_tile)
-            tmem_copy_atom = cute.make_copy_atom(
-                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.pv_acc_dtype
-            )
-            tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_epi)
-            thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
-            tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_epi)
-            tTMEM_LOADsO = thr_tmem_load.partition_D(sO_epi)
-            for i in cutlass.range(cute.size(tTMEM_LOADtO, mode=[1]), unroll_full=True):
-                tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
-                tTMEM_LOADsO_i = tTMEM_LOADsO[None, i, 0]
-                tTMrO = cute.make_rmem_tensor(tTMEM_LOADsO[None, 0, i].shape, self.pv_acc_dtype)
-                cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
-                # tcgen05.wait::ld: load must complete before the O slot is released
-                # (register use alone does not order the TMEM read)
-                cute.arch.fence_view_async_tmem_load()
-                for j in cutlass.range(0, cute.size(tTMrO), 2, unroll_full=True):
-                    tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
-                        (tTMrO[j], tTMrO[j + 1]),
-                        (scale, scale),
+            o_handle = mma_o_consumer.wait_and_advance()
+            for iter in cutlass.range_constexpr(self.iterations_pv):
+                gO = gO_staged[None, None, iter]
+                cO = cO_staged[None, None, iter]
+                sO = sO_staged[None, None, 0]
+                tOtO = tOtO_staged[(None, None), 0, 0, iter]
+                tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
+                sO_epi = cute.zipped_divide(sO, epi_tile)
+                tmem_copy_atom = cute.make_copy_atom(
+                    tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                    self.pv_acc_dtype,
+                )
+                tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_epi)
+                thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+                tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_epi)
+                tTMEM_LOADsO = thr_tmem_load.partition_D(sO_epi)
+                for i in cutlass.range(
+                    cute.size(tTMEM_LOADtO, mode=[1]), unroll_full=True
+                ):
+                    tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
+                    tTMEM_LOADsO_i = tTMEM_LOADsO[None, i, 0]
+                    tTMrO = cute.make_rmem_tensor(
+                        tTMEM_LOADsO[None, 0, i].shape, self.pv_acc_dtype
                     )
-                tSMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
-                o_vec = tTMrO.load()
-                tSMrO.store(o_vec.to(self.o_dtype))
-                cute.autovec_copy(tSMrO, tTMEM_LOADsO_i)
-            cute.arch.fence_view_async_shared()
-            cute.arch.barrier(
-                barrier_id=2,
-                number_of_threads=len(self.correction_warp_ids)
-                * self.threads_per_warp,
-            )
-            self._store_o_from_smem(
-                sO,
-                gO,
-                cO,
-                gmem_tiled_copy_o,
-                thread_idx,
-                seqlen_q,
-            )
-            cute.arch.barrier(
-                barrier_id=2,
-                number_of_threads=len(self.correction_warp_ids)
-                * self.threads_per_warp,
-            )
-        o_handle.release()
+                    cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
+                    # tcgen05.wait::ld must complete before the O slot is released.
+                    cute.arch.fence_view_async_tmem_load()
+                    for j in cutlass.range(0, cute.size(tTMrO), 2, unroll_full=True):
+                        tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
+                            (tTMrO[j], tTMrO[j + 1]),
+                            (scale, scale),
+                        )
+                    tSMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
+                    o_vec = tTMrO.load()
+                    tSMrO.store(o_vec.to(self.o_dtype))
+                    cute.autovec_copy(tSMrO, tTMEM_LOADsO_i)
+                if cutlass.const_expr(iter == self.iterations_pv - 1):
+                    o_handle.release()
+                cute.arch.fence_view_async_shared()
+                cute.arch.barrier(
+                    barrier_id=2,
+                    number_of_threads=len(self.correction_warp_ids)
+                    * self.threads_per_warp,
+                )
+                self._store_o_from_smem(
+                    sO,
+                    gO,
+                    cO,
+                    gmem_tiled_copy_o,
+                    thread_idx,
+                    seqlen_q,
+                )
+                cute.arch.barrier(
+                    barrier_id=2,
+                    number_of_threads=len(self.correction_warp_ids)
+                    * self.threads_per_warp,
+                )
+        else:
+            o_handle = mma_o_consumer.wait_and_advance()
+            for iter in cutlass.range(self.iterations_pv):
+                gO = gO_staged[None, None, iter]
+                cO = cO_staged[None, None, iter]
+                sO = sO_staged[None, None, 0]
+                row_sum = sSum[thread_idx]
+                row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
+                scale = scale_output / row_sum if not row_sum_is_zero_or_nan else 0.0
+                tOtO = tOtO_staged[(None, None), 0, 0, iter]
+                tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
+                sO_epi = cute.zipped_divide(sO, epi_tile)
+                tmem_copy_atom = cute.make_copy_atom(
+                    tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                    self.pv_acc_dtype,
+                )
+                tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_epi)
+                thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+                tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_epi)
+                tTMEM_LOADsO = thr_tmem_load.partition_D(sO_epi)
+                for i in cutlass.range(
+                    cute.size(tTMEM_LOADtO, mode=[1]), unroll_full=True
+                ):
+                    tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
+                    tTMEM_LOADsO_i = tTMEM_LOADsO[None, i, 0]
+                    tTMrO = cute.make_rmem_tensor(
+                        tTMEM_LOADsO[None, 0, i].shape, self.pv_acc_dtype
+                    )
+                    cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
+                    # tcgen05.wait::ld: load must complete before the O slot is released
+                    # (register use alone does not order the TMEM read)
+                    cute.arch.fence_view_async_tmem_load()
+                    for j in cutlass.range(0, cute.size(tTMrO), 2, unroll_full=True):
+                        tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
+                            (tTMrO[j], tTMrO[j + 1]),
+                            (scale, scale),
+                        )
+                    tSMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
+                    o_vec = tTMrO.load()
+                    tSMrO.store(o_vec.to(self.o_dtype))
+                    cute.autovec_copy(tSMrO, tTMEM_LOADsO_i)
+                cute.arch.fence_view_async_shared()
+                cute.arch.barrier(
+                    barrier_id=2,
+                    number_of_threads=len(self.correction_warp_ids)
+                    * self.threads_per_warp,
+                )
+                self._store_o_from_smem(
+                    sO,
+                    gO,
+                    cO,
+                    gmem_tiled_copy_o,
+                    thread_idx,
+                    seqlen_q,
+                )
+                cute.arch.barrier(
+                    barrier_id=2,
+                    number_of_threads=len(self.correction_warp_ids)
+                    * self.threads_per_warp,
+                )
+            o_handle.release()
         sum_handle.release()
         return mma_o_consumer, sum_consumer
 

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -161,6 +161,7 @@ class TileSchedulerArguments(ParamsBase):
     element_size: cutlass.Constexpr[int] = 2
     is_persistent: cutlass.Constexpr[bool] = False
     lpt: cutlass.Constexpr[bool] = False
+    m_block_slowest: cutlass.Constexpr[bool] = False
     is_split_kv: cutlass.Constexpr[bool] = False
     head_swizzle: cutlass.Constexpr[bool] = False
     use_cluster_idx: cutlass.Constexpr[bool] = False
@@ -799,6 +800,7 @@ class SingleTileVarlenScheduler:
         mSeqUsedQ: Optional[cute.Tensor] = None
         qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
         lpt: cutlass.Constexpr[bool] = False
+        m_block_slowest: cutlass.Constexpr[bool] = False
         is_split_kv: cutlass.Constexpr[bool] = False
         head_swizzle: cutlass.Constexpr[bool] = False
         cluster_shape_m: cutlass.Constexpr[int] = 1
@@ -842,6 +844,7 @@ class SingleTileVarlenScheduler:
                 mSeqUsedQ=args.mSeqUsedQ,
                 qhead_per_kvhead_packgqa=args.qhead_per_kvhead_packgqa,
                 lpt=args.lpt,
+                m_block_slowest=args.m_block_slowest,
                 is_split_kv=args.is_split_kv,
                 head_swizzle=args.head_swizzle,
                 cluster_shape_m=args.cluster_shape_mn[0],
@@ -885,7 +888,7 @@ class SingleTileVarlenScheduler:
     def clc_problem_shape(params: Params):
         return ClcDynamicPersistentTileSchedulerParams(
             problem_shape_ntile_mnl=SingleTileVarlenScheduler.get_grid_shape(params),
-            cluster_shape_mnk=(1, 1, 1),
+            cluster_shape_mnk=(params.cluster_shape_m, 1, 1),
         )
 
     @staticmethod
@@ -1037,6 +1040,10 @@ class SingleTileVarlenScheduler:
                 head_idx = section_idx * nheads_in_l2 + head_idx_residual
                 if cutlass.const_expr(params.lpt):
                     block = num_m_blocks - 1 - block
+            elif cutlass.const_expr(params.m_block_slowest):
+                block = mh_block // params.num_head
+                head_idx = mh_block - block * params.num_head
+                block = num_m_blocks - 1 - block
             else:
                 head_idx = mh_block // num_m_blocks
                 block = mh_block - head_idx * num_m_blocks


### PR DESCRIPTION
## Summary

- Use a CLC-persistent, longest-causal-tile-first scheduler for short SM103 hd256 causal varlen prefill.
- Release TMEM-O after its final fenced load, while preserving the static-path `tcgen05.wait::ld` ordering.
- Use native SM103 `exp2` tuning and retain current `seqused`, TMEM, register-control, and MMA APIs.

## Benchmark script

```python
#!/usr/bin/env python
"""Side-by-side prefill benchmark: FA4 hd256 2CTA kernel vs flashinfer trtllm-ragged.

Workload mirrors GLM-5.2 MLA prefill at TP8 (8 heads, qk/v head_dim 256, bf16, causal),
which is the case where vLLM PR #42669 routes to TRTLLM_RAGGED because FA4 is slower.

  .venv/bin/python scripts/bench_hd256.py
  .venv/bin/python scripts/bench_hd256.py --shapes 16x1024,ragged_a --iters 50
  .venv/bin/python scripts/bench_hd256.py --profile fa4 --shapes 4x4096

Always compare a kernel edit against a baseline taken at the SAME --iters/--warmup-ms:
back-to-back launches pull steady-state clocks down and the two kernels are not equally
sensitive to it. `nvidia-smi -lgc <freq>` (root) removes the rest of the variance.
"""

import os

os.environ.setdefault("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "1")

import argparse
import math
import statistics
import sys
import time

import torch

from vllm.vllm_flash_attn.cute.interface import flash_attn_varlen_func
from flashinfer.prefill import trtllm_ragged_attention_deepseek

NUM_HEADS = 8
HEAD_DIM = 256
HEAD_DIM_V = 256
# vLLM MLA hands the prefill backend a V that is a slice of the kv_b_proj output:
#   kv_nope = kv_b_proj(...).view(-1, heads, qk_nope + v_head)
#   k_nope, v = kv_nope.split([qk_nope, v_head], dim=-1)
# so V is a strided view with stride (heads*(qk_nope+v_head), qk_nope+v_head, 1), which
# vLLM even pins into the FA4 compile key as v_stride. K is separately allocated and
# contiguous (_concat_k_nope_k_pe). Benchmark that layout by default; --v-contiguous
# switches to a packed V so the stride effect itself can be measured.
QK_NOPE_HEAD_DIM = 192  # qk_nope 192 + qk_rope 64 = 256
DTYPE = torch.bfloat16
SOFTMAX_SCALE = 1.0 / math.sqrt(HEAD_DIM)
WORKSPACE_BYTES = 128 * 1024 * 1024

SHAPES = {
    "16x1024": [1024] * 16,
    "4x4096": [4096] * 4,
    "2x8192": [8192] * 2,
    "1x16384": [16384],
    "ragged_a": [512, 1000, 2048, 4096, 8000],
    "ragged_b": [300, 1024, 3000, 8192, 16000],
}


class Case:
    """Pre-built device tensors + kernel args for one shape."""

    def __init__(self, name, seqlens, device, v_contiguous=False):
        self.name = name
        self.seqlens = list(seqlens)
        self.batch = len(seqlens)
        self.total = sum(seqlens)
        self.max_seqlen = max(seqlens)

        g = torch.Generator(device=device).manual_seed(1234)
        rand = lambda d: torch.randn(  # noqa: E731
            (self.total, NUM_HEADS, d), generator=g, device=device, dtype=torch.float32
        ).to(DTYPE)

        self.q, self.k = rand(HEAD_DIM), rand(HEAD_DIM)
        if v_contiguous:
            self._kv, self.v = None, rand(HEAD_DIM_V)
        else:
            # production layout: V is the tail slice of kv_nope, never materialized packed
            self._kv = rand(QK_NOPE_HEAD_DIM + HEAD_DIM_V)
            self.v = self._kv.split([QK_NOPE_HEAD_DIM, HEAD_DIM_V], dim=-1)[1]
        self.v_layout = "packed" if v_contiguous else f"kv_slice{tuple(self.v.stride())}"

        self.seq_lens = torch.tensor(seqlens, dtype=torch.int32, device=device)
        zero = torch.zeros(1, dtype=torch.int32, device=device)
        self.cu_seqlens = torch.cat([zero, self.seq_lens.cumsum(0).int()])

        self.out_fa4 = torch.empty(self.total, NUM_HEADS, HEAD_DIM_V, device=device, dtype=DTYPE)
        self.out_trt = torch.empty_like(self.out_fa4)
        self.workspace = torch.empty(WORKSPACE_BYTES, dtype=torch.uint8, device=device)

    # causal FLOPs: 2 GEMMs (QK^T over d_qk, PV over d_v) over attended pairs
    def flops(self):
        pairs = sum(s * (s + 1) // 2 for s in self.seqlens)
        return 2.0 * NUM_HEADS * (HEAD_DIM + HEAD_DIM_V) * pairs

    def run_fa4(self):
        return flash_attn_varlen_func(
            q=self.q,
            k=self.k,
            v=self.v,
            cu_seqlens_q=self.cu_seqlens,
            cu_seqlens_k=self.cu_seqlens,
            max_seqlen_q=self.max_seqlen,
            max_seqlen_k=self.max_seqlen,
            softmax_scale=SOFTMAX_SCALE,
            causal=True,
            return_lse=True,
            out=self.out_fa4,
        )

    def run_trtllm(self):
        return trtllm_ragged_attention_deepseek(
            query=self.q,
            key=self.k,
            value=self.v,
            workspace_buffer=self.workspace,
            seq_lens=self.seq_lens,
            max_q_len=self.max_seqlen,
            max_kv_len=self.max_seqlen,
            bmm1_scale=SOFTMAX_SCALE,
            bmm2_scale=1.0,
            o_sf_scale=1.0,
            batch_size=self.batch,
            window_left=-1,
            cum_seq_lens_q=self.cu_seqlens,
            cum_seq_lens_kv=self.cu_seqlens,
            enable_pdl=False,
            is_causal=True,
            return_lse=True,
            out=self.out_trt,
        )


RUNNERS = {"fa4": Case.run_fa4, "trtllm": Case.run_trtllm}

# CUDA kernel launches emitted per call, measured with torch.profiler on B300.
# fa4: the single BlackwellFusedMultiHeadAttentionForward 2CTA kernel.
# trtllm: fmhaSm103aKernel...PersistentContext + flashinfer::ComputeLSEFromMDKernel.
# Only used to turn "skip N calls" into ncu's "--launch-skip N launches".
LAUNCHES_PER_CALL = {"fa4": 1, "trtllm": 2}


# ---------------------------------------------------------------- reference
def reference(case, q_chunk=1024):
    """fp32 causal attention per sequence -> out (total,h,dv), lse (h,total) natural log.
    Chunked over queries so seqlen 16384 never materializes an (h,s,s) fp32 score matrix;
    cross-checked against F.scaled_dot_product_attention on short sequences."""
    import torch.nn.functional as F

    out = torch.empty((case.total, NUM_HEADS, HEAD_DIM_V), device=case.q.device, dtype=torch.float32)
    lse = torch.empty((NUM_HEADS, case.total), device=case.q.device, dtype=torch.float32)
    base = 0
    for s in case.seqlens:
        sl = slice(base, base + s)
        qh = case.q[sl].transpose(0, 1).float()  # (h, s, d)
        kh = case.k[sl].transpose(0, 1).float()
        vh = case.v[sl].transpose(0, 1).float()
        for i in range(0, s, q_chunk):
            j = min(i + q_chunk, s)
            scores = torch.matmul(qh[:, i:j], kh.transpose(-1, -2)) * SOFTMAX_SCALE
            rows = torch.arange(i, j, device=scores.device).unsqueeze(1)
            cols = torch.arange(s, device=scores.device).unsqueeze(0)
            scores.masked_fill_(cols > rows, float("-inf"))
            lse[:, base + i : base + j] = torch.logsumexp(scores, dim=-1)
            p = torch.softmax(scores, dim=-1)
            out[base + i : base + j] = torch.matmul(p, vh).transpose(0, 1)
            del scores, p
        if s <= 2048:  # self-check the chunked reference against SDPA
            sdpa = F.scaled_dot_product_attention(
                qh.unsqueeze(0), kh.unsqueeze(0), vh.unsqueeze(0),
                is_causal=True, scale=SOFTMAX_SCALE,
            )[0].transpose(0, 1)
            err = (sdpa - out[sl]).abs().max().item()
            assert err < 1e-3, f"reference disagrees with SDPA (err {err:.3e}) on seq {s}"
        base += s
    return out, lse


def lse_convention(lse, ref_lse):
    """Match a kernel LSE against the fp32 natural-log reference, trying both layouts
    ((h,total) / (total,h)) and both log bases. -> (description, err) or (None, None)."""
    cands = []
    for layout, t in (("(heads,total)", lse), ("(total,heads)", lse.t())):
        if t.shape != ref_lse.shape:
            continue
        t = t.float()
        cands.append((f"{layout} natural-log", (t - ref_lse).abs().max().item()))
        cands.append((f"{layout} log2", (t * math.log(2.0) - ref_lse).abs().max().item()))
    if not cands:
        return None, None
    return min(cands, key=lambda c: c[1])


def check(case, kernels):
    ref_out, ref_lse = reference(case)
    results, outs = {}, {}
    for name in kernels:
        out, lse = RUNNERS[name](case)
        outs[name] = out.float()
        results[name] = {"out_err": (outs[name] - ref_out).abs().max().item(),
                         "lse": lse_convention(lse.detach(), ref_lse)}
    # Both kernels' abs err vs the fp32 reference sits at the bf16 rounding floor and is
    # weakly discriminating; the direct fa4-vs-trtllm max diff is the sharp signal (~1 bf16
    # ULP when both are correct, blows up on any real regression).
    cross = (outs["fa4"] - outs["trtllm"]).abs().max().item() if len(kernels) == 2 else None
    del ref_out, ref_lse, outs
    torch.cuda.empty_cache()
    return results, cross


# ---------------------------------------------------------------- timing
GPU_HZ = 1.5e9  # rough B300 clock; only used to size torch.cuda._sleep spins


def _sleep_ms(ms):
    """Spin the GPU for ~ms so the CPU can run ahead and enqueue without the GPU idling."""
    torch.cuda._sleep(int(max(ms, 1.0) * 1e-3 * GPU_HZ))


def host_ms_per_call(case, name, n=20):
    """Host-side dispatch cost of one call, measured with the GPU kept busy.

    FA4's Python wrapper re-runs its whole validation/heuristics prologue on every call
    even on a compile-cache hit, while flashinfer's is a thin C++ binding; if that host
    cost approaches the kernel time the CPU cannot stay ahead and the event window would
    charge FA4 for host gaps that trtllm never pays.
    """
    torch.cuda.synchronize()
    _sleep_ms(200.0)
    t0 = time.perf_counter()
    for _ in range(n):
        RUNNERS[name](case)
    dt = time.perf_counter() - t0
    torch.cuda.synchronize()
    return dt * 1e3 / n


def time_kernels(case, kernels, iters, warmup_ms):
    """Median GPU ms per call for each kernel, timed interleaved.

    Interleaving matters: timing all of kernel A then all of kernel B measures A during
    clock ramp and B at steady state, and that order effect lands straight in the ratio.
    """
    for name in kernels:
        RUNNERS[name](case)  # compile / kernel selection outside the timed region
    torch.cuda.synchronize()

    # duration-based warmup; a fixed iteration count is <10 ms here, far too short for
    # SM/HBM clocks to ramp on a B300
    for name in kernels:
        t0 = time.perf_counter()
        while (time.perf_counter() - t0) * 1e3 < warmup_ms:
            for _ in range(8):
                RUNNERS[name](case)
            torch.cuda.synchronize()

    host = {k: host_ms_per_call(case, k) for k in kernels}

    ev = {k: [(torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True))
              for _ in range(iters)] for k in kernels}
    torch.cuda.synchronize()
    # keep the GPU busy for longer than the whole enqueue sequence takes on the host,
    # so every event pair is already queued before the GPU reaches it
    _sleep_ms(1.5 * iters * sum(host.values()) + 30.0)
    for i in range(iters):
        for k in kernels:  # interleaved: both kernels see the same clock/thermal state
            s, e = ev[k][i]
            s.record()
            RUNNERS[k](case)
            e.record()
    torch.cuda.synchronize()

    ms = {k: statistics.median(s.elapsed_time(e) for s, e in ev[k]) for k in kernels}
    for k in kernels:
        if host[k] >= ms[k]:
            print(f"  LAUNCH-BOUND [{case.name}] {k}: host dispatch {host[k]:.3f} ms/call >= "
                  f"event median {ms[k]:.3f} ms; event times include host gap")
    return ms, host


# ---------------------------------------------------------------- main
def main():
    ap = argparse.ArgumentParser(description=__doc__)
    ap.add_argument("--shapes", default=",".join(SHAPES), help="comma-separated shape names")
    ap.add_argument("--iters", type=int, default=40)
    ap.add_argument("--warmup", type=int, default=5, help="warm calls before the profiled call")
    ap.add_argument("--warmup-ms", type=float, default=300.0,
                    help="per-kernel per-shape warmup duration for clock ramp")
    ap.add_argument("--kernels", choices=["fa4", "trtllm", "both"], default="both")
    ap.add_argument("--skip-check", action="store_true")
    ap.add_argument("--v-contiguous", action="store_true",
                    help="pack V instead of the production kv_nope-slice stride")
    ap.add_argument("--profile", choices=["fa4", "trtllm"], default=None,
                    help="compile+warm up, then run exactly one call and exit (for ncu/nsys)")
    args = ap.parse_args()

    names = [s.strip() for s in args.shapes.split(",") if s.strip()]
    bad = [n for n in names if n not in SHAPES]
    if bad:
        sys.exit(f"unknown shape(s) {bad}; available: {list(SHAPES)}")
    kernels = ["fa4", "trtllm"] if args.kernels == "both" else [args.kernels]

    torch.manual_seed(0)
    device = torch.device("cuda")
    print(f"device: {torch.cuda.get_device_name(device)}  cc={torch.cuda.get_device_capability(device)}")
    print(f"heads={NUM_HEADS} d_qk={HEAD_DIM} d_v={HEAD_DIM_V} dtype=bf16 causal=True lse=on "
          f"scale={SOFTMAX_SCALE:.6f}")

    if args.profile:
        name = names[0]
        case = Case(name, SHAPES[name], device, args.v_contiguous)
        print(f"v layout: {case.v_layout}")
        fn = RUNNERS[args.profile]
        fn(case)
        torch.cuda.synchronize()
        for _ in range(max(args.warmup, 5)):
            fn(case)
        torch.cuda.synchronize()
        per_call = LAUNCHES_PER_CALL[args.profile]
        warm_calls = max(args.warmup, 5) + 1  # compile call + warm calls
        # --launch-skip counts EVERY launch since process start, and Case.__init__ emits 6
        # setup kernels (3x randn + .to(bf16)) before any attention call, so a bare
        # --launch-skip N profiles a torch fill kernel. Name-filter first: with
        # --kernel-name set, --launch-skip only counts launches that match the filter.
        kernel_re = {"fa4": "FusedMultiHeadAttentionForward",
                     "trtllm": "fmhaSm|ComputeLSEFromMD"}[args.profile]
        print(f"profiling {args.profile} on {name} (b={case.batch}, total={case.total}); "
              f"{warm_calls} warm calls precede the profiled one")
        print(f"hint: /usr/local/cuda/bin/ncu --set full --kernel-name-base demangled "
              f"--kernel-name regex:'{kernel_re}' \\\n"
              f"        --launch-skip {warm_calls * per_call} --launch-count {per_call} "
              f"--target-processes all \\\n"
              f"        .venv/bin/python scripts/bench_hd256.py --profile {args.profile} "
              f"--shapes {name} --warmup {args.warmup}\n"
              f"      ({args.profile} emits {per_call} matching launch(es)/call, so skip = "
              f"{warm_calls} calls x {per_call}. Re-measure LAUNCHES_PER_CALL if an edit "
              f"adds a launch. Set TMPDIR to a writable dir if ncu cannot create its lock.)")
        fn(case)
        torch.cuda.synchronize()
        return

    failures = []
    rows = []
    v_layout = None
    for name in names:
        case = Case(name, SHAPES[name], device, args.v_contiguous)
        if v_layout is None:
            v_layout = case.v_layout
            print(f"v layout: {v_layout}   (--v-contiguous to pack V)")
        tflop = case.flops() / 1e12

        if not args.skip_check:
            res, cross = check(case, kernels)
            errs = {k: res[k]["out_err"] for k in kernels}
            parts = []
            for k in kernels:
                conv, lerr = res[k]["lse"]
                if conv is None:
                    parts.append(f"{k}: out {errs[k]:.3e}  lse SHAPE-MISMATCH")
                    print(f"  WARNING [{name}] {k} LSE shape does not match reference; "
                          f"comparing outputs only")
                    continue
                parts.append(f"{k}: out {errs[k]:.3e}  lse {conv} err {lerr:.3e}")
                if lerr > 5e-2:
                    print(f"  WARNING [{name}] {k} LSE best match {conv} still off by {lerr:.3e}")
            if cross is not None:
                parts.append(f"fa4-vs-trtllm {cross:.3e}")
            print(f"check {name:>9}  " + " | ".join(parts))
            if "fa4" in errs:
                if errs["fa4"] > 5e-2:
                    failures.append(f"{name}: fa4 out err {errs['fa4']:.3e} > 5e-2")
                if "trtllm" in errs and errs["fa4"] > 3.0 * errs["trtllm"]:
                    failures.append(
                        f"{name}: fa4 out err {errs['fa4']:.3e} > 3x trtllm {errs['trtllm']:.3e}"
                    )

        ms, host = time_kernels(case, kernels, args.iters, args.warmup_ms)
        # keep only scalars so the case's device tensors are freed before the next shape
        rows.append((name, case.batch, case.max_seqlen, tflop, ms, host))
        del case
        torch.cuda.empty_cache()

    hdr = f"{'shape':>9} {'b':>3} {'maxseq':>7} {'TFLOP':>7}"
    for k in kernels:
        hdr += f" {k + ' ms':>10} {k + ' TF/s':>10} {k + ' cpu':>9}"
    if len(kernels) == 2:
        hdr += f" {'fa4 speedup':>12}"
    print()
    print(hdr)
    print("-" * len(hdr))
    for name, batch, max_seqlen, tflop, ms, host in rows:
        line = f"{name:>9} {batch:>3} {max_seqlen:>7} {tflop:>7.2f}"
        for k in kernels:
            line += f" {ms[k]:>10.3f} {tflop / (ms[k] / 1e3):>10.1f} {host[k]:>9.3f}"
        if len(kernels) == 2:
            line += f" {ms['trtllm'] / ms['fa4']:>12.3f}"
        print(line)
    if len(kernels) == 2:
        print("(fa4 speedup = trtllm_ms / fa4_ms; > 1.0 means FA4 is faster)")
    print("(cpu = host dispatch ms/call; only comparable across runs at the same --iters)")

    if failures:
        print("\nCORRECTNESS FAILURES:")
        for f in failures:
            print(f"  {f}")
        sys.exit(1)


if __name__ == "__main__":
    main()
```

## B300 performance

NVIDIA B300 SXM6 AC, BF16 causal attention, 8 heads, QK/V head dimension 256. Both revisions used the script above with its defaults (`--iters 40 --warmup-ms 300`); lower FA4 time is better. `vs TRT` is `TRTLLM time / FA4 time`, so values above 1.0 mean FA4 is faster.

| Shape | Before | After | Change | Before vs TRT | After vs TRT |
|---|---:|---:|---:|---:|---:|
| `16x1024` | 0.112 ms | 0.086 ms | -23.21% | 0.770x | 1.012x |
| `4x4096` | 0.229 ms | 0.190 ms | -17.03% | 0.956x | 1.144x |
| `2x8192` | 0.385 ms | 0.381 ms | -1.04% | 1.034x | 1.048x |
| `1x16384` | 0.669 ms | 0.629 ms | -5.98% | 1.195x | 1.217x |
| `ragged_a` | 0.289 ms | 0.287 ms | -0.69% | 1.015x | 1.026x |
| `ragged_b` | 0.916 ms | 0.903 ms | -1.42% | 1.070x | 1.081x |