### PR TITLE
[Build] Compile FA2 for SM12x instead of JIT-ing the sm_80 PTX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12" "3.13")
 # Supported NVIDIA architectures.
 set(CUDA_SUPPORTED_ARCHS "8.0;8.6;8.9;9.0")
 if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
-    list(APPEND CUDA_SUPPORTED_ARCHS "10.0" "11.0" "12.0")
+    list(APPEND CUDA_SUPPORTED_ARCHS "10.0" "11.0" "12.0" "12.1")
 elseif(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-    list(APPEND CUDA_SUPPORTED_ARCHS "10.0" "10.1" "12.0")
+    list(APPEND CUDA_SUPPORTED_ARCHS "10.0" "10.1" "12.0" "12.1")
 endif()
 
 # Supported AMD GPU architectures.
@@ -137,7 +137,11 @@ if (FA2_ENABLED)
 
     # For CUDA we set the architectures on a per file basis
     if (VLLM_GPU_LANG STREQUAL "CUDA")
-        cuda_archs_loose_intersection(FA2_ARCHS "8.0+PTX" "${CUDA_ARCHS}")
+        # SM12x has no SASS-compatible baseline here, so without an explicit
+        # entry these targets fall back to JIT-compiling the sm_80 PTX. That is
+        # slower than native SASS, and it fails outright when the build toolkit
+        # is newer than the driver's PTX JIT support.
+        cuda_archs_loose_intersection(FA2_ARCHS "8.0+PTX;12.0;12.1" "${CUDA_ARCHS}")
         message(STATUS "FA2_ARCHS: ${FA2_ARCHS}")
 
         set_gencode_flags_for_srcs(


### PR DESCRIPTION
`FA2_ARCHS` resolves to `8.0+PTX` for every target, so SM120/SM121 get no native cubin and JIT-compile the sm_80 PTX at runtime. On GB10 (DGX Spark) `FA3_ARCHS` is empty (`9.0a` only), so that JIT'd sm_80 kernel is the only FlashAttention available — and it fails outright when the build toolkit is newer than the driver's PTX JIT support (vllm-project/vllm#47397).

Upstream FlashAttention has emitted native sm_120 cubins since CUDA 12.8; this fork never picked it up.

`cuda_archs_loose_intersection` output, before and after:

| target | before | after |
|---|---|---|
| 8.0 / 8.6 / 8.9 / 9.0 / 10.0 | `8.0+PTX` | `8.0+PTX` |
| 12.0 | `8.0+PTX` | `12.0` |
| 12.1 | `8.0+PTX` | `12.1` |

`12.1` is added to `CUDA_SUPPORTED_ARCHS` as well, otherwise a GB10 target collapses to `12.0` at the intersection on L96 before `FA2_ARCHS` is computed.

Everything outside SM12x is unchanged. I don't have Blackwell hardware, so this is verified by running the CMake arch logic directly rather than by a compile — a sanity check from someone with an SM12x box would be welcome.
