### PR TITLE
[Build] Define math constants for MSVC targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,11 @@ if (FA2_ENABLED)
         TORCH_TARGET_VERSION=0x020A000000000000ULL
     )
 
+    # MSVC exposes M_* constants from <cmath> only with this definition.
+    if(MSVC)
+        target_compile_definitions(_vllm_fa2_C PRIVATE _USE_MATH_DEFINES)
+    endif()
+
     # Pin the C++ standard on the target itself. When flash-attn is built as a
     # vLLM subproject (FetchContent), the directory-level CMAKE_CXX_STANDARD set
     # above does not propagate to targets created via define_gpu_extension_target,
@@ -319,6 +324,11 @@ if (FA3_ENABLED AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.0)
         TORCH_TARGET_VERSION=0x020A000000000000ULL
         USE_CUDA
     )
+
+    # MSVC exposes M_* constants from <cmath> only with this definition.
+    if(MSVC)
+        target_compile_definitions(_vllm_fa3_C PRIVATE _USE_MATH_DEFINES)
+    endif()
 
     # See _vllm_fa2_C above: enforce C++20 on the target for the vLLM subproject build.
     set_target_properties(_vllm_fa3_C PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary

- define `_USE_MATH_DEFINES` for the FA2 and FA3 extension targets when building with MSVC
- keep the definition `PRIVATE` to those targets, leaving non-MSVC builds unchanged

Fixes vllm-project/vllm#54459.

## Why this approach

MSVC does not expose the non-standard `M_*` constants from `<cmath>` unless `_USE_MATH_DEFINES` is defined before the header is included. This is the supported opt-in described by Microsoft:
https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170

There are several existing precedents for handling the same portability issue at the build layer:

- this repository's `hopper/setup.py` already passes `-D_USE_MATH_DEFINES` for `win_amd64` NVCC builds:
  https://github.com/vllm-project/flash-attention/blob/main/hopper/setup.py#L595-L600
- upstream Dao-AILab FlashAttention uses the same Windows NVCC definition:
  https://github.com/Dao-AILab/flash-attention/blob/main/hopper/setup.py
- DeepSeek FlashMLA also passes `-D_USE_MATH_DEFINES` in its CUDA extension build:
  https://github.com/deepseek-ai/FlashMLA/blob/main/setup.py
- the analogous vLLM FlashMLA fix uses MSVC-guarded, target-scoped compile definitions:
  https://github.com/vllm-project/vllm/pull/54007

Using `VLLM_FA_GPU_FLAGS` alone would not be sufficient: `define_gpu_extension_target` applies those flags only to the GPU language, while `M_LOG2E` is also used by host C++ sources such as `csrc/flash_attn/flash_api.cpp`. Target compile definitions cover both the C++ and CUDA translation units.

## Duplicate check

Searched open pull requests in `vllm-project/flash-attention` for `M_LOG2E`, `_USE_MATH_DEFINES`, `MSVC`, and `54459`; no active duplicate was found.

## Testing

- `git diff --check`
- Windows MSVC smoke test:
  https://github.com/Blade-of-Mikasa/flash-attention/actions/runs/33410272825
  - without `_USE_MATH_DEFINES`: fails as expected with `C2065: 'M_LOG2E': undeclared identifier`
  - with `_USE_MATH_DEFINES`: compiles successfully
  - workflow result: success with no annotations
- not run: a full Windows CUDA/NVCC build, because that environment is not available locally
- model evaluation: not applicable; this is a build-only portability change

## AI assistance

OpenAI Codex assisted with issue investigation, the CMake change, the MSVC smoke test, and drafting this description. I reviewed and understand every changed line and the stated validation boundary.