### PR TITLE
[CuTe, FA4] Preserve first-tile flag during scheduler reconstruction

### DIFF
--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -282,7 +282,11 @@ class SingleTileScheduler:
         for obj, n_items in zip([self.params, self._blk_coord], self._values_pos):
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
-        return SingleTileScheduler(*(tuple(obj_list)), loc=self._loc)
+        scheduler = SingleTileScheduler(*(tuple(obj_list)), loc=self._loc)
+        # Note: _is_first_block is a Python-only attribute omitted from MLIR values,
+        # so it must be restored explicitly after reconstruction.
+        scheduler._is_first_block = self._is_first_block
+        return scheduler
 
 
 class StaticPersistentTileScheduler:
@@ -1120,7 +1124,10 @@ class SingleTileVarlenScheduler:
         for obj, n_items in zip(objs, self._values_pos):
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
-        return self.__class__(*obj_list, loc=self._loc)
+        scheduler = self.__class__(*obj_list, loc=self._loc)
+        # See the note on Python-only attributes in SingleTileScheduler.
+        scheduler._is_first_block = self._is_first_block
+        return scheduler
 
 
 # -----------------------------------------------------------------------------
@@ -1179,7 +1186,11 @@ class Sm100FmhaStaticTileSchedulerParams:
             obj_list.append(new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
         return Sm100FmhaStaticTileSchedulerParams(
-            self.is_persistent, *(tuple(obj_list)), lpt=self.lpt, l2_swizzle=self.l2_swizzle, loc=self._loc
+            self.is_persistent,
+            *(tuple(obj_list)),
+            lpt=self.lpt,
+            l2_swizzle=self.l2_swizzle,
+            loc=self._loc,
         )
 
 
@@ -1391,9 +1402,12 @@ class Sm100FmhaStaticTileScheduler:
         )
         new_blk_coord = new_from_mlir_values(self._blk_coord, values[4:7])
         new_grid_shape = new_from_mlir_values(self._grid_shape, values[7:])
-        return Sm100FmhaStaticTileScheduler(
+        scheduler = Sm100FmhaStaticTileScheduler(
             new_params, new_current_work_linear_idx, new_blk_coord, new_grid_shape
         )
+        # See the note on Python-only attributes in SingleTileScheduler.
+        scheduler._is_first_block = self._is_first_block
+        return scheduler
 
 
 def compute_sm100_fmha_grid(


### PR DESCRIPTION
## Why are these changes needed?

CuTe reconstructs scheduler objects from their MLIR-backed values. Three single-tile schedulers also keep `_is_first_block` as Python-only state, so that flag is absent from the MLIR value list. Each constructor initializes the flag to `True`.

After `advance_to_next_work()` consumes the first tile and sets the flag to `False`, reconstruction currently calls the constructor and loses that state. The consumed tile can become valid again, repeat work, and stall pipeline synchronization.

This is a focused port of [Dao-AILab/flash-attention#2705](https://github.com/Dao-AILab/flash-attention/pull/2705), merged as `7a08d7a` and originally authored by XiaoDong. In the [upstream review](https://github.com/Dao-AILab/flash-attention/pull/2705#discussion_r3725295982), the author confirmed that the bug also existed with earlier CuTeDSL frontends and that version 4.7 exposed the latent state loss. The upstream merge and this repository both pin `nvidia-cutlass-dsl==4.6.0.dev0`.

## What changed?

Restore `_is_first_block` from the source object after reconstructing each affected scheduler:

- `SingleTileScheduler`
- `SingleTileVarlenScheduler`
- `Sm100FmhaStaticTileScheduler`

The repository-pinned Ruff formatter also wraps one existing constructor call in the same file.

## Validation

- `python -m compileall -q flash_attn/cute/tile_scheduler.py`
- `ruff check --select E9,F63,F7,F82 flash_attn/cute/tile_scheduler.py`
- `pre-commit run --files flash_attn/cute/tile_scheduler.py`
- `git diff --check`
- GitHub DCO check: pass

Validation on this branch is static. The production change matches the reviewed and merged upstream state-preservation fix. Public interfaces, kernel math, scheduling policy, and dependencies are unchanged.
