### PR TITLE
Fix FP8 decode/prefill kBlockN divergence causing KV-cache logprob mismatch

### DIFF
--- a/hopper/test_fp8_decode_prefill.py
+++ b/hopper/test_fp8_decode_prefill.py
@@ -1,0 +1,49 @@
+import pytest
+import torch
+
+from flash_attn_interface import flash_attn_varlen_func
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability("cuda")[0] < 9,
+    reason="FP8 FlashAttention-3 requires SM90 or later",
+)
+@pytest.mark.parametrize("seqlen_k", [96, 97, 128, 192, 256])
+def test_fp8_decode_prefill_final_row_matches(seqlen_k):
+    """The final causal row must not depend on decode vs. prefill tiling."""
+    torch.manual_seed(42)
+    device = "cuda"
+    nheads_q, nheads_kv, headdim = 12, 2, 128
+
+    q = torch.randn(seqlen_k, nheads_q, headdim, device=device).to(
+        torch.float8_e4m3fn
+    )
+    k = torch.randn(seqlen_k, nheads_kv, headdim, device=device).to(
+        torch.float8_e4m3fn
+    )
+    v = torch.randn(seqlen_k, nheads_kv, headdim, device=device).to(
+        torch.float8_e4m3fn
+    )
+    descale = torch.ones(1, nheads_kv, device=device)
+
+    def run(query):
+        seqlen_q = query.shape[0]
+        out, _ = flash_attn_varlen_func(
+            query,
+            k,
+            v,
+            cu_seqlens_q=torch.tensor([0, seqlen_q], device=device, dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, seqlen_k], device=device, dtype=torch.int32),
+            max_seqlen_q=seqlen_q,
+            max_seqlen_k=seqlen_k,
+            softmax_scale=headdim**-0.5,
+            causal=True,
+            q_descale=descale,
+            k_descale=descale,
+            v_descale=descale,
+        )
+        return out
+
+    prefill = run(q)[-1]
+    decode = run(q[-1:])[0]
+    assert torch.equal(prefill, decode)

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -51,43 +51,31 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
             return {128, is_local ? 64 : 80, true, true};  // 128 x 80 hits the limit of smem
         }
     } else {
-        // FP8 path
-        if (use_one_mma_wg) {
-            // Decode tiles — independent of two-level accumulation setting
-            if (headdim <= 96) {
-                return {64, 128, true, true};
-            } else {
-                return {64, 96, true, true};
-            }
-        } else {
-            // Prefill tiles — two-level accumulation needs smaller tiles to reduce
-            // register pressure from the separate fp32 accumulator (tOrO_accum).
-            // Currently just optimized for causal case.
+        // FP8 path — decode/prefill share kBlockN (fix FP8 KV logprob drift)
 #ifndef FLASHATTENTION_DISABLE_FP8_TWO_LEVEL_ACCUMULATION
-            if (headdim <= 64) {
-                return {192, 128, true, true};
-            } else if (headdim <= 96) {
-                return {128, 128, true, true};
-            } else if (headdim <= 128) {
-                return {128, 192, true, true};
-            } else if (headdim <= 192) {
-                return {128, 96, true, true};
-            } else {
-                return {128, is_local ? 64 : 128, true, !paged_kv_non_TMA};  // TODO: FP8 prefill ~0.54x of BF16 with two-level accum at hd256
-            }
+        int const kBlockN =
+            headdim <= 64 ? 128 :
+            headdim <= 96 ? 128 :
+            headdim <= 128 ? 192 :
+            headdim <= 192 ? 96 :
+            (is_local ? 64 : 128);
+        int const kBlockM = headdim <= 64 ? 192 : 128;
 #else
-            if (headdim <= 64) {
-                return {192, 160, true, true};
-            } else if (headdim <= 96) {
-                return {192, 128, true, true};
-            } else if (headdim <= 128) {
-                return {128, paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224), true, true};
-            } else if (headdim <= 192) {
-                return {128, (paged_kv_non_TMA || softcap) && is_local ? 128 : 160, true, true};
-            } else {
-                return {128, is_local ? 64 : 128, true, !paged_kv_non_TMA};
-            }
+        int const kBlockN =
+            headdim <= 64 ? 160 :
+            headdim <= 96 ? 128 :
+            headdim <= 128 ? (paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224)) :
+            headdim <= 192 ? ((paged_kv_non_TMA || softcap) && is_local ? 128 : 160) :
+            (is_local ? 64 : 128);
+        int const kBlockM = headdim <= 96 ? 192 : 128;
 #endif
