### PR TITLE
[CuTe, SM100] Size shared storage for the larger K or V layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
     1024-1024-128-True-0-0.0-False-False-False-mha-dtype0
     or 1024-1024-128-False-0-0.0-False-False-False-mha-dtype0
     or test_flash_attn_ex2_emu_decode_prefill_consistency
+    or test_flash_attn_value_dim_larger_than_query_dim
     or test_flash_attn_mla_absorbed and 256-256-False-True-64-False-0-False-False-mqa-dtype0
     or test_flash_attn_mla_absorbed and 256-256-False-True-64-True-0-False-False-mqa-dtype0
     or test_flash_attn_mla_absorbed and 256-256-False-False-64-False-0-False-False-mqa-dtype0

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -682,6 +682,8 @@ class FlashAttentionForwardSm100:
             cute.cosize(sQ_layout) if const_expr(not self.overlap_sO_sQ) else
             cutlass.max(cute.cosize(sQ_layout), cute.cosize(sO_layout) * self.o_dtype.width // self.q_dtype.width)
         )
+        # K and V alias the same physical buffer and may have different extents.
+        sKV_size = cutlass.max(cute.cosize(sK_layout), cute.cosize(sV_layout))
 
         clc_response_size = self.sched_stages * 4 if self.use_clc_scheduler else 0
         clc_mbar_size = self.sched_stages * 2 if self.use_clc_scheduler else 0
@@ -719,8 +721,7 @@ class FlashAttentionForwardSm100:
                 cute.struct.MemRange[self.q_dtype, sQ_size], self.buffer_align_bytes
             ]
             sK: cute.struct.Align[
-                # cute.cosize(sK_layout) is correct even in the case of self.uneven_kv_smem
-                cute.struct.MemRange[self.k_dtype, cute.cosize(sK_layout)],
+                cute.struct.MemRange[self.k_dtype, sKV_size],
                 self.buffer_align_bytes,
             ]
 

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -96,6 +96,25 @@ def test_flash_attn_sm120_rejects_splitkv():
         flash_attn_func(q, k, v, num_splits=3)
 
 
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime value-dimension shared-memory test",
+)
+def test_flash_attn_value_dim_larger_than_query_dim():
+    torch.manual_seed(0)
+    q = torch.randn(1, 129, 8, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 769, 8, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, 769, 8, 128, device="cuda", dtype=torch.bfloat16)
+
+    out = _flash_attn_fwd(q, k, v)[0]
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        q.float().transpose(1, 2),
+        k.float().transpose(1, 2),
+        v.float().transpose(1, 2),
+    ).transpose(1, 2)
+    torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])


### PR DESCRIPTION
## Why are these changes needed?

The SM100 forward kernel stages K and V in one dynamic shared-memory region. `sV` is built from `sK.iterator`. The region is currently sized only from `sK_layout`, even though `sV_layout` can require more elements when the value head dimension is larger than the query and key head dimension. A query and key head dimension of 64 with a value head dimension of 128 can therefore write beyond the declared shared-memory range.

This is a focused port of the shared-storage fix from Dao-AILab/flash-attention#2745, merged as `69e1bcbe` and originally authored by Driss Guessous. Upstream accepted the change after running the same dimension case on GB300 and checking the wider matrix with Compute Sanitizer.

## What changed?

- Allocate the aliased staging region with `max(cosize(sK_layout), cosize(sV_layout))`.
- Add a focused SM100 and SM110 regression for a query and key head dimension of 64 with a value head dimension of 128. The output is checked against PyTorch SDPA in FP32.
- Add the regression to `FA4_TEST_FILTER` so the existing B200 workflow exercises it after merge.

Layouts whose V extent is no larger than K retain the existing allocation size. Public interfaces and dependencies are unchanged.

## Validation

- `python -m compileall -q flash_attn/cute/flash_fwd_sm100.py tests/cute/test_flash_attn.py`
- `ruff check --select E9,F63,F7,F82 flash_attn/cute/flash_fwd_sm100.py tests/cute/test_flash_attn.py`
- The repository pre-commit invocation completed and reported no matching configured hooks for these paths.
- The workflow file passes YAML parsing.
- `git diff --check`
- GitHub DCO check: pass

The runtime regression requires SM100 or SM110 hardware and was not run locally. The identical case passed in the merged upstream validation on GB300. The downstream B200 workflow now selects the test for its first post-merge run.
