### PR TITLE
Enable split-KV for paged multi-token queries (spec-decode verify)

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -363,6 +363,13 @@ std::tuple<Tensor, Tensor> set_params_splitkv(Flash_fwd_params &params, const in
         if (params.num_splits > 1) {
             softmax_lse_accum = torch::stable::new_empty(ref, {params.num_splits, batch_size, num_heads, max_seqlen_q}, ScalarType::Float);
             out_accum = torch::stable::new_empty(ref, {params.num_splits, batch_size, num_heads, max_seqlen_q, head_size_rounded}, ScalarType::Float);
+            // Pre-initialize the accumulators: with varlen + paged KV +
+            // causal multi-token queries, empty splits can leave slots
+            // unwritten; uninitialized memory then reaches the combine
+            // kernel (observed as NaN in the second sequence of a batch).
+            // -inf LSE marks a slot as "empty split" for the combine.
+            torch::stable::fill_(softmax_lse_accum, -INFINITY);
+            torch::stable::zero_(out_accum);
             params.softmax_lseaccum_ptr = softmax_lse_accum.data_ptr();
             params.oaccum_ptr = out_accum.data_ptr();
         }
@@ -753,8 +760,10 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     params.page_block_size = page_block_size;
     // Keep references to these tensors to extend their lifetime
     Tensor softmax_lse_accum, out_accum;
-    if (seqlenq_ngroups_swapped) {
-        // Only apply split-k for decoding
+    if (seqlenq_ngroups_swapped || (paged_KV && max_seqlen_q <= 64)) {
+        // Split-k for decoding AND for short multi-token queries (spec-decode
+        // verify): without it a paged varlen call with 1 < q_len <= 64 walks
+        // the whole KV serially in one CTA per (batch, head).
         std::tie(softmax_lse_accum, out_accum) =
             set_params_splitkv(params, batch_size, num_heads, head_size,
                                max_seqlen_k, max_seqlen_q, head_size_rounded,

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -1222,7 +1222,23 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
         if (params.unpadded_lse) {
             const index_t lse_offset = row_offset_lse + tidx / kRowsPerLoadTranspose;
             if (lse_offset < lse_size) {
-                gLSE_unpadded(lse_offset) = lse_logsum;
+                if (params.cu_seqlens_q != nullptr && !params.seqlenq_ngroups_swapped) {
+                    // Varlen: the unpadded LSE is (h, total_q) packed by
+                    // cu_seqlens_q; the uniform remap above assumes equal
+                    // sequence lengths and would misplace shorter ones.
+                    const int b_i = lse_offset / (params.h * params.seqlen_q);
+                    const int h_i = (lse_offset - (index_t)b_i * params.h * params.seqlen_q) / params.seqlen_q;
+                    const int r_i = lse_offset - ((index_t)b_i * params.h + h_i) * params.seqlen_q;
+                    const int q_start = params.cu_seqlens_q[b_i];
+                    const int q_len_b = params.cu_seqlens_q[b_i + 1] - q_start;
+                    if (r_i < q_len_b) {
+                        const index_t total_q = params.cu_seqlens_q[params.b];
+                        reinterpret_cast<ElementAccum *>(params.softmax_lse_ptr)
+                            [(index_t)h_i * total_q + q_start + r_i] = lse_logsum;
+                    }
+                } else {
+                    gLSE_unpadded(lse_offset) = lse_logsum;
+                }
             }
         } else {
             gLSE(tidx / kRowsPerLoadTranspose) = lse_logsum;
@@ -1295,8 +1311,21 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
             const int head_idx = (idx - batch_idx * (params.h * params.seqlen_q)) / params.seqlen_q;
             // The index to the rows of Q
             const int row = idx - batch_idx * (params.h * params.seqlen_q) - head_idx * params.seqlen_q;
-            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + batch_idx * params.o_batch_stride
-                + head_idx * params.o_head_stride + row * params.o_row_stride;
+            index_t o_row_offset;
+            if (params.cu_seqlens_q != nullptr && !params.seqlenq_ngroups_swapped) {
+                // Varlen: O rows are packed by cu_seqlens_q — there is no
+                // batch stride, and rows beyond a sequence's actual length
+                // have no O slot (params.seqlen_q is the max across seqs).
+                const int q_start = params.cu_seqlens_q[batch_idx];
+                const int q_len_b = params.cu_seqlens_q[batch_idx + 1] - q_start;
+                if (row >= q_len_b) { continue; }
+                o_row_offset = (index_t)(q_start + row) * params.o_row_stride
+                    + head_idx * params.o_head_stride;
+            } else {
+                o_row_offset = batch_idx * params.o_batch_stride
+                    + head_idx * params.o_head_stride + row * params.o_row_stride;
+            }
+            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + o_row_offset;
             #pragma unroll
             for (int k = 0; k < size<2>(rO); ++k) {
                 if (Is_even_K || tOpOaccum(k)) {


### PR DESCRIPTION
`set_params_splitkv` only applies split-k in the
`seqlenq_ngroups_swapped` case (q_len == 1): "Only apply split-k for
decoding". Any paged varlen call with 1 < q_len ≤ 64 — exactly the
shape of a speculative-decode verify — is forced to `num_splits ≤ 1`
and walks the whole KV serially in one CTA per (batch, head). At long
context this is a kernel-level cliff:

- Ampere (RTX 3090 Ti, unmodified vLLM 0.13.0 wheel, 31k paged KV):
  verify q=2 is **22.8×** slower than the equivalent split decode call;
  q=4: 16.5×; q=8: 7.3×. The restriction is unchanged in today's main
  (`STD_TORCH_CHECK(num_splits <= 1, ...)`).
- The absolute verify time is context-bound, not head-bound (~1.4 ms at
  31k regardless of q_len and head count) — the signature of a serial
  KV walk.

The fix enables splits for `paged_KV && max_seqlen_q <= 64` and makes
the combine kernel varlen-correct, which the old gate had masked:

- final O write used `batch_idx * o_batch_stride` (unset in varlen) —
  now cu_seqlens_q packing with a row guard;
- unpadded LSE write assumed uniform sequence lengths — now cu_seqlens
  packing;
- `softmax_lse_accum`/`out_accum` are pre-initialized (-inf / 0) so
  early-exit splits cannot leak garbage into the combine.

Measured end to end (2× Quadro RTX 8000, 27B W4A8, MTP spec decode,
31k context): long-context decode 23 → 34 tok/s; speculation at long
context flips from a loss to a win. Numerics: max abs err 2.4e-4 vs
fp32 reference across q_len 1–8, splits 1/2/4 bitwise-consistent.
