### PR TITLE
Fix heuristic for hdim 256 kernel

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -708,8 +708,13 @@ def _flash_attn_fwd(
     total_mblocks = batch_size * num_head_kv * num_m_blocks
     num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
     num_SMs = 132 if is_fake_mode() else torch.cuda.get_device_properties(device).multi_processor_count
+
+    # hd=256 forward uses the dedicated Blackwell-family kernel.
+    use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     if arch // 10 == 12:
         assert num_splits == 1, "SM120 forward only supports num_splits=1"
+    elif use_dedicated_hd256_kernel:
+        num_splits = 1  # the dedicated hd=256 kernel has no SplitKV variant
     elif num_splits < 1:
         num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
 
@@ -755,8 +760,6 @@ def _flash_attn_fwd(
         and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
     )
 
-    # hd=256 forward uses the dedicated Blackwell-family kernel.
-    use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
     if use_dedicated_hd256_kernel:
         hd256_varlen_b1 = cu_seqlens_q is not None and batch_size == 1

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -82,6 +82,7 @@ DISABLE_SPLIT = os.getenv("FLASH_ATTENTION_DISABLE_SPLIT", "FALSE") == "TRUE"
 # SplitKV is not supported on SM90 or SM120
 IS_SM90 = torch.cuda.get_device_capability()[0] == 9
 IS_SM100 = torch.cuda.get_device_capability()[0] == 10
+IS_SM110 = torch.cuda.get_device_capability()[0] == 11
 IS_SM120 = torch.cuda.get_device_capability()[0] == 12
 TEST_BWD_ONLY = False
 VERBOSE = True
@@ -94,6 +95,20 @@ def test_flash_attn_sm120_rejects_splitkv():
     v = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
     with pytest.raises(AssertionError, match="SM120 forward only supports num_splits=1"):
         flash_attn_func(q, k, v, num_splits=3)
+
+
+@pytest.mark.skipif(not (IS_SM100 or IS_SM110), reason="SM100/SM110 hd256 forward only")
+def test_flash_attn_hd256_sm100_sm110_clamps_splitkv():
+    torch.manual_seed(0)
+    q = torch.randn(1, 128, 1, 256, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 8192, 1, 256, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+
+    out_ref, _ = flash_attn_func(q, k, v, num_splits=1)
+    # This shape has one M block and 64 N blocks, so auto requests SplitKV.
+    for num_splits in (0, 4):
+        out, _ = flash_attn_func(q, k, v, num_splits=num_splits)
+        assert torch.equal(out, out_ref)
 
 
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])


### PR DESCRIPTION
## Summary

The dedicated SM100/SM110 head-dimension-256 forward kernel has no SplitKV
variant, but the automatic split heuristic could still request one for
small-query/long-key shapes. Clamp automatic and explicit split requests to one
before split-dependent state and temporary allocations are derived.

SM120's existing explicit `num_splits == 1` contract is unchanged.

## Validation

- Added a B300 regression for `(QK dim, V dim) = (256, 256)`: automatic
  `num_splits=0` and explicit `num_splits=4` are bit-identical to
  `num_splits=1` and no longer assert.
- Focused vLLM selector/adapter suite: 50 passed; focused FA regression:
  1 passed.
- Real GLM-5.2-NVFP4 TP4 serving: 2,304 measured requests, zero failures.
- Nsight Systems confirms 624 dedicated hd256 launches for two dense 1K
  requests: exactly `2 requests × 78 layers × TP4`.