+        // Decode keeps kBlockM=64. Prefill keeps its original kBlockM and
+        // IntraWGOverlap choices; only kBlockN is shared.
+        if (use_one_mma_wg) {
+            return {64, kBlockN, true, true};
+        } else {
+            bool const intra_wg_overlap = headdim <= 192 ? true : !paged_kv_non_TMA;
+            return {kBlockM, kBlockN, true, intra_wg_overlap};
         }
     }
 }


### PR DESCRIPTION
Fixes a systematic logprob mismatch between decode and prefill under FP8 KV cache. Closely related to [sgl-project/sglang#25790](https://github.com/sgl-project/sglang/issues/25790), which reports the same root cause in the sibling `sgl-attn` fork.

**Base commit:** `06bdd47` (`upstream/main`, 2026-08-27)

### Problem

Under FP8 KV cache (`kv_cache_dtype="fp8_e4m3"`), vLLM users who compare decode-time logprobs (token-by-token generation) with full-prefill rescore logprobs (`prompt_logprobs` on the same sequence) see a systematic divergence. On Qwen3-4B (H100, vLLM 0.28.0, greedy, 224 generated tokens, `VLLM_BATCH_INVARIANT=1`), the first mismatch is at absolute sequence position **97**, with 115–117 mismatching generated-token positions and max `|Δlogprob|` ≈ 0.56.

### Root cause

`use_one_mma_wg` ([`hopper/heuristics.h#L10-L14`](https://github.com/vllm-project/flash-attention/blob/main/hopper/heuristics.h#L10-L14)) is true for decode and false for prefill. The FP8 branch of [`hopper/tile_size.h#L53-L92`](https://github.com/vllm-project/flash-attention/blob/main/hopper/tile_size.h#L53-L92) then picks different **`kBlockN`** values — for `head_dim=128` with default two-level accumulation, decode uses `kBlockN=96` ([L60](https://github.com/vllm-project/flash-attention/blob/main/hopper/tile_size.h#L60)) and prefill uses `kBlockN=192` ([L72](https://github.com/vllm-project/flash-attention/blob/main/hopper/tile_size.h#L72)). Online softmax reduces over K in `kBlockN`-sized chunks; the divergence starts at `kBlockN_decode + 1 = 97`, matching the E2E first-mismatch position.

### Fix

Make decode and prefill share the same `kBlockN`. Decode keeps `kBlockM=64`. Prefill keeps its original `kBlockM` and `IntraWGOverlap`; only `kBlockN` is aligned.

Reviewer notes: use `int const` (not `int constexpr`) for local `kBlockN`; do not collapse prefill's `kBlockM` / `IntraWGOverlap` into a single hardcoded return.

### Changes in this PR

- `hopper/tile_size.h` — unify FP8 `kBlockN` between decode and prefill
- `hopper/test_fp8_decode_prefill.py` — Hopper regression test (new)

### Added regression test

`hopper/test_fp8_decode_prefill.py` holds fixed FP8 Q/K/V and asserts bitwise equality between a one-row decode-shaped call and the final row of a causal prefill-shaped call. Length `97` is the first length where the stock kernel diverges; `96` is the last matching length.

```python
import pytest
import torch

from flash_attn_interface import flash_attn_varlen_func


@pytest.mark.skipif(
    torch.cuda.get_device_capability("cuda")[0] < 9,
    reason="FP8 FlashAttention-3 requires SM90 or later",
)
@pytest.mark.parametrize("seqlen_k", [96, 97, 128, 192, 256])
def test_fp8_decode_prefill_final_row_matches(seqlen_k):
    """The final causal row must not depend on decode vs. prefill tiling."""
    torch.manual_seed(42)
    device = "cuda"
    nheads_q, nheads_kv, headdim = 12, 2, 128

    q = torch.randn(seqlen_k, nheads_q, headdim, device=device).to(
        torch.float8_e4m3fn
    )
    k = torch.randn(seqlen_k, nheads_kv, headdim, device=device).to(
        torch.float8_e4m3fn
    )
    v = torch.randn(seqlen_k, nheads_kv, headdim, device=device).to(
        torch.float8_e4m3fn
    )
    descale = torch.ones(1, nheads_kv, device=device)

    def run(query):
        seqlen_q = query.shape[0]
        out, _ = flash_attn_varlen_func(
            query,
            k,
            v,
            cu_seqlens_q=torch.tensor([0, seqlen_q], device=device, dtype=torch.int32),
            cu_seqlens_k=torch.tensor([0, seqlen_k], device=device, dtype=torch.int32),
            max_seqlen_q=seqlen_q,
            max_seqlen_k=seqlen_k,
            softmax_scale=headdim**-0.5,
            causal=True,
            q_descale=descale,
            k_descale=descale,
            v_descale=descale,
        )
        return out

    prefill = run(q)[-1]
    decode = run(q[-1:])[0]
    assert torch.equal(prefill, decode)
```

Run after building this branch's FA3 extension:

```bash
cd hopper
PYTHONPATH=$PWD pytest -q -s test_fp8_decode_prefill.py
```

### Test results (H100 80GB, 2026-08-27)

Built `_vllm_fa3_C` from **this PR branch** (`06bdd47` + patch) via cmake on SM90.

#### Kernel regression

Direct FA3 test: identical FP8 Q/K/V; compare final attention row from decode-shaped vs prefill-shaped calls. Sweep: 28 KV lengths (88–111, 128, 160, 192, 256).

| Measurement | Unpatched | Patched (this branch) |
|---|---:|---:|
| First KV length with a different final row | 97 | none |
| Mismatching sampled lengths | 19 / 28 | **0 / 28** |
| Largest elementwise difference | ~9.8e-3 | **0** |

The added pytest covers the critical lengths including the `96 → 97` boundary.

#### vLLM E2E (`VLLM_BATCH_INVARIANT=1`)

Greedy 224-token generation → full-prefill rescore; Qwen3-4B, FP8 KV cache, eager, prefix caching disabled. E2E was also validated with the same patch on the vLLM 0.28.0 FA3 pin (`f3e1a4f`; identical `tile_size.h` diff).

| | `tell me a story` | `讲个故事` |
|---|---|---|
| **Unpatched** — first mismatch / mismatching / max `\|Δlogprob\|` | 97 / 115/224 / 0.50 | 97 / 117/224 / 0.40 |
| **Patched** — mismatching / max `\|Δlogprob\|` | **0/224 / 0** | **0/224 / 0** |

### Test plan (for reviewers)

1. Build `_vllm_fa3_C` from this branch on H100/SM90 and install into vLLM.
2. Run `cd hopper && PYTHONPATH=$PWD pytest -q -s test_fp8_decode_prefill.py`.
3. Optional E2E: set `VLLM_BATCH_INVARIANT=1`, generate 224 tokens with FP8 KV cache, rescore with `prompt_logprobs`; expect exact match on all generated-token positions.

### Related

- vLLM issue: https://github.com/vllm-project/vllm/issues/54035
- [sgl-project/sglang#25790](https://github.com/sgl-project/sglang/issues/25790)

---

<details>
<summary>Checklist</summary>

- [x] Purpose and root cause described
- [x] Regression test included (`hopper/test_fp8_decode_prefill.py`)
- [x] Kernel + E2E before/after results included
- [x] Reproduction steps for reviewers provided

</details>