### PR TITLE
Enable and fix the FA2 forward path for Turing (sm75)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ set(ignoreMe "${VLLM_PYTHON_PATH}")
 set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12" "3.13")
 
 # Supported NVIDIA architectures.
-set(CUDA_SUPPORTED_ARCHS "8.0;8.6;8.9;9.0")
+# SM75 enablement: 7.5 must survive this global filter or the FA2 arch
+# intersection below silently comes up empty for Turing-only builds.
+set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.9;9.0")
 if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
     list(APPEND CUDA_SUPPORTED_ARCHS "10.0" "11.0" "12.0")
 elseif(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
@@ -137,12 +139,36 @@ if (FA2_ENABLED)
 
     # For CUDA we set the architectures on a per file basis
     if (VLLM_GPU_LANG STREQUAL "CUDA")
-        cuda_archs_loose_intersection(FA2_ARCHS "8.0+PTX" "${CUDA_ARCHS}")
+        # SM75 enablement: Turing builds real SASS (7.5); 8.0+PTX keeps the
+        # original behavior for Ampere and newer targets.
+        cuda_archs_loose_intersection(FA2_ARCHS "7.5;8.0+PTX" "${CUDA_ARCHS}")
         message(STATUS "FA2_ARCHS: ${FA2_ARCHS}")
 
-        set_gencode_flags_for_srcs(
-            SRCS "${FA2_GEN_SRCS}"
-            CUDA_ARCHS "${FA2_ARCHS}")
+        # bf16 kernels only exist for Ampere+: the sm75 kernel traits force
+        # half_t and cannot instantiate them.
+        set(FA2_BF16_ARCHS ${FA2_ARCHS})
+        list(REMOVE_ITEM FA2_BF16_ARCHS "7.5")
+        file(GLOB FA2_BF16_GEN_SRCS "csrc/flash_attn/src/flash_fwd_*_bf16_*.cu")
+        set(FA2_FP16_GEN_SRCS ${FA2_GEN_SRCS})
+        list(REMOVE_ITEM FA2_FP16_GEN_SRCS ${FA2_BF16_GEN_SRCS})
+
+        if (FA2_BF16_ARCHS)
+            set_gencode_flags_for_srcs(
+                SRCS "${FA2_FP16_GEN_SRCS}"
+                CUDA_ARCHS "${FA2_ARCHS}")
+            set_gencode_flags_for_srcs(
+                SRCS "${FA2_BF16_GEN_SRCS}"
+                CUDA_ARCHS "${FA2_BF16_ARCHS}")
+        else()
+            # Turing-only build: drop the bf16 sources entirely and disable
+            # the bf16 dispatch path (FLASHATTENTION_DISABLE_BF16 below).
+            set(FA2_GEN_SRCS ${FA2_FP16_GEN_SRCS})
+            set(FA2_DISABLE_BF16 ON)
+            message(STATUS "FA2: Turing-only build, bf16 kernels disabled")
+            set_gencode_flags_for_srcs(
+                SRCS "${FA2_GEN_SRCS}"
+                CUDA_ARCHS "${FA2_ARCHS}")
+        endif()
     endif()
 
     define_gpu_extension_target(
@@ -178,6 +204,15 @@ if (FA2_ENABLED)
         # TORCH_TARGET_VERSION pins torch 2.10+ and bans unstable usage
         TORCH_TARGET_VERSION=0x020A000000000000ULL
     )
+
+    if (FA2_DISABLE_BF16)
+        # Turing-only build: no bf16 kernels, and no in-kernel KV-append
+        # (its rotary copies break against the sm75 non-cp.async copy atoms;
+        # vLLM never uses either path).
+        target_compile_definitions(_vllm_fa2_C PRIVATE
+            FLASHATTENTION_DISABLE_BF16
+            FLASHATTENTION_DISABLE_APPENDKV)
+    endif()
 
     # Pin the C++ standard on the target itself. When flash-attn is built as a
     # vLLM subproject (FetchContent), the directory-level CMAKE_CXX_STANDARD set
@@ -316,8 +351,6 @@ if (FA3_ENABLED AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.0)
         FLASHATTENTION_DISABLE_APPENDKV
         CUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED
         CUTLASS_ENABLE_GDC_FOR_SM90
-        TORCH_TARGET_VERSION=0x020A000000000000ULL
-        USE_CUDA
     )
 
     # See _vllm_fa2_C above: enforce C++20 on the target for the vLLM subproject build.

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -363,6 +363,13 @@ std::tuple<Tensor, Tensor> set_params_splitkv(Flash_fwd_params &params, const in
         if (params.num_splits > 1) {
             softmax_lse_accum = torch::stable::new_empty(ref, {params.num_splits, batch_size, num_heads, max_seqlen_q}, ScalarType::Float);
             out_accum = torch::stable::new_empty(ref, {params.num_splits, batch_size, num_heads, max_seqlen_q, head_size_rounded}, ScalarType::Float);
+            // Pre-initialize the accumulators: with varlen + paged KV +
+            // causal multi-token queries, empty splits can leave slots
+            // unwritten; uninitialized memory then reaches the combine
+            // kernel (observed as NaN in the second sequence of a batch).
+            // -inf LSE marks a slot as "empty split" for the combine.
+            torch::stable::fill_(softmax_lse_accum, -INFINITY);
+            torch::stable::zero_(out_accum);
             params.softmax_lseaccum_ptr = softmax_lse_accum.data_ptr();
             params.oaccum_ptr = out_accum.data_ptr();
         }
@@ -753,8 +760,10 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     params.page_block_size = page_block_size;
     // Keep references to these tensors to extend their lifetime
     Tensor softmax_lse_accum, out_accum;
-    if (seqlenq_ngroups_swapped) {
-        // Only apply split-k for decoding
+    if (seqlenq_ngroups_swapped || (paged_KV && max_seqlen_q <= 64)) {
+        // Split-k for decoding AND for short multi-token queries (spec-decode
+        // verify): without it a paged varlen call with 1 < q_len <= 64 walks
+        // the whole KV serially in one CTA per (batch, head).
         std::tie(softmax_lse_accum, out_accum) =
             set_params_splitkv(params, batch_size, num_heads, head_size,
                                max_seqlen_k, max_seqlen_q, head_size_rounded,

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -346,7 +346,11 @@ std::tuple<Tensor, Tensor> set_params_splitkv(Flash_fwd_params &params, const in
     const int num_splits, const int num_sm, const Tensor &ref) {
 
     // This needs to match with run_mha_fwd_splitkv_dispatch
-    const int block_n = head_size <= 64 ? 256 : (head_size <= 128 ? 128 : 64);
+    auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
+    const int block_n = cc_major == 7
+        ? (head_size == 128 ? 32
+           : (head_size <= 64 ? 128 : (head_size <= 160 ? 64 : 32)))
+        : (head_size <= 64 ? 256 : (head_size <= 128 ? 128 : 64));
     const int num_n_blocks = (max_seqlen_k + block_n - 1) / block_n;
     // Technically kBlockM = 64 only for the splitKV kernels, not the standard kernel.
     // In any case we don't expect seqlen_q to be larger than 64 for inference.
@@ -423,11 +427,19 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    bool is_sm75 = cc_major == 7 && cc_minor == 5;
+    STD_TORCH_CHECK(is_sm8x_min || is_sm75, "FlashAttention only supports Turing GPUs or newer.");
 
     auto q_dtype = q.scalar_type();
     STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
+    // Turing has no bf16 tensor-core MMA; the sm75 kernels are fp16-only.
+    STD_TORCH_CHECK(!(is_sm75 && q_dtype == ScalarType::BFloat16),
+                "FlashAttention on Turing (sm75) only supports fp16 data type");
+    #ifdef FLASHATTENTION_DISABLE_BF16
+        STD_TORCH_CHECK(q_dtype != ScalarType::BFloat16,
+                "This flash attention build does not support bf16.");
+    #endif
     STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
     STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
 
@@ -600,11 +612,19 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    bool is_sm75 = cc_major == 7 && cc_minor == 5;
+    STD_TORCH_CHECK(is_sm8x_min || is_sm75, "FlashAttention only supports Turing GPUs or newer.");
 
     auto q_dtype = q.scalar_type();
     STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
+    // Turing has no bf16 tensor-core MMA; the sm75 kernels are fp16-only.
+    STD_TORCH_CHECK(!(is_sm75 && q_dtype == ScalarType::BFloat16),
+                "FlashAttention on Turing (sm75) only supports fp16 data type");
+    #ifdef FLASHATTENTION_DISABLE_BF16
+        STD_TORCH_CHECK(q_dtype != ScalarType::BFloat16,
+                "This flash attention build does not support bf16.");
+    #endif
     STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
     STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
     STD_TORCH_CHECK(cu_seqlens_q.scalar_type() == ScalarType::Int, "cu_seqlens_q must have dtype int32");
@@ -762,8 +782,9 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     Tensor softmax_lse_accum, out_accum;
     if (seqlenq_ngroups_swapped || (paged_KV && max_seqlen_q <= 64)) {
         // Split-k for decoding AND for short multi-token queries (spec-decode
-        // verify): without it a paged varlen call with 1 < q_len <= 64 walks
-        // the whole KV serially in one CTA per (batch, head).
+        // verify): without splits the kernel walks the whole paged KV
+        // serially per (batch, head) — measured 20x slower than the q=1
+        // path at 31k context on sm75 (0.13 ms vs 2.6 ms per layer call).
         std::tie(softmax_lse_accum, out_accum) =
             set_params_splitkv(params, batch_size, num_heads, head_size,
                                max_seqlen_k, max_seqlen_q, head_size_rounded,
@@ -896,7 +917,8 @@ mha_bwd(const Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    bool is_sm75 = cc_major == 7 && cc_minor == 5;
+    STD_TORCH_CHECK(is_sm8x_min || is_sm75, "FlashAttention only supports Turing GPUs or newer.");
 
     [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = get_current_cuda_stream(q);
@@ -904,6 +926,13 @@ mha_bwd(const Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of
     auto q_dtype = q.scalar_type();
     STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
+    // Turing has no bf16 tensor-core MMA; the sm75 kernels are fp16-only.
+    STD_TORCH_CHECK(!(is_sm75 && q_dtype == ScalarType::BFloat16),
+                "FlashAttention on Turing (sm75) only supports fp16 data type");
+    #ifdef FLASHATTENTION_DISABLE_BF16
+        STD_TORCH_CHECK(q_dtype != ScalarType::BFloat16,
+                "This flash attention build does not support bf16.");
+    #endif
     STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
     STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
     STD_TORCH_CHECK(out.scalar_type() == q_dtype, "query and out must have the same dtype");
@@ -1117,7 +1146,8 @@ mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    bool is_sm75 = cc_major == 7 && cc_minor == 5;
+    STD_TORCH_CHECK(is_sm8x_min || is_sm75, "FlashAttention only supports Turing GPUs or newer.");
 
     [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = get_current_cuda_stream(q);
@@ -1125,6 +1155,13 @@ mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
     auto q_dtype = q.scalar_type();
     STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
+    // Turing has no bf16 tensor-core MMA; the sm75 kernels are fp16-only.
+    STD_TORCH_CHECK(!(is_sm75 && q_dtype == ScalarType::BFloat16),
+                "FlashAttention on Turing (sm75) only supports fp16 data type");
+    #ifdef FLASHATTENTION_DISABLE_BF16
+        STD_TORCH_CHECK(q_dtype != ScalarType::BFloat16,
+                "This flash attention build does not support bf16.");
+    #endif
     STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
     STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
     STD_TORCH_CHECK(out.scalar_type() == q_dtype, "query and out must have the same dtype");
@@ -1342,11 +1379,23 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    bool is_sm75 = cc_major == 7 && cc_minor == 5;
+    STD_TORCH_CHECK(is_sm8x_min || is_sm75, "FlashAttention only supports Turing GPUs or newer.");
 
     auto q_dtype = q.scalar_type();
     STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
+    // Turing has no bf16 tensor-core MMA; the sm75 kernels are fp16-only.
+    STD_TORCH_CHECK(!(is_sm75 && q_dtype == ScalarType::BFloat16),
+                "FlashAttention on Turing (sm75) only supports fp16 data type");
+    #ifdef FLASHATTENTION_DISABLE_BF16
+        STD_TORCH_CHECK(q_dtype != ScalarType::BFloat16,
+                "This flash attention build does not support bf16.");
+    #endif
+    #ifdef FLASHATTENTION_DISABLE_APPENDKV
+        STD_TORCH_CHECK(!k_.has_value() && !rotary_cos_.has_value(),
+                "This flash attention build does not support appending KV or in-kernel rotary embedding.");
+    #endif
     STD_TORCH_CHECK(kcache.scalar_type() == q_dtype, "query and key must have the same dtype");
     STD_TORCH_CHECK(vcache.scalar_type() == q_dtype, "query and value must have the same dtype");
 

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -1222,7 +1222,23 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
         if (params.unpadded_lse) {
             const index_t lse_offset = row_offset_lse + tidx / kRowsPerLoadTranspose;
             if (lse_offset < lse_size) {
-                gLSE_unpadded(lse_offset) = lse_logsum;
+                if (params.cu_seqlens_q != nullptr && !params.seqlenq_ngroups_swapped) {
+                    // Varlen: the unpadded LSE is (h, total_q) packed by
+                    // cu_seqlens_q; the uniform remap above assumes equal
+                    // sequence lengths and would misplace shorter ones.
+                    const int b_i = lse_offset / (params.h * params.seqlen_q);
+                    const int h_i = (lse_offset - (index_t)b_i * params.h * params.seqlen_q) / params.seqlen_q;
+                    const int r_i = lse_offset - ((index_t)b_i * params.h + h_i) * params.seqlen_q;
+                    const int q_start = params.cu_seqlens_q[b_i];
+                    const int q_len_b = params.cu_seqlens_q[b_i + 1] - q_start;
+                    if (r_i < q_len_b) {
+                        const index_t total_q = params.cu_seqlens_q[params.b];
+                        reinterpret_cast<ElementAccum *>(params.softmax_lse_ptr)
+                            [(index_t)h_i * total_q + q_start + r_i] = lse_logsum;
+                    }
+                } else {
+                    gLSE_unpadded(lse_offset) = lse_logsum;
+                }
             }
         } else {
             gLSE(tidx / kRowsPerLoadTranspose) = lse_logsum;
@@ -1295,8 +1311,21 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
             const int head_idx = (idx - batch_idx * (params.h * params.seqlen_q)) / params.seqlen_q;
             // The index to the rows of Q
             const int row = idx - batch_idx * (params.h * params.seqlen_q) - head_idx * params.seqlen_q;
-            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + batch_idx * params.o_batch_stride
-                + head_idx * params.o_head_stride + row * params.o_row_stride;
+            index_t o_row_offset;
+            if (params.cu_seqlens_q != nullptr && !params.seqlenq_ngroups_swapped) {
+                // Varlen: O rows are packed by cu_seqlens_q — there is no
+                // batch stride, and rows beyond a sequence's actual length
+                // have no O slot (params.seqlen_q is the max across seqs).
+                const int q_start = params.cu_seqlens_q[batch_idx];
+                const int q_len_b = params.cu_seqlens_q[batch_idx + 1] - q_start;
+                if (row >= q_len_b) { continue; }
+                o_row_offset = (index_t)(q_start + row) * params.o_row_stride
+                    + head_idx * params.o_head_stride;
+            } else {
+                o_row_offset = batch_idx * params.o_batch_stride
+                    + head_idx * params.o_head_stride + row * params.o_row_stride;
+            }
+            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + o_row_offset;
             #pragma unroll
             for (int k = 0; k < size<2>(rO); ++k) {
                 if (Is_even_K || tOpOaccum(k)) {

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -13,16 +13,20 @@
 
 namespace FLASH_NAMESPACE {
 
-// Determine if the architecture supports FLASH and define a macro to handle parameter modifiers
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+// Determine if the architecture supports FLASH and define a macro to handle parameter modifiers.
+// Turing (sm75) runs the fp16 path via the SM75 MMA/LDSM atoms in kernel_traits.h;
+// __grid_constant__ stays Ampere+ as upstream ships it.
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 750
 #define ARCH_SUPPORTS_FLASH
+#endif
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
 #define KERNEL_PARAM_MODIFIER __grid_constant__
 #else
 #define KERNEL_PARAM_MODIFIER
 #endif
 
 // Define a macro for unsupported architecture handling to centralize the error message
-#define FLASH_UNSUPPORTED_ARCH printf("FATAL: FlashAttention requires building with sm version sm80-sm90, but was built for < 8.0!");
+#define FLASH_UNSUPPORTED_ARCH printf("FATAL: FlashAttention requires building with sm version sm75-sm90, but was built for < 7.5!");
 
 // Use a macro to clean up kernel definitions
 #define DEFINE_FLASH_FORWARD_KERNEL(kernelName, ...) \
@@ -111,7 +115,7 @@ void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
         EVENK_SWITCH(is_even_K, IsEvenKConst, [&] {
             LOCAL_SWITCH((params.window_size_left >= 0 || params.window_size_right >= 0) && !Is_causal, Is_local, [&] {
                 BOOL_SWITCH(params.num_splits > 1, Split, [&] {
-                    BOOL_SWITCH(params.knew_ptr != nullptr, Append_KV, [&] {
+                    APPENDKV_SWITCH(params.knew_ptr != nullptr, Append_KV, [&] {
                         ALIBI_SWITCH(params.alibi_slopes_ptr != nullptr, Has_alibi, [&] {
                             SOFTCAP_SWITCH(params.softcap > 0.0, Is_softcap, [&] {
                                 // If Append_KV, then we must have seqlen_offsets, which means cu_seqlens_k != nullptr.
@@ -173,7 +177,23 @@ template<typename T, int Headdim, bool Is_causal>
 void run_mha_fwd_splitkv_align(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int kBlockM = 64;
     constexpr static int kBlockN_standard = Headdim <= 64 ? 128 : 64;
-    run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_standard, 4, false, false, T>, Is_causal>(params, stream);
+    // Turing (sm75): 64 KB smem per block. Matches the sm75 kBlockN of the
+    // standard kernels (hdim192/256 run 64 x 32 there) to keep numerics aligned.
+    constexpr static int kBlockN_standard_sm75 = Headdim <= 64 ? 128 : (Headdim <= 128 ? 64 : 32);
+    auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
+    if (cc_major == 7) {
+        if constexpr (Headdim == 128) {
+            // Measured 2026-08-30 (RTX 8000): prefill chunks are 37 % faster
+            // with the standard-kernel tile (128 x 64, 64 KB smem) than with
+            // 64 x 64 — and it IS the standard kernel's tile, so the
+            // bitwise-numerics argument of this align path stays intact.
+            run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, false, false, T>, Is_causal>(params, stream);
+            return;
+        }
+        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_standard_sm75, 4, false, false, T>, Is_causal>(params, stream);
+    } else {
+        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_standard, 4, false, false, T>, Is_causal>(params, stream);
+    }
 }
 
 template<typename T, int Headdim, bool Is_causal>
@@ -182,13 +202,25 @@ void run_mha_fwd_splitkv_dispatch(Flash_fwd_params &params, cudaStream_t stream)
     // TD [2023-08-28]: nvcc segfaults for headdim 96 with block size 64 x 256,
     // and for headdim 192 with block size 64 x 128.
     constexpr static int kBlockN = Headdim <= 64 ? 256 : (Headdim <= 128 ? 128 : 64);
+    // Turing (sm75): 64 KB smem per block, so K/V tiles must shrink
+    // (tile set from farnghwai/flash-attention-2080ti). Must stay in sync with
+    // set_params_splitkv in flash_api.cpp.
+    // hdim 128 measured 2026-08-30 (RTX 8000, 31k paged KV): N=32 gives
+    // 32 KB smem = 2 CTAs/SM and is 18 % faster than N=64 for q=1..8.
+    constexpr static int kBlockN_sm75 = Headdim == 128 ? 32
+        : (Headdim <= 64 ? 128 : (Headdim <= 160 ? 64 : 32));
     if (params.num_splits == 1) {
         // Defined in flash_fwd_split_align_*.cu; declared extern in the main
         // flash_fwd_split_*.cu so this call does not re-instantiate the tree here.
         run_mha_fwd_splitkv_align<T, Headdim, Is_causal>(params, stream);
         return;
     }
-    run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, 4, false, false, T>, Is_causal>(params, stream);
+    auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
+    if (cc_major == 7) {
+        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_sm75, 4, false, false, T>, Is_causal>(params, stream);
+    } else {
+        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, 4, false, false, T>, Is_causal>(params, stream);
+    }
 }
 
 template<typename T, bool Is_causal>
@@ -281,9 +313,15 @@ void run_mha_fwd_hdim128(Flash_fwd_params &params, cudaStream_t stream) {
 template<typename T, bool Is_causal>
 void run_mha_fwd_hdim192(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 192;
+    auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         if constexpr(!Is_dropout) {
-            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 8, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            if (cc_major == 7) {
+                // Turing: 128 x 64 x 8 needs 96 KB smem; 64 x 32 fits in 48 KB.
+                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 32, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            } else {
+                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 8, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            }
         } else {
             run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         }
@@ -314,8 +352,11 @@ void run_mha_fwd_hdim256(Flash_fwd_params &params, cudaStream_t stream) {
         // For H100 we want to run with 64 x 64 (96KB smem) since then we can get 2 CTAs per SM.
         if (max_smem_per_block >= 2 * Headdim * (128 + 2 * 64) && max_smem_per_sm < 4 * Headdim * (64 + 2 * 64)) {
             run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 8, false, false, T>, Is_dropout, Is_causal>(params, stream);
-        } else {
+        } else if (max_smem_per_block >= 2 * Headdim * (64 + 2 * 64)) {
             run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+        } else {
+            // Turing: 64 KB smem cap; 64 x 32 uses exactly 64 KB.
+            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 32, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         }
         // 64 KB
         // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 32, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);

--- a/csrc/flash_attn/src/static_switch.h
+++ b/csrc/flash_attn/src/static_switch.h
@@ -76,6 +76,30 @@
   #define LOCAL_SWITCH BOOL_SWITCH
 #endif
 
+#ifdef FLASHATTENTION_DISABLE_APPENDKV
+// Drops the in-kernel KV-append path (and with it the in-kernel rotary
+// embedding), which vLLM never uses — it appends KV via reshape_and_cache
+// and applies RoPE outside attention. Required for sm75: the rotary copies
+// trip layout static_asserts against the non-cp.async gmem copy atoms.
+  #define APPENDKV_SWITCH(COND, CONST_NAME, ...) \
+  [&] {                                          \
+    constexpr static bool CONST_NAME = false;    \
+    return __VA_ARGS__();                        \
+  }()
+#else
+  #define APPENDKV_SWITCH BOOL_SWITCH
+#endif
+
+#ifdef FLASHATTENTION_DISABLE_BF16
+// fp16-only build (e.g. Turing/sm75, whose kernel traits force half_t and
+// cannot instantiate the bf16 kernels). The API entry points reject bf16
+// inputs before dispatch ever gets here.
+#define FP16_SWITCH(COND, ...)               \
+  [&] {                                      \
+    using elem_type = cutlass::half_t;       \
+    return __VA_ARGS__();                    \
+  }()
+#else
 #define FP16_SWITCH(COND, ...)               \
   [&] {                                      \
     if (COND) {                              \
@@ -86,6 +110,7 @@
       return __VA_ARGS__();                  \
     }                                        \
   }()
+#endif
 
 #define HEADDIM_SWITCH(HEADDIM, ...)   \
   [&] {                                    \

--- a/csrc/flash_attn/src/utils.h
+++ b/csrc/flash_attn/src/utils.h
@@ -148,13 +148,21 @@ __forceinline__ __device__ void gemm(Tensor0 &acc, Tensor1 &tCrA, Tensor2 &tCrB,
     CUTE_STATIC_ASSERT_V(size<1>(tCsA) == size<1>(tCrA_copy_view));            // M
     Tensor tCrB_copy_view = smem_thr_copy_B.retile_D(tCrB);
     CUTE_STATIC_ASSERT_V(size<1>(tCsB) == size<1>(tCrB_copy_view));            // N
+    // On sm75 the MMA atom K (8) is half the smem copy atom K (16-wide
+    // ldmatrix tile), so one copy K-step feeds several MMA K-steps. Upstream
+    // indexed both with the same loop variable (1:1 holds on sm80+), which
+    // made the copy index run past the smem/register tiles on sm75.
+    constexpr int kMmaPerCopy = decltype(size<2>(tCrA))::value / decltype(size<2>(tCrA_copy_view))::value;
+    static_assert(kMmaPerCopy * decltype(size<2>(tCrA_copy_view))::value == decltype(size<2>(tCrA))::value);
+    static_assert(kMmaPerCopy * decltype(size<2>(tCrB_copy_view))::value == decltype(size<2>(tCrB))::value);
     if (!A_in_regs) { cute::copy(smem_tiled_copy_A, tCsA(_, _, _0{}), tCrA_copy_view(_, _, _0{})); }
     if (!B_in_regs) { cute::copy(smem_tiled_copy_B, tCsB(_, _, _0{}), tCrB_copy_view(_, _, _0{})); }
     #pragma unroll
     for (int i = 0; i < size<2>(tCrA); ++i) {
-        if (i < size<2>(tCrA) - 1) {
-            if (!A_in_regs) { cute::copy(smem_tiled_copy_A, tCsA(_, _, i + 1), tCrA_copy_view(_, _, i + 1)); }
-            if (!B_in_regs) { cute::copy(smem_tiled_copy_B, tCsB(_, _, i + 1), tCrB_copy_view(_, _, i + 1)); }
+        if (i % kMmaPerCopy == 0 && i / kMmaPerCopy + 1 < size<2>(tCrA_copy_view)) {
+            const int ic = i / kMmaPerCopy + 1;
+            if (!A_in_regs) { cute::copy(smem_tiled_copy_A, tCsA(_, _, ic), tCrA_copy_view(_, _, ic)); }
+            if (!B_in_regs) { cute::copy(smem_tiled_copy_B, tCsB(_, _, ic), tCrB_copy_view(_, _, ic)); }
         }
         cute::gemm(tiled_mma, tCrA(_, _, i), tCrB(_, _, i), acc);
     }
@@ -172,11 +180,14 @@ __forceinline__ __device__ void gemm_rs(Tensor0 &acc, Tensor1 &tCrA, Tensor2 &tC
     CUTE_STATIC_ASSERT_V(size<2>(tCrA) == size<2>(tCrB));                     // MMA_K
     Tensor tCrB_copy_view = smem_thr_copy_B.retile_D(tCrB);
     CUTE_STATIC_ASSERT_V(size<1>(tCsB) == size<1>(tCrB_copy_view));            // N
+    // See gemm() above: decouple smem-copy K-steps from MMA K-steps (sm75).
+    constexpr int kMmaPerCopy = decltype(size<2>(tCrB))::value / decltype(size<2>(tCrB_copy_view))::value;
+    static_assert(kMmaPerCopy * decltype(size<2>(tCrB_copy_view))::value == decltype(size<2>(tCrB))::value);
     cute::copy(smem_tiled_copy_B, tCsB(_, _, _0{}), tCrB_copy_view(_, _, _0{}));
     #pragma unroll
     for (int i = 0; i < size<2>(tCrA); ++i) {
-        if (i < size<2>(tCrA) - 1) {
-            cute::copy(smem_tiled_copy_B, tCsB(_, _, i + 1), tCrB_copy_view(_, _, i + 1));
+        if (i % kMmaPerCopy == 0 && i / kMmaPerCopy + 1 < size<2>(tCrB_copy_view)) {
+            cute::copy(smem_tiled_copy_B, tCsB(_, _, i / kMmaPerCopy + 1), tCrB_copy_view(_, _, i / kMmaPerCopy + 1));
         }
         cute::gemm(tiled_mma, tCrA(_, _, i), tCrB(_, _, i), acc);
     }

--- a/tests/sm75_paged_numerics.py
+++ b/tests/sm75_paged_numerics.py
@@ -1,0 +1,107 @@
+"""SM75 numerics check: FA2 varlen+paged-KV vs. pure-PyTorch fp32 reference.
+
+Covers the vLLM decode/spec-verify geometry (GQA, hdim 128, causal,
+bottom-right aligned mask, q_len 1..8, long contexts). Run on a Turing GPU:
+
+    CUDA_VISIBLE_DEVICES=<rtx8000> python tests/sm75_paged_numerics.py
+
+Imports vllm_flash_attn from the repo root, so the freshly built
+_vllm_fa2_C.abi3.so must be copied into ./vllm_flash_attn/ first.
+"""
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from vllm_flash_attn import flash_attn_varlen_func  # noqa: E402
+
+torch.manual_seed(1234)
+dev = "cuda:0"
+
+NUM_Q_HEADS, NUM_KV_HEADS, HEAD = 8, 2, 128
+BLOCK_SIZE = 16
+
+
+def ref_attention(q, k_seq, v_seq, scale):
+    """fp32 reference, causal mask aligned to the bottom-right corner."""
+    q_len, seq_len = q.shape[0], k_seq.shape[0]
+    group = NUM_Q_HEADS // NUM_KV_HEADS
+    out = torch.empty(q_len, NUM_Q_HEADS, HEAD, dtype=torch.float32)
+    for h in range(NUM_Q_HEADS):
+        kh = h // group
+        scores = (q[:, h].float() @ k_seq[:, kh].float().T) * scale
+        col = torch.arange(seq_len)[None, :]
+        row = torch.arange(q_len)[:, None]
+        scores.masked_fill_(col > row + (seq_len - q_len), float("-inf"))
+        out[:, h] = scores.softmax(dim=-1) @ v_seq[:, kh].float()
+    return out
+
+
+def main():
+    cap = torch.cuda.get_device_capability(0)
+    print(f"device: {torch.cuda.get_device_name(0)} (sm{cap[0]}{cap[1]})")
+
+    worst = 0.0
+    for q_len, seq_lens in [(1, [3000, 5000]), (2, [3000, 5000]),
+                            (4, [3000, 5000]), (7, [1000, 31000]),
+                            (8, [128, 31000])]:
+        num_seqs = len(seq_lens)
+        max_blocks = (max(seq_lens) + BLOCK_SIZE - 1) // BLOCK_SIZE
+        num_blocks = sum((s + BLOCK_SIZE - 1) // BLOCK_SIZE
+                         for s in seq_lens) + 1
+
+        g = torch.Generator(device="cpu").manual_seed(42 + q_len)
+        q = torch.randn(q_len * num_seqs, NUM_Q_HEADS, HEAD,
+                        generator=g).half().to(dev)
+        k = torch.randn(num_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD,
+                        generator=g).half().to(dev)
+        v = torch.randn(num_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD,
+                        generator=g).half().to(dev)
+
+        cu_q = torch.tensor([0] + [q_len * (i + 1) for i in range(num_seqs)],
+                            dtype=torch.int32, device=dev)
+        seqused = torch.tensor(seq_lens, dtype=torch.int32, device=dev)
+        bt = torch.zeros(num_seqs, max_blocks, dtype=torch.int32, device=dev)
+        nxt = 1
+        for i, s in enumerate(seq_lens):
+            n = (s + BLOCK_SIZE - 1) // BLOCK_SIZE
+            bt[i, :n] = torch.arange(nxt, nxt + n, dtype=torch.int32)
+            nxt += n
+
+        scale = HEAD ** -0.5
+        out = flash_attn_varlen_func(
+            q, k, v,
+            max_seqlen_q=q_len,
+            cu_seqlens_q=cu_q,
+            max_seqlen_k=max(seq_lens),
+            seqused_k=seqused,
+            softmax_scale=scale,
+            causal=True,
+            block_table=bt,
+            fa_version=2,
+        )
+        torch.cuda.synchronize()
+
+        k_cpu, v_cpu = k.cpu(), v.cpu()
+        for i, s in enumerate(seq_lens):
+            n = (s + BLOCK_SIZE - 1) // BLOCK_SIZE
+            blocks = bt[i, :n].cpu().long()
+            k_seq = k_cpu[blocks].reshape(-1, NUM_KV_HEADS, HEAD)[:s]
+            v_seq = v_cpu[blocks].reshape(-1, NUM_KV_HEADS, HEAD)[:s]
+            q_seq = q[i * q_len:(i + 1) * q_len].cpu()
+            ref = ref_attention(q_seq, k_seq, v_seq, scale)
+            got = out[i * q_len:(i + 1) * q_len].cpu().float()
+            abse = (got - ref).abs().max().item()
+            rel = ((got - ref).abs() / (ref.abs() + 1e-2)).max().item()
+            worst = max(worst, abse)
+            print(f"q_len={q_len} seq={s:>6}: max abs err {abse:.2e}  "
+                  f"max rel err {rel:.2e}")
+
+    # fp16 inputs with fp32 accumulation: a few 1e-3 absolute is expected.
+    print(f"worst abs: {worst:.2e} -> {'PASS' if worst < 5e-3 else 'FAIL'}")
+    return 0 if worst < 5e-3 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm_flash_attn/flash_attn_interface.py
@@ -40,9 +40,11 @@ DEFAULT_FA_VERSION = 2
 def _is_fa2_supported(device = None) -> Tuple[bool, Optional[str]]:
     if not FA2_AVAILABLE:
         return False, f"FA2 is unavaible due to: {FA2_UNAVAILABLE_REASON}"
-    if torch.cuda.get_device_capability(device)[0] < 8:
+    # SM75 enablement: Turing (7.5) runs the fp16-only FA2 path; the C++ entry
+    # points reject bf16 inputs on sm75.
+    if torch.cuda.get_device_capability(device) < (7, 5):
         return False, \
-            "FA2 is only supported on devices with compute capability >= 8"
+            "FA2 is only supported on devices with compute capability >= 7.5"
     return True, None
     
 def _is_fa3_supported(device = None) -> Tuple[bool, Optional[str]]:


### PR DESCRIPTION
FlashAttention-2 has carried an sm75 code path in its kernel traits
(SM75_16x8x8 MMA atom, LDSM copy atoms, `Has_cp_async=false`) since the
beginning, but it was never enabled — and it turns out it computes wrong
results for head dims > 64. This PR enables the forward path for Turing
and fixes the underlying bug, giving vLLM a real FlashAttention backend
on sm75 (Quadro RTX 8000, RTX 2080 Ti, Tesla T4) instead of the
TRITON_ATTN fallback that collapses at long context.

Why it matters: the sm75 fleet is large and cheap. T4s are still
everywhere in clouds and inference boxes; RTX 8000 (48 GB) and
2080 Ti cards flood the used market at a fraction of the price of any
current 48-GB-class accelerator. Enabling the FA2 path keeps that
hardware viable for long-context serving instead of forcing owners to
replace it.

### The bug

`utils.h::gemm()/gemm_rs()` index the smem→register operand copies with
the MMA K-step loop variable:

```cpp
for (int i = 0; i < size<2>(tCrA); ++i) {
    if (i < size<2>(tCrA) - 1) {
        cute::copy(smem_tiled_copy_A, tCsA(_, _, i + 1), tCrA_copy_view(_, _, i + 1));
```

On sm80+ this is 1:1 — the MMA atom K (16) equals the ldmatrix tile
width. The sm75 atom has K=8 at the same 16-wide copy granularity, so
`size<2>(tCrA)` is twice `size<2>(tCsA)`, and the copy index runs past
both the smem tile and the register view. The out-of-bounds layout
arithmetic walks into the *next* smem tiles: for hdim 128, Q-operand
reads land in the K and V tiles (measured offsets: K-step 8 → +32 KiB,
K-step 12 → +48 KiB = the V tile), and the register-side writes clobber
neighbouring fragments (corrupting the LSE). Head dims ≤ 64 happen to
stay inside their own tile, which is why small-hdim smoke tests pass
and the path looks deceptively functional.

The fix decouples the copy loop from the MMA loop via the compile-time
ratio `kMmaPerCopy = size<2>(tCrA) / size<2>(tCrA_copy_view)` (2 on
sm75, 1 on sm80+ — a no-op there).

### Enablement around it

- CMake: let `7.5` through the arch filters; bf16 kernel sources are
  built only for Ampere+ (the sm75 traits force `half_t` and cannot
  instantiate them). Turing-only builds drop them and define
  `FLASHATTENTION_DISABLE_BF16`.
- `FLASHATTENTION_DISABLE_APPENDKV` (mirroring the FA3 flag): the
  in-kernel KV-append/rotary copies trip layout static_asserts against
  the non-cp.async copy atoms on sm75; vLLM appends KV via
  `reshape_and_cache` and applies RoPE outside attention, so the path
  is dropped for Turing-only builds instead of ported.
- Entry-point checks admit sm75 (fp16-only; bf16 is rejected — Turing
  has no bf16 tensor-core MMA), and the splitkv tile tables get an
  sm75 column respecting the 64 KiB shared-memory limit.
- Measured sm75 tiles (RTX 8000, hdim 128, 31k paged KV): splitkv
  dispatch 64×32 (32 KiB smem = 2 CTAs/SM, 18 % faster than 64×64 for
  q ≤ 8), align path 128×64 (the standard kernel's tile, 37 % faster
  chunk prefill, bitwise identity with the standard kernel preserved).

### Verification (2× Quadro RTX 8000, Qwen 27B W4A8, TP2)

- Paged-KV varlen numerics vs an fp32 reference: max abs err 2.4e-4
  across q_len 1–8, GQA 8:2, hdim 128, contexts up to 31k; splitkv
  with 1/2/4 splits: 1e-4.
- End-to-end coherence 3/3.
- Throughput vs the (tuned) Triton backend on the same rig:
  short-context decode 43 → 76 tok/s (with MTP k=3), 31k-context
  prefill 194 → 505 tok/s, 31k-context decode 23 → 34 tok/s.

### Notes

- Forward only (`FLASHATTENTION_DISABLE_BACKWARD`), fp16 only.
- **Stacked on #190** (split-KV for paged multi-token queries). This
  branch is based on that one, so the diff here includes its two files;
  please review #190 first.
- The vLLM-side gates (backend priority for sm75, fp16-only
  `supports_combination`) live in vllm-project/vllm and are out of scope
  here.
